### PR TITLE
Add Chainlit native slash commands for prompt, subagent, and MCP tool invocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,9 @@ Supported subagent fields:
 
 You can configure slash-style commands that run from the Chainlit composer before the model call.
 
+Place this config in `deepagent.toml` or whatever file `DEEPAGENT_CONFIG` points to.
+Do not put it in the app UI file `chainlit.toml` or Chainlit's native [`.chainlit/config.toml`](.chainlit/config.toml).
+
 Example:
 
 ```toml
@@ -333,6 +336,7 @@ commands = [
 
 Notes:
 
+- The `[chainlit]` table for native commands belongs in `deepagent.toml`, alongside `[model]`, `[agent]`, `[mcp]`, `[[subagents]]`, and `[[async_subagents]]`.
 - Command `name` is invoked as `/<name>` and must be unique.
 - `template` is optional and may include `{input}`.
 - For `mcp_tool`, user command arguments must be valid JSON, e.g. `/repo-readme {"path":"README.md"}`.

--- a/README.md
+++ b/README.md
@@ -310,6 +310,33 @@ Supported subagent fields:
 - `mcp_servers`: optional list of MCP server names to attach to that subagent
 - `model`: optional model override
 
+## Chainlit Native Commands
+
+You can configure slash-style commands that run from the Chainlit composer before the model call.
+
+Example:
+
+```toml
+[chainlit]
+commands = [
+  { name = "ask-researcher", description = "Delegate to repo-researcher.", target = "subagent", value = "repo-researcher", template = "{input}" },
+  { name = "repo-readme", description = "Run an MCP tool directly.", target = "mcp_tool", value = "repo_read_file", mcp_server = "repo", template = "{\"path\":\"README.md\"}" },
+  { name = "summarize", description = "Apply a prompt template.", target = "prompt", value = "Summarize the input", template = "Summarize this:\n{input}" }
+]
+```
+
+`target` modes:
+
+- `prompt`: rewrites the user prompt before sending it to the agent.
+- `subagent`: rewrites the user prompt to direct the runtime to delegate via the configured subagent.
+- `mcp_tool`: invokes the configured MCP tool directly and returns tool output in chat.
+
+Notes:
+
+- Command `name` is invoked as `/<name>` and must be unique.
+- `template` is optional and may include `{input}`.
+- For `mcp_tool`, user command arguments must be valid JSON, e.g. `/repo-readme {"path":"README.md"}`.
+
 ## Add Async Subagents
 
 Async subagents are loaded from `deepagent.toml` as background Agent Protocol jobs. They are useful for long-running or remote work where the main agent should return a task ID immediately and let you check, update, cancel, or list tasks later.

--- a/chainlit.md
+++ b/chainlit.md
@@ -30,6 +30,7 @@ Local-first LangChain Deep Agent UI running on Ollama or any OpenAI-compatible s
 ## Optional Extensions
 
 - Use `deepagent.toml` to add skills, MCP servers, custom subagents, and async subagents.
+- Use `[chainlit].commands` in `deepagent.toml` to add slash commands that can rewrite prompts, delegate to configured subagents, or invoke MCP tools directly.
 - Each sync subagent can have its own `skills` and `mcp_servers`.
 - Async subagents are Agent Protocol background jobs configured with `graph_id` and optional `url`/`headers`.
 - Omit async subagent `url` only when running the co-deployed graphs from `langgraph.json`; Chainlit-only runs need an HTTP `url`.

--- a/deepagent.toml
+++ b/deepagent.toml
@@ -70,3 +70,10 @@ description = "Researches the current repository, explains architecture, and ide
 system_prompt_file = "prompts/repo-researcher.md"
 skills = ["skills"]
 mcp_servers = ["repo"]
+
+[chainlit]
+commands = [
+  { name = "ask-researcher", description = "Delegate to repo-researcher.", target = "subagent", value = "repo-researcher", template = "{input}" },
+  { name = "repo-readme", description = "Run an MCP tool directly.", target = "mcp_tool", value = "repo_read_file", mcp_server = "repo", template = "{\"path\":\"README.md\"}" },
+  { name = "summarize", description = "Apply a prompt template.", target = "prompt", value = "Summarize the input", template = "Summarize this:\n{input}" }
+]

--- a/deepagent.toml.example
+++ b/deepagent.toml.example
@@ -30,6 +30,14 @@ url = "http://localhost:8000/mcp"
 skills = ["skills"]
 mcp_servers = ["repo"]
 
+[chainlit]
+# Native slash commands available from the Chainlit composer.
+commands = [
+  { name = "summarize-docs", description = "Summarize repository docs.", target = "prompt", value = "Summarize the repository documentation changes.", template = "Summarize docs for: {input}" },
+  { name = "ask-researcher", description = "Delegate to repo-researcher subagent.", target = "subagent", value = "repo-researcher", template = "{input}" },
+  { name = "repo-readme", description = "Call MCP filesystem read_file on README.md.", target = "mcp_tool", value = "repo_read_file", mcp_server = "repo", template = "{\"path\": \"README.md\"}" },
+]
+
 [rag]
 enabled = true
 persist_directory = ".rag"

--- a/deepagent_runtime.py
+++ b/deepagent_runtime.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import math
 import os
@@ -312,6 +313,16 @@ class AsyncSubagentConfig:
 
 
 @dataclass(frozen=True)
+class ChainlitCommandConfig:
+    name: str
+    description: str
+    target: Literal["prompt", "subagent", "mcp_tool"]
+    value: str
+    template: str | None = None
+    mcp_server: str | None = None
+
+
+@dataclass(frozen=True)
 class ExtensionsConfig:
     config_path: Path | None
     mcp_tool_name_prefix: bool = True
@@ -321,6 +332,7 @@ class ExtensionsConfig:
     agent_mcp_servers: tuple[str, ...] = ()
     subagents: tuple[SubagentConfig, ...] = ()
     async_subagents: tuple[AsyncSubagentConfig, ...] = ()
+    chainlit_commands: tuple[ChainlitCommandConfig, ...] = ()
 
     @property
     def enabled(self) -> bool:
@@ -329,6 +341,7 @@ class ExtensionsConfig:
             or self.agent_mcp_servers
             or self.subagents
             or self.async_subagents
+            or self.chainlit_commands
         )
 
 
@@ -578,6 +591,65 @@ def parse_extensions_config(raw_config: dict[str, Any], config_path: Path) -> Ex
             )
         )
 
+    chainlit_section = raw_config.get("chainlit", {})
+    if chainlit_section and not isinstance(chainlit_section, dict):
+        raise ValueError("The top-level 'chainlit' config must be a table/object.")
+
+    raw_chainlit_commands = chainlit_section.get("commands", [])
+    if not isinstance(raw_chainlit_commands, list):
+        raise ValueError("The top-level 'chainlit.commands' config must be an array of tables.")
+
+    chainlit_commands: list[ChainlitCommandConfig] = []
+    seen_commands: set[str] = set()
+    for index, raw_chainlit_command in enumerate(raw_chainlit_commands, start=1):
+        if not isinstance(raw_chainlit_command, dict):
+            raise ValueError(
+                f"Chainlit command entry #{index} must be a table/object."
+            )
+        name = str(raw_chainlit_command.get("name", "")).strip().lstrip("/").lower()
+        description = str(raw_chainlit_command.get("description", "")).strip()
+        target = str(raw_chainlit_command.get("target", "")).strip().lower()
+        value = str(raw_chainlit_command.get("value", "")).strip()
+        template = normalize_optional_string(raw_chainlit_command.get("template"))
+        mcp_server = normalize_optional_string(raw_chainlit_command.get("mcp_server"))
+        if not name or " " in name:
+            raise ValueError(
+                f"Chainlit command entry #{index} must define a slash-compatible 'name' with no spaces."
+            )
+        if name in seen_commands:
+            raise ValueError(f"Chainlit command '/{name}' is defined more than once.")
+        if not description:
+            raise ValueError(f"Chainlit command '/{name}' must include a non-empty 'description'.")
+        if target not in {"prompt", "subagent", "mcp_tool"}:
+            raise ValueError(
+                f"Chainlit command '/{name}' target must be one of: prompt, subagent, mcp_tool."
+            )
+        if not value:
+            raise ValueError(f"Chainlit command '/{name}' must include a non-empty 'value'.")
+        if target == "subagent":
+            valid_subagent_names = {subagent.name for subagent in subagents}
+            if value not in valid_subagent_names:
+                raise ValueError(
+                    f"Chainlit command '/{name}' references unknown subagent '{value}'. "
+                    f"Defined subagents: {sorted(valid_subagent_names)}"
+                )
+        if target == "mcp_tool" and mcp_server and mcp_server not in mcp_servers:
+            raise ValueError(
+                f"Chainlit command '/{name}' references unknown MCP server '{mcp_server}'. "
+                f"Defined servers: {sorted(mcp_servers)}"
+            )
+        chainlit_commands.append(
+            ChainlitCommandConfig(
+                name=name,
+                description=description,
+                target=target,  # type: ignore[arg-type]
+                value=value,
+                template=template,
+                mcp_server=mcp_server,
+            )
+        )
+        seen_commands.add(name)
+
     return ExtensionsConfig(
         config_path=config_path,
         mcp_tool_name_prefix=bool(mcp_section.get("tool_name_prefix", True)),
@@ -587,6 +659,7 @@ def parse_extensions_config(raw_config: dict[str, Any], config_path: Path) -> Ex
         agent_mcp_servers=raw_agent_mcp_servers,
         subagents=tuple(subagents),
         async_subagents=tuple(async_subagents),
+        chainlit_commands=tuple(chainlit_commands),
     )
 
 
@@ -1014,6 +1087,63 @@ class AgentRuntime:
             thread_id=thread_id,
             uploads=uploads,
         )
+
+    def resolve_chainlit_command(self, name: str) -> ChainlitCommandConfig | None:
+        normalized = name.strip().lstrip("/").lower()
+        if not normalized:
+            return None
+        for command in self.config.extensions.chainlit_commands:
+            if command.name == normalized:
+                return command
+        return None
+
+    async def invoke_mcp_tool_command(
+        self,
+        *,
+        tool_name: str,
+        raw_args: str,
+        thread_id: str | None = None,
+        server_name: str | None = None,
+    ) -> Any:
+        candidate_servers: tuple[str, ...]
+        if server_name:
+            candidate_servers = (server_name,)
+        else:
+            available_servers = self.config.extensions.mcp_servers or {}
+            candidate_servers = tuple(available_servers.keys())
+
+        tools = await self._get_mcp_tools(candidate_servers, thread_id=thread_id)
+        selected_tool = next(
+            (
+                tool
+                for tool in tools
+                if str(getattr(tool, "name", "")).strip() == tool_name
+            ),
+            None,
+        )
+        if selected_tool is None:
+            available = sorted(
+                {
+                    str(getattr(tool, "name", "")).strip()
+                    for tool in tools
+                    if str(getattr(tool, "name", "")).strip()
+                }
+            )
+            raise ValueError(
+                f"MCP tool '{tool_name}' is unavailable."
+                + (f" Available tools: {available}" if available else "")
+            )
+
+        parsed_args: Any = {}
+        raw_text = raw_args.strip()
+        if raw_text:
+            try:
+                parsed_args = json.loads(raw_text)
+            except json.JSONDecodeError:
+                raise ValueError(
+                    f"Command arguments for MCP tool '{tool_name}' must be valid JSON."
+                ) from None
+        return await selected_tool.ainvoke(parsed_args)
 
     def _sanitize_tools_for_model(self, tools: list[Any]) -> list[Any]:
         return sanitize_tools_for_model(self.config.model_provider, tools)

--- a/main.py
+++ b/main.py
@@ -216,6 +216,25 @@ def parse_native_command(raw_text: str) -> ParsedNativeCommand | None:
     )
 
 
+def resolve_native_command(
+    *,
+    raw_text: str,
+    selected_command: str | None = None,
+) -> ParsedNativeCommand | None:
+    parsed = parse_native_command(raw_text)
+    if parsed is not None:
+        return parsed
+
+    command_name = str(selected_command or "").strip().lstrip("/").lower()
+    if not command_name:
+        return None
+
+    return ParsedNativeCommand(
+        command_name=command_name,
+        raw_args=raw_text.strip(),
+    )
+
+
 def apply_native_template(template: str | None, raw_args: str) -> str:
     if template is None:
         return raw_args.strip()
@@ -576,10 +595,13 @@ async def on_message(message: cl.Message) -> None:
             upload_message.actions = rag_actions()
         await upload_message.send()
 
-    if not message.content.strip() and uploaded_files:
+    parsed_command = resolve_native_command(
+        raw_text=message.content,
+        selected_command=getattr(message, "command", None),
+    )
+    if not message.content.strip() and uploaded_files and parsed_command is None:
         return
 
-    parsed_command = parse_native_command(message.content)
     if parsed_command is not None:
         try:
             transformed_prompt = await handle_native_command(

--- a/main.py
+++ b/main.py
@@ -252,9 +252,10 @@ async def handle_native_command(
         return None
 
     if command.target == "mcp_tool":
+        tool_raw_args = apply_native_template(command.template, parsed.raw_args)
         result = await runtime.invoke_mcp_tool_command(
             tool_name=command.value,
-            raw_args=parsed.raw_args,
+            raw_args=tool_raw_args,
             thread_id=settings.thread_id,
             server_name=command.mcp_server,
         )
@@ -599,6 +600,7 @@ async def on_message(message: cl.Message) -> None:
         raw_text=message.content,
         selected_command=getattr(message, "command", None),
     )
+    slash_command_from_text = parse_native_command(message.content)
     if not message.content.strip() and uploaded_files and parsed_command is None:
         return
 
@@ -616,17 +618,19 @@ async def on_message(message: cl.Message) -> None:
             ).send()
             return
         if transformed_prompt is None:
-            await cl.Message(
-                author="System",
-                content=(
-                    f"Unknown command `/{parsed_command.command_name}`.\n"
-                    "Use a configured command from startup or send a normal prompt."
-                ),
-            ).send()
-            return
-        if not transformed_prompt.strip():
-            return
-        message.content = transformed_prompt
+            if slash_command_from_text is None:
+                await cl.Message(
+                    author="System",
+                    content=(
+                        f"Unknown command `/{parsed_command.command_name}`.\n"
+                        "Use a configured command from startup or send a normal prompt."
+                    ),
+                ).send()
+                return
+        else:
+            if not transformed_prompt.strip():
+                return
+            message.content = transformed_prompt
 
     async_url_override = async_subagent_url_override()
     agent = await runtime.get_agent(

--- a/main.py
+++ b/main.py
@@ -116,6 +116,28 @@ def rag_actions() -> list[cl.Action]:
     return [build_rag_action(), build_upload_rag_action()]
 
 
+def build_native_command_specs(runtime: AgentRuntime) -> list[dict[str, Any]]:
+    icon_by_target = {
+        "prompt": "square-pen",
+        "subagent": "bot",
+        "mcp_tool": "wrench",
+    }
+    return [
+        {
+            "id": command.name,
+            "description": command.description,
+            "icon": icon_by_target.get(command.target, "terminal"),
+            "button": False,
+            "persistent": True,
+        }
+        for command in runtime.config.extensions.chainlit_commands
+    ]
+
+
+async def publish_native_commands(runtime: AgentRuntime) -> None:
+    await cl.context.emitter.set_commands(build_native_command_specs(runtime))
+
+
 def rag_status_line(runtime: AgentRuntime) -> str:
     status = runtime.rag_status
     if not status.enabled:
@@ -372,6 +394,7 @@ async def on_chat_start() -> None:
     runtime = await get_runtime_or_notify()
     if runtime is None:
         return
+    await publish_native_commands(runtime)
     run_task_list = await get_run_task_list()
     await run_task_list.show_ready()
     settings = AppSettings(
@@ -437,6 +460,7 @@ async def on_chat_resume(thread: ThreadDict) -> None:
     runtime = await get_runtime_or_notify()
     if runtime is None:
         return
+    await publish_native_commands(runtime)
 
     run_task_list = await get_run_task_list()
     await run_task_list.show_ready()

--- a/main.py
+++ b/main.py
@@ -6,9 +6,8 @@ import os
 import secrets
 import traceback
 from contextlib import suppress
-from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, NamedTuple
 
 import chainlit as cl
 from chainlit.input_widget import Select, TextInput
@@ -177,9 +176,7 @@ def upload_result_message(upload_result) -> str:
 
     return upload_result.reason or "No files were added to RAG."
 
-
-@dataclass(frozen=True)
-class ParsedNativeCommand:
+class ParsedNativeCommand(NamedTuple):
     command_name: str
     raw_args: str
 

--- a/main.py
+++ b/main.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import os
 import secrets
 import traceback
 from contextlib import suppress
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -176,6 +178,71 @@ def upload_result_message(upload_result) -> str:
     return upload_result.reason or "No files were added to RAG."
 
 
+@dataclass(frozen=True)
+class ParsedNativeCommand:
+    command_name: str
+    raw_args: str
+
+
+def parse_native_command(raw_text: str) -> ParsedNativeCommand | None:
+    text = raw_text.strip()
+    if not text.startswith("/"):
+        return None
+    tokens = text[1:].split(None, 1)
+    if not tokens:
+        return None
+    return ParsedNativeCommand(
+        command_name=tokens[0].strip().lower(),
+        raw_args=tokens[1].strip() if len(tokens) > 1 else "",
+    )
+
+
+def apply_native_template(template: str | None, raw_args: str) -> str:
+    if template is None:
+        return raw_args.strip()
+    return template.replace("{input}", raw_args.strip()).strip()
+
+
+async def handle_native_command(
+    *,
+    runtime: AgentRuntime,
+    settings: AppSettings,
+    parsed: ParsedNativeCommand,
+) -> str | None:
+    command = runtime.resolve_chainlit_command(parsed.command_name)
+    if command is None:
+        return None
+
+    if command.target == "mcp_tool":
+        result = await runtime.invoke_mcp_tool_command(
+            tool_name=command.value,
+            raw_args=parsed.raw_args,
+            thread_id=settings.thread_id,
+            server_name=command.mcp_server,
+        )
+        await cl.Message(
+            author="System",
+            content=(
+                f"Ran `/{command.name}` ({command.description}).\n\n"
+                "Tool result:\n```json\n"
+                f"{json.dumps(result, indent=2, sort_keys=True, ensure_ascii=True, default=str)}\n"
+                "```"
+            ),
+        ).send()
+        return ""
+
+    transformed = apply_native_template(command.template, parsed.raw_args)
+    if command.target == "prompt":
+        return transformed or command.value
+
+    return (
+        f"Delegate this request to the configured `{command.value}` subagent.\n\n"
+        f"Command: `/{command.name}`\n"
+        f"Description: {command.description}\n\n"
+        f"User request:\n{transformed or parsed.raw_args or command.value}"
+    ).strip()
+
+
 async def ask_for_rag_upload() -> list[UploadedRagFile]:
     files = await cl.AskFileMessage(
         content=(
@@ -338,7 +405,14 @@ async def on_chat_start() -> None:
         f"{mcp_session_mode_line}"
         f"- Custom subagents: `{len(extensions.subagents)}`\n"
         f"- Async subagents: `{len(extensions.async_subagents)}`\n"
+        f"- Native commands: `{len(extensions.chainlit_commands)}`\n"
     )
+    if extensions.chainlit_commands:
+        command_lines = "\n".join(
+            f"  - `/{command.name}` ({command.target}): {command.description}"
+            for command in extensions.chainlit_commands
+        )
+        extensions_line += f"Configured commands:\n{command_lines}\n"
     if extensions.config_path is not None:
         extensions_line += f"- Extensions config: `{extensions.config_path.name}`\n"
     startup_message = cl.Message(
@@ -483,6 +557,33 @@ async def on_message(message: cl.Message) -> None:
 
     if not message.content.strip() and uploaded_files:
         return
+
+    parsed_command = parse_native_command(message.content)
+    if parsed_command is not None:
+        try:
+            transformed_prompt = await handle_native_command(
+                runtime=runtime,
+                settings=settings,
+                parsed=parsed_command,
+            )
+        except Exception as exc:
+            await cl.Message(
+                author="System",
+                content=f"Native command `/{parsed_command.command_name}` failed: {exc}",
+            ).send()
+            return
+        if transformed_prompt is None:
+            await cl.Message(
+                author="System",
+                content=(
+                    f"Unknown command `/{parsed_command.command_name}`.\n"
+                    "Use a configured command from startup or send a normal prompt."
+                ),
+            ).send()
+            return
+        if not transformed_prompt.strip():
+            return
+        message.content = transformed_prompt
 
     async_url_override = async_subagent_url_override()
     agent = await runtime.get_agent(

--- a/tests/test_deepagent_runtime_rag.py
+++ b/tests/test_deepagent_runtime_rag.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 
 from langgraph.checkpoint.memory import MemorySaver
 from langgraph.store.memory import InMemoryStore
+import pytest
 
 import deepagent_runtime
 from deepagent_runtime import (
@@ -352,3 +353,95 @@ def test_ingest_rag_uploads_delegates_to_rag_service(tmp_path: Path) -> None:
 
     assert result.success is True
     assert result.added_files == ("notes.md",)
+
+
+def test_load_extensions_config_parses_chainlit_commands(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    config_path = tmp_path / "deepagent.toml"
+    config_path.write_text(
+        """
+[mcp.servers.repo]
+transport = "stdio"
+command = "npx"
+args = ["server"]
+
+[[subagents]]
+name = "repo-researcher"
+description = "Researches the repo"
+system_prompt = "Do research"
+
+[chainlit]
+commands = [
+  { name = "ask-researcher", description = "Delegate to subagent", target = "subagent", value = "repo-researcher" },
+  { name = "run-tool", description = "Call MCP tool", target = "mcp_tool", value = "repo_read_file", mcp_server = "repo" },
+  { name = "rewrite", description = "Prompt rewrite", target = "prompt", value = "Rewrite prompt", template = "Rewrite: {input}" }
+]
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DEEPAGENT_CONFIG", str(config_path))
+
+    extensions = deepagent_runtime.load_extensions_config()
+
+    assert len(extensions.chainlit_commands) == 3
+    assert extensions.chainlit_commands[0].name == "ask-researcher"
+    assert extensions.chainlit_commands[1].target == "mcp_tool"
+    assert extensions.chainlit_commands[2].template == "Rewrite: {input}"
+
+
+def test_load_extensions_config_rejects_unknown_chainlit_subagent(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    config_path = tmp_path / "deepagent.toml"
+    config_path.write_text(
+        """
+[chainlit]
+commands = [
+  { name = "ask-researcher", description = "Delegate to subagent", target = "subagent", value = "missing-subagent" }
+]
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DEEPAGENT_CONFIG", str(config_path))
+
+    with pytest.raises(ValueError, match="unknown subagent"):
+        deepagent_runtime.load_extensions_config()
+
+
+def test_invoke_mcp_tool_command_calls_configured_tool(tmp_path: Path) -> None:
+    class FakeTool:
+        name = "repo_read_file"
+
+        async def ainvoke(self, payload):
+            return {"ok": True, "payload": payload}
+
+    runtime = AgentRuntime(
+        make_runtime_config(
+            tmp_path,
+            extensions=ExtensionsConfig(
+                config_path=None,
+                mcp_servers={"repo": {"transport": "stdio", "command": "npx", "args": []}},
+            ),
+        )
+    )
+
+    async def fake_get_mcp_tools(server_names, *, thread_id=None):
+        assert server_names == ("repo",)
+        assert thread_id == "thread-1"
+        return [FakeTool()]
+
+    runtime._get_mcp_tools = fake_get_mcp_tools  # type: ignore[assignment]
+
+    result = asyncio.run(
+        runtime.invoke_mcp_tool_command(
+            tool_name="repo_read_file",
+            raw_args='{"path":"README.md"}',
+            thread_id="thread-1",
+            server_name="repo",
+        )
+    )
+
+    assert result == {"ok": True, "payload": {"path": "README.md"}}

--- a/tests/test_main_native_commands.py
+++ b/tests/test_main_native_commands.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import main
+
+
+def test_resolve_native_command_prefers_explicit_slash_text() -> None:
+    parsed = main.resolve_native_command(
+        raw_text="/summarize hello world",
+        selected_command="ask-researcher",
+    )
+
+    assert parsed == main.ParsedNativeCommand(
+        command_name="summarize",
+        raw_args="hello world",
+    )
+
+
+def test_resolve_native_command_uses_selected_command_input() -> None:
+    parsed = main.resolve_native_command(
+        raw_text="hello world",
+        selected_command="summarize",
+    )
+
+    assert parsed == main.ParsedNativeCommand(
+        command_name="summarize",
+        raw_args="hello world",
+    )
+
+
+def test_resolve_native_command_returns_none_without_command() -> None:
+    parsed = main.resolve_native_command(
+        raw_text="hello world",
+        selected_command=None,
+    )
+
+    assert parsed is None

--- a/tests/test_main_native_commands.py
+++ b/tests/test_main_native_commands.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import main
+import pytest
 
 
 def test_resolve_native_command_prefers_explicit_slash_text() -> None:
@@ -34,3 +37,62 @@ def test_resolve_native_command_returns_none_without_command() -> None:
     )
 
     assert parsed is None
+
+
+class _DummyRuntime:
+    def __init__(self) -> None:
+        self.invocation: dict[str, str | None] | None = None
+        self.command = SimpleNamespace(
+            name="repo-readme",
+            description="Read repository README",
+            target="mcp_tool",
+            value="repo_readme",
+            template='{"path":"README.md"}',
+            mcp_server="repo",
+        )
+
+    def resolve_chainlit_command(self, command_name: str):
+        if command_name == self.command.name:
+            return self.command
+        return None
+
+    async def invoke_mcp_tool_command(
+        self,
+        *,
+        tool_name: str,
+        raw_args: str,
+        thread_id: str,
+        server_name: str | None = None,
+    ):
+        self.invocation = {
+            "tool_name": tool_name,
+            "raw_args": raw_args,
+            "thread_id": thread_id,
+            "server_name": server_name,
+        }
+        return {"ok": True}
+
+
+class _DummyMessage:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+    async def send(self):
+        return None
+
+
+@pytest.mark.asyncio
+async def test_handle_native_command_applies_template_for_mcp_tool(monkeypatch) -> None:
+    runtime = _DummyRuntime()
+    settings = SimpleNamespace(thread_id="thread-1")
+    monkeypatch.setattr(main.cl, "Message", _DummyMessage)
+
+    result = await main.handle_native_command(
+        runtime=runtime,
+        settings=settings,
+        parsed=main.ParsedNativeCommand(command_name="repo-readme", raw_args=""),
+    )
+
+    assert result == ""
+    assert runtime.invocation is not None
+    assert runtime.invocation["raw_args"] == '{"path":"README.md"}'

--- a/tests/test_main_native_commands.py
+++ b/tests/test_main_native_commands.py
@@ -81,7 +81,7 @@ class _DummyMessage:
         return None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_handle_native_command_applies_template_for_mcp_tool(monkeypatch) -> None:
     runtime = _DummyRuntime()
     settings = SimpleNamespace(thread_id="thread-1")


### PR DESCRIPTION
### Motivation
- Provide a configurable native Chainlit composer surface to invoke common workflows (prompt rewrites, delegating to configured subagents, or calling MCP tools) with a simple `/command` interface.
- Make repetitive tasks and tool invocations discoverable and executable without manual prompt engineering or separate UI steps.

### Description
- Add `ChainlitCommandConfig` and a `chainlit_commands` field on `ExtensionsConfig`, and parse `[chainlit].commands` from `deepagent.toml` with validation for unique names, allowed `target` values (`prompt`, `subagent`, `mcp_tool`), and reference checks for subagents and MCP servers (`deepagent_runtime.py`).
- Extend runtime with `AgentRuntime.resolve_chainlit_command` and `AgentRuntime.invoke_mcp_tool_command` to resolve commands and call MCP tools (expects JSON args) with helpful errors when unavailable (`deepagent_runtime.py`).
- Implement composer-side handling: `parse_native_command`, `handle_native_command`, and glue in `on_message` to intercept `/name ...` inputs to either rewrite the prompt, produce a delegation prompt for a subagent, or invoke an MCP tool and post results as a System message (`main.py`).
- Surface configured native commands in the startup System message and document the new feature with examples in `deepagent.toml.example`, `README.md`, and `chainlit.md`.
- Add unit tests for parsing and validation of command configs and for MCP-tool invocation; include small supporting changes (`json` import and JSON serialization when sending tool results).

### Testing
- Ran `pytest tests/test_deepagent_runtime_rag.py -q` and all tests passed (`11 passed`).
- Ran `pytest tests/test_rag_runtime.py -q` and all tests passed (`8 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e25cdfd58c8324bc4fda9b421bab81)