### PR TITLE
Add Chainlit native commands support for skill targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,7 @@ Example:
 commands = [
   { name = "ask-researcher", description = "Delegate to repo-researcher.", target = "subagent", value = "repo-researcher", template = "{input}" },
   { name = "repo-readme", description = "Run an MCP tool directly.", target = "mcp_tool", value = "repo_read_file", mcp_server = "repo", template = "{\"path\":\"README.md\"}" },
+  { name = "review-skill", description = "Run the reviewer skill.", target = "skill", value = "reviewer", template = "{input}" },
   { name = "summarize", description = "Apply a prompt template.", target = "prompt", value = "Summarize the input", template = "Summarize this:\n{input}" }
 ]
 ```
@@ -331,6 +332,7 @@ commands = [
 `target` modes:
 
 - `prompt`: rewrites the user prompt before sending it to the agent.
+- `skill`: rewrites the user prompt to direct the runtime toward a configured skill name.
 - `subagent`: rewrites the user prompt to direct the runtime to delegate via the configured subagent.
 - `mcp_tool`: invokes the configured MCP tool directly and returns tool output in chat.
 

--- a/chainlit.md
+++ b/chainlit.md
@@ -30,7 +30,7 @@ Local-first LangChain Deep Agent UI running on Ollama or any OpenAI-compatible s
 ## Optional Extensions
 
 - Use `deepagent.toml` to add skills, MCP servers, custom subagents, and async subagents.
-- Use `[chainlit].commands` in `deepagent.toml` to add slash commands that can rewrite prompts, delegate to configured subagents, or invoke MCP tools directly.
+- Use `[chainlit].commands` in `deepagent.toml` to add slash commands that can rewrite prompts, steer execution toward a named skill, delegate to configured subagents, or invoke MCP tools directly.
 - Each sync subagent can have its own `skills` and `mcp_servers`.
 - Async subagents are Agent Protocol background jobs configured with `graph_id` and optional `url`/`headers`.
 - Omit async subagent `url` only when running the co-deployed graphs from `langgraph.json`; Chainlit-only runs need an HTTP `url`.

--- a/deepagent.toml.example
+++ b/deepagent.toml.example
@@ -34,6 +34,7 @@ mcp_servers = ["repo"]
 # Native slash commands available from the Chainlit composer.
 commands = [
   { name = "summarize-docs", description = "Summarize repository docs.", target = "prompt", value = "Summarize the repository documentation changes.", template = "Summarize docs for: {input}" },
+  { name = "review-skill", description = "Run the repository reviewer skill.", target = "skill", value = "reviewer", template = "{input}" },
   { name = "ask-researcher", description = "Delegate to repo-researcher subagent.", target = "subagent", value = "repo-researcher", template = "{input}" },
   { name = "repo-readme", description = "Call MCP filesystem read_file on README.md.", target = "mcp_tool", value = "repo_read_file", mcp_server = "repo", template = "{\"path\": \"README.md\"}" },
 ]

--- a/deepagent_runtime.py
+++ b/deepagent_runtime.py
@@ -316,7 +316,7 @@ class AsyncSubagentConfig:
 class ChainlitCommandConfig:
     name: str
     description: str
-    target: Literal["prompt", "subagent", "mcp_tool"]
+    target: Literal["prompt", "subagent", "mcp_tool", "skill"]
     value: str
     template: str | None = None
     mcp_server: str | None = None
@@ -620,9 +620,9 @@ def parse_extensions_config(raw_config: dict[str, Any], config_path: Path) -> Ex
             raise ValueError(f"Chainlit command '/{name}' is defined more than once.")
         if not description:
             raise ValueError(f"Chainlit command '/{name}' must include a non-empty 'description'.")
-        if target not in {"prompt", "subagent", "mcp_tool"}:
+        if target not in {"prompt", "subagent", "mcp_tool", "skill"}:
             raise ValueError(
-                f"Chainlit command '/{name}' target must be one of: prompt, subagent, mcp_tool."
+                f"Chainlit command '/{name}' target must be one of: prompt, subagent, mcp_tool, skill."
             )
         if not value:
             raise ValueError(f"Chainlit command '/{name}' must include a non-empty 'value'.")

--- a/main.py
+++ b/main.py
@@ -121,6 +121,7 @@ def build_native_command_specs(runtime: AgentRuntime) -> list[dict[str, Any]]:
         "prompt": "square-pen",
         "subagent": "bot",
         "mcp_tool": "wrench",
+        "skill": "sparkles",
     }
     return [
         {
@@ -272,6 +273,13 @@ async def handle_native_command(
     transformed = apply_native_template(command.template, parsed.raw_args)
     if command.target == "prompt":
         return transformed or command.value
+    if command.target == "skill":
+        return (
+            f"Use the configured `{command.value}` skill for this request.\n\n"
+            f"Command: `/{command.name}`\n"
+            f"Description: {command.description}\n\n"
+            f"User request:\n{transformed or parsed.raw_args or command.value}"
+        ).strip()
 
     return (
         f"Delegate this request to the configured `{command.value}` subagent.\n\n"

--- a/tests/test_deepagent_runtime_rag.py
+++ b/tests/test_deepagent_runtime_rag.py
@@ -376,6 +376,7 @@ system_prompt = "Do research"
 commands = [
   { name = "ask-researcher", description = "Delegate to subagent", target = "subagent", value = "repo-researcher" },
   { name = "run-tool", description = "Call MCP tool", target = "mcp_tool", value = "repo_read_file", mcp_server = "repo" },
+  { name = "review-skill", description = "Use reviewer skill", target = "skill", value = "reviewer" },
   { name = "rewrite", description = "Prompt rewrite", target = "prompt", value = "Rewrite prompt", template = "Rewrite: {input}" }
 ]
 """.strip(),
@@ -385,10 +386,11 @@ commands = [
 
     extensions = deepagent_runtime.load_extensions_config()
 
-    assert len(extensions.chainlit_commands) == 3
+    assert len(extensions.chainlit_commands) == 4
     assert extensions.chainlit_commands[0].name == "ask-researcher"
     assert extensions.chainlit_commands[1].target == "mcp_tool"
-    assert extensions.chainlit_commands[2].template == "Rewrite: {input}"
+    assert extensions.chainlit_commands[2].target == "skill"
+    assert extensions.chainlit_commands[3].template == "Rewrite: {input}"
 
 
 def test_load_extensions_config_rejects_unknown_chainlit_subagent(

--- a/tests/test_main_native_commands.py
+++ b/tests/test_main_native_commands.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import asyncio
+
 import main
 
 
@@ -34,3 +36,38 @@ def test_resolve_native_command_returns_none_without_command() -> None:
     )
 
     assert parsed is None
+
+
+def test_handle_native_command_skill_target_builds_skill_prompt() -> None:
+    class DummyRuntime:
+        def resolve_chainlit_command(self, name: str):
+            assert name == "review-skill"
+            return type(
+                "Command",
+                (),
+                {
+                    "name": "review-skill",
+                    "description": "Run reviewer skill",
+                    "target": "skill",
+                    "value": "reviewer",
+                    "template": "Please review: {input}",
+                },
+            )()
+
+    settings = type("Settings", (), {"thread_id": "thread-1"})()
+    parsed = main.ParsedNativeCommand(
+        command_name="review-skill",
+        raw_args="main.py",
+    )
+
+    transformed = asyncio.run(
+        main.handle_native_command(
+            runtime=DummyRuntime(),  # type: ignore[arg-type]
+            settings=settings,  # type: ignore[arg-type]
+            parsed=parsed,
+        )
+    )
+
+    assert transformed is not None
+    assert "Use the configured `reviewer` skill" in transformed
+    assert "Please review: main.py" in transformed


### PR DESCRIPTION
### Motivation
- Enable configuring and invoking repository-defined skills via the native Chainlit `/command` interface so composer commands can target named `skill` entries in addition to `prompt`, `subagent`, and `mcp_tool`.

### Description
- Add `skill` to the `ChainlitCommandConfig.target` literal and accept it during parsing/validation in `parse_extensions_config` so `[chainlit].commands` accepts `target = "skill"` (`deepagent_runtime.py`).
- Handle `skill` commands in the composer runtime by mapping an icon and producing a skill-directed rewritten prompt in `handle_native_command` so `/my-skill` produces a skill-invocation instruction similar to `subagent`/`prompt` flows (`main.py`).
- Update docs and examples to show `skill` usage in `README.md`, `chainlit.md`, and `deepagent.toml.example`.
- Extend tests to cover `skill` parsing and runtime behavior by adding a `skill` entry to the config parsing test and adding a focused unit test for `handle_native_command` producing the expected skill prompt (`tests/test_deepagent_runtime_rag.py`, `tests/test_main_native_commands.py`).

### Testing
- Ran `python -m py_compile main.py deepagent_runtime.py tests/test_deepagent_runtime_rag.py tests/test_main_native_commands.py` which succeeded.
- Ran `pytest tests/test_main_native_commands.py -q` which failed during collection in this environment due to a missing runtime dependency (`ModuleNotFoundError: No module named 'chainlit'`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2cc409f248324a145b649c5e577a6)