### PR TITLE
[codex] add skill-backed Chainlit slash commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,9 @@ Notes:
 - Relative skill paths are automatically mapped into the Deep Agents virtual filesystem as `/workspace/...`.
 - Each skill source directory should contain one or more skill folders, and each skill folder must contain `SKILL.md`.
 - You can also use explicit virtual paths such as `"/workspace/skills/"` if you prefer.
+- Every loaded skill is also exposed as a Chainlit slash command using the skill `name`, for example `reviewer` becomes `/reviewer`.
+- Running a skill-backed slash command forces the main agent to read that skill's `SKILL.md` and apply it for that request.
+- Skills loaded through `[agent].skills` and sync `[[subagents]].skills` are both considered for slash commands, but explicit `[chainlit].commands` take precedence on name collisions.
 
 Minimal `SKILL.md` example:
 
@@ -313,6 +316,7 @@ Supported subagent fields:
 ## Chainlit Native Commands
 
 You can configure slash-style commands that run from the Chainlit composer before the model call.
+Chainlit also auto-generates slash commands for loaded skills.
 
 Place this config in `deepagent.toml` or whatever file `DEEPAGENT_CONFIG` points to.
 Do not put it in the app UI file `chainlit.toml` or Chainlit's native [`.chainlit/config.toml`](.chainlit/config.toml).
@@ -340,6 +344,9 @@ Notes:
 - Command `name` is invoked as `/<name>` and must be unique.
 - `template` is optional and may include `{input}`.
 - For `mcp_tool`, user command arguments must be valid JSON, e.g. `/repo-readme {"path":"README.md"}`.
+- Each discovered skill also becomes `/<skill-name>` automatically. For example, a skill with `name: reviewer` is available as `/reviewer`.
+- Skill-backed commands always force the main agent to read the selected `SKILL.md` first and use it for that turn.
+- If a configured `[chainlit].commands` entry and a skill share the same slash name, the configured command wins.
 
 ## Add Async Subagents
 

--- a/deepagent_runtime.py
+++ b/deepagent_runtime.py
@@ -20,6 +20,7 @@ from deepagents.backends import (
     StateBackend,
     StoreBackend,
 )
+from deepagents.middleware.skills import _list_skills
 from langchain.agents.middleware.types import AgentMiddleware, ToolCallRequest
 from langchain_core.messages import ToolMessage
 from langchain_ollama import ChatOllama
@@ -407,10 +408,37 @@ class AsyncSubagentConfig:
 class ChainlitCommandConfig:
     name: str
     description: str
-    target: Literal["prompt", "subagent", "mcp_tool"]
+    target: Literal["prompt", "subagent", "mcp_tool", "skill"]
     value: str
     template: str | None = None
     mcp_server: str | None = None
+    source: Literal["config", "agent_skill", "subagent_skill"] = "config"
+
+
+@dataclass(frozen=True)
+class SkillCommandMetadata:
+    name: str
+    description: str
+    path: str
+    source: Literal["agent_skill", "subagent_skill"]
+    owner: str | None = None
+
+    @property
+    def label(self) -> str:
+        if self.source == "agent_skill":
+            return f"main agent skill `{self.path}`"
+        if self.owner:
+            return f"subagent `{self.owner}` skill `{self.path}`"
+        return f"subagent skill `{self.path}`"
+
+    def to_chainlit_command(self) -> ChainlitCommandConfig:
+        return ChainlitCommandConfig(
+            name=self.name,
+            description=self.description,
+            target="skill",
+            value=self.path,
+            source=self.source,
+        )
 
 
 @dataclass(frozen=True)
@@ -898,23 +926,148 @@ def build_model(config: RuntimeConfig, reasoning_level: ReasoningLevel) -> Any:
     return ChatOpenAI(**kwargs)
 
 
-def build_deepagent_backend() -> CompositeBackend:
-    artifacts_root = deepagent_artifacts_root()
+def build_deepagent_backend(*, project_root: Path | None = None) -> CompositeBackend:
+    resolved_project_root = project_root or PROJECT_ROOT
+    artifacts_root = deepagent_artifacts_root(resolved_project_root)
     return CompositeBackend(
         default=StateBackend(),
         routes={
-            deepagent_artifacts_route_prefix(): FilesystemBackend(
+            deepagent_artifacts_route_prefix(resolved_project_root): FilesystemBackend(
                 root_dir=str(artifacts_root),
                 virtual_mode=True,
             ),
             "/workspace/": FilesystemBackend(
-                root_dir=str(PROJECT_ROOT),
+                root_dir=str(resolved_project_root),
                 virtual_mode=True,
             ),
             "/memories/": StoreBackend(),
         },
         artifacts_root=str(artifacts_root),
     )
+
+
+def normalize_chainlit_command_name(value: str) -> str:
+    return value.strip().lstrip("/").lower()
+
+
+def _load_skill_command_bucket(
+    *,
+    backend: CompositeBackend,
+    source_paths: tuple[str, ...],
+    source: Literal["agent_skill", "subagent_skill"],
+    owner: str | None = None,
+) -> tuple[SkillCommandMetadata, ...]:
+    commands_by_name: dict[str, SkillCommandMetadata] = {}
+    for source_path in source_paths:
+        try:
+            source_skills = _list_skills(backend, source_path)
+        except Exception as exc:
+            logger.warning(
+                "Failed to load skills from '%s' for Chainlit command generation: %s",
+                source_path,
+                exc,
+            )
+            continue
+
+        for skill in source_skills:
+            command_name = normalize_chainlit_command_name(str(skill["name"]))
+            if not command_name or " " in command_name:
+                logger.warning(
+                    "Skipping skill '%s' from %s because it is not slash-command compatible.",
+                    skill["name"],
+                    skill["path"],
+                )
+                continue
+
+            metadata = SkillCommandMetadata(
+                name=command_name,
+                description=str(skill["description"]).strip(),
+                path=str(skill["path"]).strip(),
+                source=source,
+                owner=owner,
+            )
+            previous = commands_by_name.pop(command_name, None)
+            if previous is not None:
+                logger.warning(
+                    "Auto skill command '/%s' from %s overrides %s.",
+                    command_name,
+                    metadata.label,
+                    previous.label,
+                )
+            commands_by_name[command_name] = metadata
+    return tuple(commands_by_name.values())
+
+
+def build_chainlit_command_catalog(
+    extensions: ExtensionsConfig,
+    *,
+    backend: CompositeBackend | None = None,
+    project_root: Path | None = None,
+) -> tuple[tuple[ChainlitCommandConfig, ...], tuple[str, ...]]:
+    backend = backend or build_deepagent_backend(project_root=project_root)
+    notes: list[str] = []
+    merged_commands = list(extensions.chainlit_commands)
+    explicit_names = {command.name: command for command in extensions.chainlit_commands}
+
+    main_skill_commands = _load_skill_command_bucket(
+        backend=backend,
+        source_paths=extensions.skills,
+        source="agent_skill",
+    )
+    subagent_commands_by_name: dict[str, SkillCommandMetadata] = {}
+    for subagent in extensions.subagents:
+        for metadata in _load_skill_command_bucket(
+            backend=backend,
+            source_paths=subagent.skills,
+            source="subagent_skill",
+            owner=subagent.name,
+        ):
+            previous = subagent_commands_by_name.pop(metadata.name, None)
+            if previous is not None:
+                logger.warning(
+                    "Auto skill command '/%s' from %s overrides %s.",
+                    metadata.name,
+                    metadata.label,
+                    previous.label,
+                )
+            subagent_commands_by_name[metadata.name] = metadata
+    subagent_skill_commands = tuple(subagent_commands_by_name.values())
+
+    winner_by_name: dict[str, ChainlitCommandConfig | SkillCommandMetadata] = {
+        command.name: command for command in merged_commands
+    }
+
+    for metadata in main_skill_commands:
+        explicit = explicit_names.get(metadata.name)
+        if explicit is not None:
+            note = (
+                f"`/{metadata.name}` from {metadata.label} is hidden by explicit "
+                f"Chainlit command `/{explicit.name}`."
+            )
+            notes.append(note)
+            logger.warning(note)
+            continue
+        merged_commands.append(metadata.to_chainlit_command())
+        winner_by_name[metadata.name] = metadata
+
+    for metadata in subagent_skill_commands:
+        winner = winner_by_name.get(metadata.name)
+        if winner is None:
+            merged_commands.append(metadata.to_chainlit_command())
+            winner_by_name[metadata.name] = metadata
+            continue
+
+        if isinstance(winner, ChainlitCommandConfig):
+            note = (
+                f"`/{metadata.name}` from {metadata.label} is hidden by explicit "
+                f"Chainlit command `/{winner.name}`."
+            )
+        else:
+            note = f"`/{metadata.name}` from {metadata.label} is hidden by {winner.label}."
+        notes.append(note)
+        logger.warning(note)
+
+    return tuple(merged_commands), tuple(notes)
 
 
 def sanitize_tools_for_model(
@@ -1015,8 +1168,9 @@ class AgentRuntime:
     _instance: "AgentRuntime | None" = None
     _instance_lock = asyncio.Lock()
 
-    def __init__(self, config: RuntimeConfig) -> None:
+    def __init__(self, config: RuntimeConfig, *, project_root: Path | None = None) -> None:
         self.config = config
+        self.project_root = project_root or PROJECT_ROOT
         self._exit_stack = AsyncExitStack()
         self._agent_lock = asyncio.Lock()
         self._agents: dict[tuple[ReasoningLevel, str | None, str | None], object] = {}
@@ -1026,6 +1180,10 @@ class AgentRuntime:
         self._checkpointer: AsyncPostgresSaver | MemorySaver | None = None
         self._store: AsyncPostgresStore | InMemoryStore | None = None
         self._rag_service: WorkspaceDocsRAG | None = None
+        self._chainlit_commands, self._chainlit_command_notes = build_chainlit_command_catalog(
+            config.extensions,
+            project_root=self.project_root,
+        )
 
     @classmethod
     async def get(cls) -> "AgentRuntime":
@@ -1055,6 +1213,14 @@ class AgentRuntime:
     @property
     def rag_enabled(self) -> bool:
         return self.config.rag_requested
+
+    @property
+    def chainlit_commands(self) -> tuple[ChainlitCommandConfig, ...]:
+        return self._chainlit_commands
+
+    @property
+    def chainlit_command_notes(self) -> tuple[str, ...]:
+        return self._chainlit_command_notes
 
     @property
     def rag_status(self) -> RagStatus:
@@ -1093,7 +1259,7 @@ class AgentRuntime:
         if self.config.rag is not None:
             self._rag_service = WorkspaceDocsRAG(
                 self.config.rag,
-                project_root=PROJECT_ROOT,
+                project_root=self.project_root,
             )
             rag_status = await asyncio.to_thread(self._rag_service.ensure_ready)
             if not rag_status.ready and rag_status.reason:
@@ -1191,10 +1357,10 @@ class AgentRuntime:
         )
 
     def resolve_chainlit_command(self, name: str) -> ChainlitCommandConfig | None:
-        normalized = name.strip().lstrip("/").lower()
+        normalized = normalize_chainlit_command_name(name)
         if not normalized:
             return None
-        for command in self.config.extensions.chainlit_commands:
+        for command in self.chainlit_commands:
             if command.name == normalized:
                 return command
         return None
@@ -1335,4 +1501,4 @@ class AgentRuntime:
             self._agents.clear()
 
     def _build_backend(self, runtime):
-        return build_deepagent_backend()
+        return build_deepagent_backend(project_root=self.project_root)

--- a/main.py
+++ b/main.py
@@ -121,6 +121,7 @@ def build_native_command_specs(runtime: AgentRuntime) -> list[dict[str, Any]]:
         "prompt": "square-pen",
         "subagent": "bot",
         "mcp_tool": "wrench",
+        "skill": "book-open",
     }
     return [
         {
@@ -130,7 +131,7 @@ def build_native_command_specs(runtime: AgentRuntime) -> list[dict[str, Any]]:
             "button": False,
             "persistent": True,
         }
-        for command in runtime.config.extensions.chainlit_commands
+        for command in runtime.chainlit_commands
     ]
 
 
@@ -241,6 +242,25 @@ def apply_native_template(template: str | None, raw_args: str) -> str:
     return template.replace("{input}", raw_args.strip()).strip()
 
 
+def build_skill_command_prompt(*, skill_name: str, skill_path: str, raw_args: str) -> str:
+    prelude = (
+        f"Use the configured `{skill_name}` skill for this request.\n"
+        f"Read `{skill_path}` before taking any other action and follow it for this entire turn.\n"
+        "Skill usage is mandatory for this request.\n"
+    )
+    request = raw_args.strip()
+    if request:
+        return (
+            f"{prelude}\n"
+            "After reading the skill, complete the user's request below.\n\n"
+            f"User request:\n{request}"
+        ).strip()
+    return (
+        f"{prelude}\n"
+        "After reading the skill, briefly explain what it does and ask the user for the specific task."
+    ).strip()
+
+
 async def handle_native_command(
     *,
     runtime: AgentRuntime,
@@ -250,6 +270,13 @@ async def handle_native_command(
     command = runtime.resolve_chainlit_command(parsed.command_name)
     if command is None:
         return None
+
+    if command.target == "skill":
+        return build_skill_command_prompt(
+            skill_name=command.name,
+            skill_path=command.value,
+            raw_args=parsed.raw_args,
+        )
 
     if command.target == "mcp_tool":
         tool_raw_args = apply_native_template(command.template, parsed.raw_args)
@@ -434,6 +461,10 @@ async def on_chat_start() -> None:
         else "- History bar: disabled; set `DATABASE_URL`, `CHAINLIT_AUTH_SECRET`, `CHAINLIT_AUTH_USERNAME`, and `CHAINLIT_AUTH_PASSWORD` to enable native Chainlit history\n"
     )
     extensions = runtime.config.extensions
+    configured_command_count = len(extensions.chainlit_commands)
+    skill_command_count = sum(
+        1 for command in runtime.chainlit_commands if command.target == "skill"
+    )
     mcp_session_mode_line = (
         "- MCP session mode: stateful per LangGraph thread while this app process stays alive\n"
         if extensions.mcp_stateful
@@ -445,14 +476,19 @@ async def on_chat_start() -> None:
         f"{mcp_session_mode_line}"
         f"- Custom subagents: `{len(extensions.subagents)}`\n"
         f"- Async subagents: `{len(extensions.async_subagents)}`\n"
-        f"- Native commands: `{len(extensions.chainlit_commands)}`\n"
+        f"- Configured commands: `{configured_command_count}`\n"
+        f"- Skill-backed commands: `{skill_command_count}`\n"
+        f"- Native commands: `{len(runtime.chainlit_commands)}`\n"
     )
-    if extensions.chainlit_commands:
+    if runtime.chainlit_commands:
         command_lines = "\n".join(
             f"  - `/{command.name}` ({command.target}): {command.description}"
-            for command in extensions.chainlit_commands
+            for command in runtime.chainlit_commands
         )
-        extensions_line += f"Configured commands:\n{command_lines}\n"
+        extensions_line += f"Available commands:\n{command_lines}\n"
+    if runtime.chainlit_command_notes:
+        note_lines = "\n".join(f"  - {note}" for note in runtime.chainlit_command_notes)
+        extensions_line += f"Command notes:\n{note_lines}\n"
     if extensions.config_path is not None:
         extensions_line += f"- Extensions config: `{extensions.config_path.name}`\n"
     startup_message = cl.Message(

--- a/tests/test_deepagent_runtime_rag.py
+++ b/tests/test_deepagent_runtime_rag.py
@@ -14,9 +14,13 @@ import pytest
 import deepagent_runtime
 from deepagent_runtime import (
     AgentRuntime,
+    ChainlitCommandConfig,
     ExtensionsConfig,
     RuntimeConfig,
+    SubagentConfig,
     ToolExecutionResilienceMiddleware,
+    build_chainlit_command_catalog,
+    build_deepagent_backend,
     deepagent_artifacts_root,
     deepagent_artifacts_route_prefix,
 )
@@ -78,6 +82,27 @@ def make_extensions_config(
         mcp_stateful=mcp_stateful,
         mcp_servers={"repo": {"transport": "stdio", "command": "npx", "args": []}},
         agent_mcp_servers=agent_mcp_servers,
+    )
+
+
+def write_skill(
+    root: Path,
+    directory: str,
+    *,
+    name: str,
+    description: str,
+) -> None:
+    skill_path = root / directory / "SKILL.md"
+    skill_path.parent.mkdir(parents=True, exist_ok=True)
+    skill_path.write_text(
+        (
+            "---\n"
+            f"name: {name}\n"
+            f"description: {description}\n"
+            "---\n\n"
+            f"# {name}\n"
+        ),
+        encoding="utf-8",
     )
 
 
@@ -471,6 +496,155 @@ commands = [
 
     with pytest.raises(ValueError, match="unknown subagent"):
         deepagent_runtime.load_extensions_config()
+
+
+def test_build_chainlit_command_catalog_includes_main_and_subagent_skills(
+    tmp_path: Path,
+) -> None:
+    write_skill(
+        tmp_path,
+        "skills/reviewer",
+        name="reviewer",
+        description="Review code for bugs.",
+    )
+    write_skill(
+        tmp_path,
+        "subskills/repo-guide",
+        name="repo-guide",
+        description="Walk the repository.",
+    )
+    extensions = ExtensionsConfig(
+        config_path=None,
+        skills=("/workspace/skills/",),
+        subagents=(
+            SubagentConfig(
+                name="repo-researcher",
+                description="Researches the repo",
+                system_prompt="Do research",
+                skills=("/workspace/subskills/",),
+            ),
+        ),
+    )
+
+    commands, notes = build_chainlit_command_catalog(
+        extensions,
+        backend=build_deepagent_backend(project_root=tmp_path),
+        project_root=tmp_path,
+    )
+
+    assert [command.name for command in commands] == ["reviewer", "repo-guide"]
+    assert commands[0].target == "skill"
+    assert commands[0].value == "/workspace/skills/reviewer/SKILL.md"
+    assert commands[1].value == "/workspace/subskills/repo-guide/SKILL.md"
+    assert notes == ()
+
+
+def test_build_chainlit_command_catalog_prefers_explicit_command_over_skill(
+    tmp_path: Path,
+) -> None:
+    write_skill(
+        tmp_path,
+        "skills/reviewer",
+        name="reviewer",
+        description="Review code for bugs.",
+    )
+    extensions = ExtensionsConfig(
+        config_path=None,
+        skills=("/workspace/skills/",),
+        chainlit_commands=(
+            ChainlitCommandConfig(
+                name="reviewer",
+                description="Explicit reviewer command",
+                target="prompt",
+                value="Review this",
+            ),
+        ),
+    )
+
+    commands, notes = build_chainlit_command_catalog(
+        extensions,
+        backend=build_deepagent_backend(project_root=tmp_path),
+        project_root=tmp_path,
+    )
+
+    assert len(commands) == 1
+    assert commands[0].target == "prompt"
+    assert len(notes) == 1
+    assert "hidden by explicit Chainlit command" in notes[0]
+
+
+def test_build_chainlit_command_catalog_prefers_main_agent_skill_over_subagent_skill(
+    tmp_path: Path,
+) -> None:
+    write_skill(
+        tmp_path,
+        "skills/reviewer",
+        name="reviewer",
+        description="Main reviewer",
+    )
+    write_skill(
+        tmp_path,
+        "subskills/reviewer",
+        name="reviewer",
+        description="Subagent reviewer",
+    )
+    extensions = ExtensionsConfig(
+        config_path=None,
+        skills=("/workspace/skills/",),
+        subagents=(
+            SubagentConfig(
+                name="repo-researcher",
+                description="Researches the repo",
+                system_prompt="Do research",
+                skills=("/workspace/subskills/",),
+            ),
+        ),
+    )
+
+    commands, notes = build_chainlit_command_catalog(
+        extensions,
+        backend=build_deepagent_backend(project_root=tmp_path),
+        project_root=tmp_path,
+    )
+
+    assert len(commands) == 1
+    assert commands[0].target == "skill"
+    assert commands[0].description == "Main reviewer"
+    assert commands[0].value == "/workspace/skills/reviewer/SKILL.md"
+    assert len(notes) == 1
+    assert "main agent skill" in notes[0]
+
+
+def test_build_chainlit_command_catalog_uses_later_skill_source_in_same_bucket(
+    tmp_path: Path,
+) -> None:
+    write_skill(
+        tmp_path,
+        "skills-a/reviewer",
+        name="reviewer",
+        description="Earlier reviewer",
+    )
+    write_skill(
+        tmp_path,
+        "skills-b/reviewer",
+        name="reviewer",
+        description="Later reviewer",
+    )
+    extensions = ExtensionsConfig(
+        config_path=None,
+        skills=("/workspace/skills-a/", "/workspace/skills-b/"),
+    )
+
+    commands, notes = build_chainlit_command_catalog(
+        extensions,
+        backend=build_deepagent_backend(project_root=tmp_path),
+        project_root=tmp_path,
+    )
+
+    assert len(commands) == 1
+    assert commands[0].description == "Later reviewer"
+    assert commands[0].value == "/workspace/skills-b/reviewer/SKILL.md"
+    assert notes == ()
 
 
 def test_invoke_mcp_tool_command_calls_configured_tool(tmp_path: Path) -> None:

--- a/tests/test_main_native_commands.py
+++ b/tests/test_main_native_commands.py
@@ -40,9 +40,9 @@ def test_resolve_native_command_returns_none_without_command() -> None:
 
 
 class _DummyRuntime:
-    def __init__(self) -> None:
+    def __init__(self, command=None) -> None:
         self.invocation: dict[str, str | None] | None = None
-        self.command = SimpleNamespace(
+        self.command = command or SimpleNamespace(
             name="repo-readme",
             description="Read repository README",
             target="mcp_tool",
@@ -96,3 +96,114 @@ async def test_handle_native_command_applies_template_for_mcp_tool(monkeypatch) 
     assert result == ""
     assert runtime.invocation is not None
     assert runtime.invocation["raw_args"] == '{"path":"README.md"}'
+
+
+def test_build_skill_command_prompt_requires_skill_and_request() -> None:
+    prompt = main.build_skill_command_prompt(
+        skill_name="reviewer",
+        skill_path="/workspace/skills/reviewer/SKILL.md",
+        raw_args="inspect this diff",
+    )
+
+    assert "Use the configured `reviewer` skill" in prompt
+    assert "Read `/workspace/skills/reviewer/SKILL.md` before taking any other action" in prompt
+    assert "Skill usage is mandatory" in prompt
+    assert "User request:\ninspect this diff" in prompt
+
+
+def test_build_skill_command_prompt_without_request_asks_for_task() -> None:
+    prompt = main.build_skill_command_prompt(
+        skill_name="reviewer",
+        skill_path="/workspace/skills/reviewer/SKILL.md",
+        raw_args="",
+    )
+
+    assert "briefly explain what it does and ask the user for the specific task" in prompt
+
+
+@pytest.mark.anyio
+async def test_handle_native_command_returns_forced_skill_prompt() -> None:
+    runtime = _DummyRuntime(
+        command=SimpleNamespace(
+            name="reviewer",
+            description="Review code for bugs",
+            target="skill",
+            value="/workspace/skills/reviewer/SKILL.md",
+            template=None,
+            mcp_server=None,
+        )
+    )
+    settings = SimpleNamespace(thread_id="thread-1")
+
+    result = await main.handle_native_command(
+        runtime=runtime,
+        settings=settings,
+        parsed=main.ParsedNativeCommand(
+            command_name="reviewer",
+            raw_args="inspect this diff",
+        ),
+    )
+
+    assert result is not None
+    assert "Use the configured `reviewer` skill" in result
+    assert "User request:\ninspect this diff" in result
+
+
+@pytest.mark.anyio
+async def test_handle_native_command_without_skill_args_requests_clarification() -> None:
+    runtime = _DummyRuntime(
+        command=SimpleNamespace(
+            name="reviewer",
+            description="Review code for bugs",
+            target="skill",
+            value="/workspace/skills/reviewer/SKILL.md",
+            template=None,
+            mcp_server=None,
+        )
+    )
+    settings = SimpleNamespace(thread_id="thread-1")
+
+    result = await main.handle_native_command(
+        runtime=runtime,
+        settings=settings,
+        parsed=main.ParsedNativeCommand(
+            command_name="reviewer",
+            raw_args="",
+        ),
+    )
+
+    assert result is not None
+    assert "briefly explain what it does and ask the user for the specific task" in result
+
+
+@pytest.mark.anyio
+async def test_handle_native_command_uses_selected_skill_command_input() -> None:
+    runtime = _DummyRuntime(
+        command=SimpleNamespace(
+            name="reviewer",
+            description="Review code for bugs",
+            target="skill",
+            value="/workspace/skills/reviewer/SKILL.md",
+            template=None,
+            mcp_server=None,
+        )
+    )
+    settings = SimpleNamespace(thread_id="thread-1")
+    parsed = main.resolve_native_command(
+        raw_text="inspect this diff",
+        selected_command="reviewer",
+    )
+
+    assert parsed == main.ParsedNativeCommand(
+        command_name="reviewer",
+        raw_args="inspect this diff",
+    )
+
+    result = await main.handle_native_command(
+        runtime=runtime,
+        settings=settings,
+        parsed=parsed,
+    )
+
+    assert result is not None
+    assert "User request:\ninspect this diff" in result


### PR DESCRIPTION
## Summary

- auto-discover loaded Deep Agent skills and expose them as Chainlit slash commands
- merge explicit Chainlit commands with generated skill commands using the requested precedence rules
- force skill-backed commands to read and apply the selected `SKILL.md` for the current turn
- document the new skill command behavior and add regression coverage

## Validation

- `./.venv/bin/pytest`