### PR TITLE
[codex] make MCP sessions stateful per LangGraph thread

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@ Example:
 ```toml
 [mcp]
 tool_name_prefix = true
+stateful = true
 
 [mcp.servers.repo]
 transport = "stdio"
@@ -371,6 +372,7 @@ Example:
 ```toml
 [mcp]
 tool_name_prefix = true
+stateful = true
 
 [mcp.servers.repo]
 transport = "stdio"
@@ -406,6 +408,7 @@ mcp_servers = ["github"]
 Supported MCP config fields:
 
 - top-level `[mcp] tool_name_prefix = true|false`
+- top-level `[mcp] stateful = true|false`
 - `[mcp.servers.<name>] transport`
 - for `stdio`: `command`, `args`, optional `cwd`, optional `env`
 - for `http`, `streamable_http`, `streamable-http`: `url`, optional `headers`
@@ -419,6 +422,8 @@ Notes:
 - Skills and MCP servers are independent. You can use neither, either, or both on any subagent.
 - Relative `cwd` values are resolved from the location of `deepagent.toml`.
 - `tool_name_prefix = true` is recommended when multiple MCP servers expose overlapping tool names.
+- `stateful = true` keeps MCP sessions open per LangGraph thread while the app process is running.
+- `stateful = false` recreates the MCP session for every tool call.
 
 Current scope of this config support:
 
@@ -441,6 +446,7 @@ See [deepagent.toml.example](deepagent.toml.example) for a complete example.
 - If `DATABASE_URL` is set but authentication is not configured, Chainlit still persists thread records, but they are not browseable from the UI.
 - When `DATABASE_URL` is unset, thread IDs only persist while the process stays alive.
 - When `DATABASE_URL` is set, durable state is available through LangGraph thread IDs. You can reuse a thread ID from the chat settings panel to continue the same checkpointed thread.
+- MCP stateful sessions are process-local. They survive tool calls in the same thread, but not an app restart.
 - On startup, the UI shows how many skill sources, MCP servers, custom subagents, and async subagents were loaded from `deepagent.toml`.
 
 ## License

--- a/deepagent.toml
+++ b/deepagent.toml
@@ -25,6 +25,7 @@ reasoning_effort = "medium"
 
 [mcp]
 tool_name_prefix = true
+stateful = true
 
 [mcp.servers.repo]
 transport = "stdio"

--- a/deepagent.toml
+++ b/deepagent.toml
@@ -24,7 +24,7 @@ reasoning_effort = "medium"
 
 
 [mcp]
-tool_name_prefix = true
+tool_name_prefix = false
 stateful = true
 
 [mcp.servers.repo]

--- a/deepagent.toml.example
+++ b/deepagent.toml.example
@@ -12,6 +12,7 @@ reasoning_effort = "medium"
 
 [mcp]
 tool_name_prefix = true
+stateful = true
 
 [mcp.servers.repo]
 transport = "stdio"

--- a/deepagent_runtime.py
+++ b/deepagent_runtime.py
@@ -21,6 +21,7 @@ from deepagents.backends import (
 from langchain_ollama import ChatOllama
 from langchain_openai import ChatOpenAI
 from langchain_mcp_adapters.client import MultiServerMCPClient
+from langchain_mcp_adapters.tools import load_mcp_tools
 from langchain_core.utils.function_calling import convert_to_openai_tool
 from langgraph.checkpoint.memory import MemorySaver
 from langgraph.checkpoint.postgres.aio import AsyncPostgresSaver
@@ -314,6 +315,7 @@ class AsyncSubagentConfig:
 class ExtensionsConfig:
     config_path: Path | None
     mcp_tool_name_prefix: bool = True
+    mcp_stateful: bool = False
     mcp_servers: dict[str, dict[str, Any]] | None = None
     skills: tuple[str, ...] = ()
     agent_mcp_servers: tuple[str, ...] = ()
@@ -579,6 +581,7 @@ def parse_extensions_config(raw_config: dict[str, Any], config_path: Path) -> Ex
     return ExtensionsConfig(
         config_path=config_path,
         mcp_tool_name_prefix=bool(mcp_section.get("tool_name_prefix", True)),
+        mcp_stateful=bool(mcp_section.get("stateful", False)),
         mcp_servers=mcp_servers or None,
         skills=skill_paths,
         agent_mcp_servers=raw_agent_mcp_servers,
@@ -846,7 +849,8 @@ class AgentRuntime:
         self._agent_lock = asyncio.Lock()
         self._agents: dict[tuple[ReasoningLevel, str | None, str | None], object] = {}
         self._mcp_client: MultiServerMCPClient | None = None
-        self._mcp_tools_cache: dict[tuple[str, ...], list[Any]] = {}
+        self._mcp_tools_cache: dict[tuple[str | None, tuple[str, ...]], list[Any]] = {}
+        self._mcp_sessions: dict[tuple[str | None, str], Any] = {}
         self._checkpointer: AsyncPostgresSaver | MemorySaver | None = None
         self._store: AsyncPostgresStore | InMemoryStore | None = None
         self._rag_service: WorkspaceDocsRAG | None = None
@@ -946,7 +950,10 @@ class AgentRuntime:
                     subagent.to_deepagents_spec(
                         tools=sanitize_tools_for_model(
                             self.config.model_provider,
-                            await self._get_mcp_tools(subagent.mcp_servers),
+                            await self._get_mcp_tools(
+                                subagent.mcp_servers,
+                                thread_id=thread_id,
+                            ),
                         )
                     )
                     for subagent in self.config.extensions.subagents
@@ -1018,24 +1025,69 @@ class AgentRuntime:
     def _build_model(self, reasoning_level: ReasoningLevel) -> Any:
         return build_model(self.config, reasoning_level)
 
-    async def _get_mcp_tools(self, server_names: tuple[str, ...]) -> list[Any]:
+    async def _get_stateful_mcp_session(
+        self,
+        *,
+        server_name: str,
+        thread_id: str | None,
+    ) -> Any:
+        cache_key = (thread_id, server_name)
+        session = self._mcp_sessions.get(cache_key)
+        if session is not None:
+            return session
+
+        if self._mcp_client is None:
+            raise RuntimeError("MCP client is not initialized.")
+
+        session = await self._exit_stack.enter_async_context(
+            self._mcp_client.session(server_name)
+        )
+        self._mcp_sessions[cache_key] = session
+        return session
+
+    async def _get_mcp_tools(
+        self,
+        server_names: tuple[str, ...],
+        *,
+        thread_id: str | None = None,
+    ) -> list[Any]:
         if not server_names or self._mcp_client is None:
             return []
 
-        cache_key = tuple(server_names)
+        tool_scope = thread_id if self.config.extensions.mcp_stateful else None
+        cache_key = (tool_scope, tuple(server_names))
         cached = self._mcp_tools_cache.get(cache_key)
         if cached is not None:
             return list(cached)
 
         tools: list[Any] = []
-        for server_name in cache_key:
+        for server_name in cache_key[1]:
+            if self.config.extensions.mcp_stateful:
+                session = await self._get_stateful_mcp_session(
+                    server_name=server_name,
+                    thread_id=thread_id,
+                )
+                tools.extend(
+                    await load_mcp_tools(
+                        session,
+                        callbacks=self._mcp_client.callbacks,
+                        tool_interceptors=self._mcp_client.tool_interceptors,
+                        server_name=server_name,
+                        tool_name_prefix=self.config.extensions.mcp_tool_name_prefix,
+                    )
+                )
+                continue
+
             tools.extend(await self._mcp_client.get_tools(server_name=server_name))
 
         self._mcp_tools_cache[cache_key] = tools
         return list(tools)
 
     async def _build_main_tools(self, *, thread_id: str | None) -> list[Any]:
-        tools = await self._get_mcp_tools(self.config.extensions.agent_mcp_servers)
+        tools = await self._get_mcp_tools(
+            self.config.extensions.agent_mcp_servers,
+            thread_id=thread_id,
+        )
         if self._rag_service is not None:
             tools = list(tools)
             tools.append(

--- a/main.py
+++ b/main.py
@@ -327,9 +327,15 @@ async def on_chat_start() -> None:
         else "- History bar: disabled; set `DATABASE_URL`, `CHAINLIT_AUTH_SECRET`, `CHAINLIT_AUTH_USERNAME`, and `CHAINLIT_AUTH_PASSWORD` to enable native Chainlit history\n"
     )
     extensions = runtime.config.extensions
+    mcp_session_mode_line = (
+        "- MCP session mode: stateful per LangGraph thread while this app process stays alive\n"
+        if extensions.mcp_stateful
+        else "- MCP session mode: stateless; a new MCP session is created for each tool call\n"
+    )
     extensions_line = (
         f"- Skill sources: `{len(extensions.skills)}`\n"
         f"- MCP servers: `{len(extensions.mcp_servers or {})}`\n"
+        f"{mcp_session_mode_line}"
         f"- Custom subagents: `{len(extensions.subagents)}`\n"
         f"- Async subagents: `{len(extensions.async_subagents)}`\n"
     )

--- a/tests/test_deepagent_runtime_rag.py
+++ b/tests/test_deepagent_runtime_rag.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import asyncio
+from contextlib import asynccontextmanager
 from pathlib import Path
+from types import SimpleNamespace
 
 from langgraph.checkpoint.memory import MemorySaver
 from langgraph.store.memory import InMemoryStore
@@ -39,7 +41,11 @@ def make_runtime_rag_config(project_root: Path) -> ResolvedRagConfig:
     )
 
 
-def make_runtime_config(project_root: Path) -> RuntimeConfig:
+def make_runtime_config(
+    project_root: Path,
+    *,
+    extensions: ExtensionsConfig | None = None,
+) -> RuntimeConfig:
     return RuntimeConfig(
         database_url=None,
         model_provider="ollama",
@@ -49,10 +55,23 @@ def make_runtime_config(project_root: Path) -> RuntimeConfig:
         model_temperature=0.0,
         default_reasoning="medium",
         persistence_mode="memory",
-        extensions=ExtensionsConfig(config_path=None),
+        extensions=extensions or ExtensionsConfig(config_path=None),
         rag_requested=True,
         rag=make_runtime_rag_config(project_root),
         rag_error=None,
+    )
+
+
+def make_extensions_config(
+    *,
+    mcp_stateful: bool = False,
+    agent_mcp_servers: tuple[str, ...] = (),
+) -> ExtensionsConfig:
+    return ExtensionsConfig(
+        config_path=None,
+        mcp_stateful=mcp_stateful,
+        mcp_servers={"repo": {"transport": "stdio", "command": "npx", "args": []}},
+        agent_mcp_servers=agent_mcp_servers,
     )
 
 
@@ -84,6 +103,33 @@ provider = "auto"
     assert config.rag is None
     assert config.rag_error is not None
     assert "rag.embedding.model" in config.rag_error
+
+
+def test_load_extensions_config_reads_mcp_stateful_flag(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    config_path = tmp_path / "deepagent.toml"
+    config_path.write_text(
+        """
+[mcp]
+stateful = true
+
+[mcp.servers.repo]
+transport = "stdio"
+command = "npx"
+args = ["server"]
+
+[agent]
+mcp_servers = ["repo"]
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DEEPAGENT_CONFIG", str(config_path))
+
+    config = deepagent_runtime.load_extensions_config()
+
+    assert config.mcp_stateful is True
 
 
 def test_agent_runtime_initialize_runs_rag_startup_check(
@@ -186,6 +232,75 @@ def test_get_agent_omits_rag_tool_when_service_is_missing(
 
     tool_names = [tool.name for tool in captured["tools"]]
     assert "search_workspace_knowledge" not in tool_names
+
+
+def test_stateful_mcp_reuses_session_per_thread(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    created_sessions: list[tuple[str, object]] = []
+    load_calls: list[tuple[object, str]] = []
+
+    class FakeMCPClient:
+        callbacks = object()
+        tool_interceptors: list[object] = []
+
+        @asynccontextmanager
+        async def session(self, server_name: str, *, auto_initialize: bool = True):
+            session = object()
+            created_sessions.append((server_name, session))
+            yield session
+
+        async def get_tools(self, *, server_name: str | None = None):
+            raise AssertionError("stateful MCP mode should not call get_tools()")
+
+    async def fake_load_mcp_tools(
+        session,
+        *,
+        server_name: str | None = None,
+        **kwargs,
+    ):
+        assert kwargs["tool_name_prefix"] is True
+        load_calls.append((session, str(server_name)))
+        return [SimpleNamespace(name=f"{server_name}_tool", session=session)]
+
+    monkeypatch.setattr(deepagent_runtime, "load_mcp_tools", fake_load_mcp_tools)
+
+    runtime = AgentRuntime(
+        make_runtime_config(
+            tmp_path,
+            extensions=make_extensions_config(
+                mcp_stateful=True,
+                agent_mcp_servers=("repo",),
+            ),
+        )
+    )
+    runtime._mcp_client = FakeMCPClient()
+
+    async def exercise_runtime():
+        thread_1_tools_first = await runtime._get_mcp_tools(
+            ("repo",),
+            thread_id="thread-1",
+        )
+        thread_1_tools_second = await runtime._get_mcp_tools(
+            ("repo",),
+            thread_id="thread-1",
+        )
+        thread_2_tools = await runtime._get_mcp_tools(
+            ("repo",),
+            thread_id="thread-2",
+        )
+        await runtime._exit_stack.aclose()
+        return thread_1_tools_first, thread_1_tools_second, thread_2_tools
+
+    thread_1_tools_first, thread_1_tools_second, thread_2_tools = asyncio.run(
+        exercise_runtime()
+    )
+
+    assert len(created_sessions) == 2
+    assert len(load_calls) == 2
+    assert thread_1_tools_first[0].session is thread_1_tools_second[0].session
+    assert thread_1_tools_first[0].session is not thread_2_tools[0].session
 
 
 def test_rebuild_rag_index_clears_cached_agents(


### PR DESCRIPTION
## Summary

This PR makes MCP usage stateful within a LangGraph thread instead of recreating a fresh MCP session for every tool call, and updates the repo config to stop prefixing MCP tool names.

## What Changed

- add `[mcp].stateful` config parsing in the runtime
- keep MCP sessions open and reuse them per server and LangGraph thread
- cache stateful MCP tool wrappers per thread
- pass the active LangGraph thread ID through the main agent and sync subagents when building MCP tools
- show the MCP session mode in the Chainlit startup message
- enable `stateful = true` in the repo config and example config
- disable `tool_name_prefix` in the live repo config
- document the new setting and its process-local behavior in the README
- add tests for config parsing and per-thread session reuse

## Why

The previous implementation used `MultiServerMCPClient.get_tools()`, which wraps tools in a way that opens a new MCP session for each tool call. That made MCP effectively stateless from the server's perspective, even when the user stayed in the same chat thread.

## Impact

- MCP servers that keep in-memory session state can now preserve that state across tool calls in the same LangGraph thread
- different LangGraph threads still get isolated MCP sessions
- MCP state remains process-local and is not restored after an app restart
- the configured MCP tool names in the live repo no longer get server-name prefixes

## Validation

- `./.venv/bin/pytest -q tests/test_deepagent_runtime_rag.py`
- `./.venv/bin/pytest -q`