### PR TITLE
[codex] bind stateful MCP sessions to Chainlit sessions

### DIFF
--- a/deepagent_runtime.py
+++ b/deepagent_runtime.py
@@ -1173,13 +1173,19 @@ class AgentRuntime:
         self.project_root = project_root or PROJECT_ROOT
         self._exit_stack = AsyncExitStack()
         self._agent_lock = asyncio.Lock()
-        self._agents: dict[tuple[ReasoningLevel, str | None, str | None], object] = {}
+        self._mcp_lock = asyncio.Lock()
+        self._agents: dict[
+            tuple[ReasoningLevel, str | None, str | None, str | None],
+            object,
+        ] = {}
         self._mcp_client: MultiServerMCPClient | None = None
         self._mcp_tools_cache: dict[tuple[str | None, tuple[str, ...]], list[Any]] = {}
         self._mcp_sessions: dict[tuple[str | None, str], Any] = {}
+        self._mcp_session_stacks: dict[str | None, AsyncExitStack] = {}
         self._checkpointer: AsyncPostgresSaver | MemorySaver | None = None
         self._store: AsyncPostgresStore | InMemoryStore | None = None
         self._rag_service: WorkspaceDocsRAG | None = None
+        self._exit_stack.push_async_callback(self.close_all_mcp_sessions)
         self._chainlit_commands, self._chainlit_command_notes = build_chainlit_command_catalog(
             config.extensions,
             project_root=self.project_root,
@@ -1193,6 +1199,10 @@ class AgentRuntime:
                 await instance._initialize()
                 cls._instance = instance
             return cls._instance
+
+    @classmethod
+    def current(cls) -> "AgentRuntime | None":
+        return cls._instance
 
     @property
     def checkpointer(self) -> AsyncPostgresSaver | MemorySaver:
@@ -1273,8 +1283,18 @@ class AgentRuntime:
         *,
         thread_id: str | None = None,
         async_subagent_url_override: str | None = None,
+        mcp_session_id: str | None = None,
     ):
-        cache_key = (reasoning_level, thread_id, async_subagent_url_override)
+        mcp_scope = self._mcp_scope(
+            mcp_session_id=mcp_session_id,
+            thread_id=thread_id,
+        )
+        cache_key = (
+            reasoning_level,
+            thread_id,
+            async_subagent_url_override,
+            mcp_scope,
+        )
         async with self._agent_lock:
             agent = self._agents.get(cache_key)
             if agent is None:
@@ -1282,7 +1302,10 @@ class AgentRuntime:
                 rag_tool_enabled = self._rag_service is not None
                 main_tools = sanitize_tools_for_model(
                     self.config.model_provider,
-                    await self._build_main_tools(thread_id=thread_id),
+                    await self._build_main_tools(
+                        thread_id=thread_id,
+                        mcp_session_id=mcp_session_id,
+                    ),
                 )
                 middleware = build_agent_middleware()
                 subagent_specs: list[Any] = [
@@ -1292,6 +1315,7 @@ class AgentRuntime:
                             await self._get_mcp_tools(
                                 subagent.mcp_servers,
                                 thread_id=thread_id,
+                                mcp_session_id=mcp_session_id,
                             ),
                         ),
                         middleware=middleware,
@@ -1371,6 +1395,7 @@ class AgentRuntime:
         tool_name: str,
         raw_args: str,
         thread_id: str | None = None,
+        mcp_session_id: str | None = None,
         server_name: str | None = None,
     ) -> Any:
         candidate_servers: tuple[str, ...]
@@ -1380,7 +1405,11 @@ class AgentRuntime:
             available_servers = self.config.extensions.mcp_servers or {}
             candidate_servers = tuple(available_servers.keys())
 
-        tools = await self._get_mcp_tools(candidate_servers, thread_id=thread_id)
+        tools = await self._get_mcp_tools(
+            candidate_servers,
+            thread_id=thread_id,
+            mcp_session_id=mcp_session_id,
+        )
         selected_tool = next(
             (
                 tool
@@ -1423,13 +1452,34 @@ class AgentRuntime:
     def _build_model(self, reasoning_level: ReasoningLevel) -> Any:
         return build_model(self.config, reasoning_level)
 
+    def _mcp_scope(
+        self,
+        *,
+        mcp_session_id: str | None,
+        thread_id: str | None = None,
+    ) -> str | None:
+        if not self.config.extensions.mcp_stateful:
+            return None
+
+        candidate = str(mcp_session_id or "").strip()
+        if candidate:
+            return candidate
+
+        fallback = str(thread_id or "").strip()
+        return fallback or None
+
     async def _get_stateful_mcp_session(
         self,
         *,
         server_name: str,
         thread_id: str | None,
+        mcp_session_id: str | None,
     ) -> Any:
-        cache_key = (thread_id, server_name)
+        scope = self._mcp_scope(
+            mcp_session_id=mcp_session_id,
+            thread_id=thread_id,
+        )
+        cache_key = (scope, server_name)
         session = self._mcp_sessions.get(cache_key)
         if session is not None:
             return session
@@ -1437,9 +1487,12 @@ class AgentRuntime:
         if self._mcp_client is None:
             raise RuntimeError("MCP client is not initialized.")
 
-        session = await self._exit_stack.enter_async_context(
-            self._mcp_client.session(server_name)
-        )
+        stack = self._mcp_session_stacks.get(scope)
+        if stack is None:
+            stack = AsyncExitStack()
+            self._mcp_session_stacks[scope] = stack
+
+        session = await stack.enter_async_context(self._mcp_client.session(server_name))
         self._mcp_sessions[cache_key] = session
         return session
 
@@ -1448,43 +1501,56 @@ class AgentRuntime:
         server_names: tuple[str, ...],
         *,
         thread_id: str | None = None,
+        mcp_session_id: str | None = None,
     ) -> list[Any]:
         if not server_names or self._mcp_client is None:
             return []
 
-        tool_scope = thread_id if self.config.extensions.mcp_stateful else None
+        tool_scope = self._mcp_scope(
+            mcp_session_id=mcp_session_id,
+            thread_id=thread_id,
+        )
         cache_key = (tool_scope, tuple(server_names))
-        cached = self._mcp_tools_cache.get(cache_key)
-        if cached is not None:
-            return list(cached)
 
-        tools: list[Any] = []
-        for server_name in cache_key[1]:
-            if self.config.extensions.mcp_stateful:
-                session = await self._get_stateful_mcp_session(
-                    server_name=server_name,
-                    thread_id=thread_id,
-                )
-                tools.extend(
-                    await load_mcp_tools(
-                        session,
-                        callbacks=self._mcp_client.callbacks,
-                        tool_interceptors=self._mcp_client.tool_interceptors,
+        async with self._mcp_lock:
+            cached = self._mcp_tools_cache.get(cache_key)
+            if cached is not None:
+                return list(cached)
+
+            tools: list[Any] = []
+            for server_name in cache_key[1]:
+                if self.config.extensions.mcp_stateful:
+                    session = await self._get_stateful_mcp_session(
                         server_name=server_name,
-                        tool_name_prefix=self.config.extensions.mcp_tool_name_prefix,
+                        thread_id=thread_id,
+                        mcp_session_id=mcp_session_id,
                     )
-                )
-                continue
+                    tools.extend(
+                        await load_mcp_tools(
+                            session,
+                            callbacks=self._mcp_client.callbacks,
+                            tool_interceptors=self._mcp_client.tool_interceptors,
+                            server_name=server_name,
+                            tool_name_prefix=self.config.extensions.mcp_tool_name_prefix,
+                        )
+                    )
+                    continue
 
-            tools.extend(await self._mcp_client.get_tools(server_name=server_name))
+                tools.extend(await self._mcp_client.get_tools(server_name=server_name))
 
-        self._mcp_tools_cache[cache_key] = tools
-        return list(tools)
+            self._mcp_tools_cache[cache_key] = tools
+            return list(tools)
 
-    async def _build_main_tools(self, *, thread_id: str | None) -> list[Any]:
+    async def _build_main_tools(
+        self,
+        *,
+        thread_id: str | None,
+        mcp_session_id: str | None,
+    ) -> list[Any]:
         tools = await self._get_mcp_tools(
             self.config.extensions.agent_mcp_servers,
             thread_id=thread_id,
+            mcp_session_id=mcp_session_id,
         )
         if self._rag_service is not None:
             tools = list(tools)
@@ -1499,6 +1565,45 @@ class AgentRuntime:
     async def _clear_agent_cache(self) -> None:
         async with self._agent_lock:
             self._agents.clear()
+
+    async def close_mcp_session(self, mcp_session_id: str | None) -> None:
+        mcp_scope = self._mcp_scope(mcp_session_id=mcp_session_id)
+        if mcp_scope is None:
+            return
+
+        async with self._agent_lock:
+            self._agents = {
+                key: agent
+                for key, agent in self._agents.items()
+                if len(key) < 4 or key[3] != mcp_scope
+            }
+            async with self._mcp_lock:
+                stack = self._mcp_session_stacks.pop(mcp_scope, None)
+                self._mcp_sessions = {
+                    key: session
+                    for key, session in self._mcp_sessions.items()
+                    if key[0] != mcp_scope
+                }
+                self._mcp_tools_cache = {
+                    key: tools
+                    for key, tools in self._mcp_tools_cache.items()
+                    if key[0] != mcp_scope
+                }
+
+        if stack is not None:
+            await stack.aclose()
+
+    async def close_all_mcp_sessions(self) -> None:
+        async with self._agent_lock:
+            async with self._mcp_lock:
+                stacks = list(self._mcp_session_stacks.values())
+                self._mcp_session_stacks.clear()
+                self._mcp_sessions.clear()
+                self._mcp_tools_cache.clear()
+                self._agents.clear()
+
+        for stack in stacks:
+            await stack.aclose()
 
     def _build_backend(self, runtime):
         return build_deepagent_backend(project_root=self.project_root)

--- a/main.py
+++ b/main.py
@@ -34,6 +34,7 @@ from response_exports import (
 SESSION_SETTINGS_KEY = "agent_settings"
 SESSION_TASK_LIST_KEY = "run_task_list"
 SESSION_ASYNC_TASK_NOTIFIER_KEY = "async_task_notifier"
+SESSION_MCP_SESSION_ID_KEY = "mcp_session_id"
 REBUILD_RAG_INDEX_ACTION = "rebuild_knowledge_index"
 UPLOAD_RAG_FILE_ACTION = "upload_rag_file"
 RAG_UPLOAD_ACCEPT = {
@@ -79,6 +80,27 @@ def current_chainlit_thread_id() -> str:
         return ""
     thread_id = getattr(session, "thread_id", None) or getattr(session, "id", None)
     return str(thread_id or "").strip()
+
+
+def current_chainlit_session_id() -> str:
+    try:
+        session = cl.context.session
+    except Exception:
+        return ""
+    return str(getattr(session, "id", None) or "").strip()
+
+
+def store_mcp_session_id() -> str:
+    session_id = current_chainlit_session_id() or current_chainlit_thread_id()
+    cl.user_session.set(SESSION_MCP_SESSION_ID_KEY, session_id)
+    return session_id
+
+
+def current_mcp_session_id() -> str:
+    session_id = str(cl.user_session.get(SESSION_MCP_SESSION_ID_KEY) or "").strip()
+    if session_id:
+        return session_id
+    return store_mcp_session_id()
 
 
 def settings_payload(settings: AppSettings) -> dict[str, str]:
@@ -266,6 +288,7 @@ async def handle_native_command(
     runtime: AgentRuntime,
     settings: AppSettings,
     parsed: ParsedNativeCommand,
+    mcp_session_id: str | None = None,
 ) -> str | None:
     command = runtime.resolve_chainlit_command(parsed.command_name)
     if command is None:
@@ -284,6 +307,7 @@ async def handle_native_command(
             tool_name=command.value,
             raw_args=tool_raw_args,
             thread_id=settings.thread_id,
+            mcp_session_id=mcp_session_id,
             server_name=command.mcp_server,
         )
         await cl.Message(
@@ -441,6 +465,7 @@ async def on_chat_start() -> None:
     runtime = await get_runtime_or_notify()
     if runtime is None:
         return
+    store_mcp_session_id()
     await publish_native_commands(runtime)
     run_task_list = await get_run_task_list()
     await run_task_list.show_ready()
@@ -466,7 +491,7 @@ async def on_chat_start() -> None:
         1 for command in runtime.chainlit_commands if command.target == "skill"
     )
     mcp_session_mode_line = (
-        "- MCP session mode: stateful per LangGraph thread while this app process stays alive\n"
+        "- MCP session mode: stateful for this Chainlit session; cleaned up when the session ends\n"
         if extensions.mcp_stateful
         else "- MCP session mode: stateless; a new MCP session is created for each tool call\n"
     )
@@ -516,6 +541,7 @@ async def on_chat_resume(thread: ThreadDict) -> None:
     runtime = await get_runtime_or_notify()
     if runtime is None:
         return
+    mcp_session_id = store_mcp_session_id()
     await publish_native_commands(runtime)
 
     run_task_list = await get_run_task_list()
@@ -533,6 +559,7 @@ async def on_chat_resume(thread: ThreadDict) -> None:
         settings.reasoning_level,
         thread_id=settings.thread_id,
         async_subagent_url_override=async_url_override,
+        mcp_session_id=mcp_session_id,
     )
     async_task_notifier = get_async_task_notifier(
         agent=agent,
@@ -615,6 +642,7 @@ async def on_message(message: cl.Message) -> None:
     runtime = await get_runtime_or_notify()
     if runtime is None:
         return
+    mcp_session_id = current_mcp_session_id()
     run_task_list = await get_run_task_list()
     uploaded_files = message_uploaded_rag_files(message)
     prompt_note = ""
@@ -646,6 +674,7 @@ async def on_message(message: cl.Message) -> None:
                 runtime=runtime,
                 settings=settings,
                 parsed=parsed_command,
+                mcp_session_id=mcp_session_id,
             )
         except Exception as exc:
             await cl.Message(
@@ -673,6 +702,7 @@ async def on_message(message: cl.Message) -> None:
         settings.reasoning_level,
         thread_id=settings.thread_id,
         async_subagent_url_override=async_url_override,
+        mcp_session_id=mcp_session_id,
     )
     async_task_notifier = get_async_task_notifier(
         agent=agent,
@@ -732,3 +762,9 @@ async def on_chat_end() -> None:
     notifier = cl.user_session.get(SESSION_ASYNC_TASK_NOTIFIER_KEY)
     if isinstance(notifier, AsyncTaskNotifier):
         notifier.cancel()
+    runtime = AgentRuntime.current()
+    if runtime is not None:
+        with suppress(Exception):
+            await runtime.close_mcp_session(
+                cl.user_session.get(SESSION_MCP_SESSION_ID_KEY)
+            )

--- a/tests/test_deepagent_runtime_rag.py
+++ b/tests/test_deepagent_runtime_rag.py
@@ -322,11 +322,12 @@ def test_get_agent_omits_rag_tool_when_service_is_missing(
     assert any(isinstance(item, ToolExecutionResilienceMiddleware) for item in middleware)
 
 
-def test_stateful_mcp_reuses_session_per_thread(
+def test_stateful_mcp_reuses_session_per_chainlit_session(
     tmp_path: Path,
     monkeypatch,
 ) -> None:
     created_sessions: list[tuple[str, object]] = []
+    closed_sessions: list[object] = []
     load_calls: list[tuple[object, str]] = []
 
     class FakeMCPClient:
@@ -337,7 +338,10 @@ def test_stateful_mcp_reuses_session_per_thread(
         async def session(self, server_name: str, *, auto_initialize: bool = True):
             session = object()
             created_sessions.append((server_name, session))
-            yield session
+            try:
+                yield session
+            finally:
+                closed_sessions.append(session)
 
         async def get_tools(self, *, server_name: str | None = None):
             raise AssertionError("stateful MCP mode should not call get_tools()")
@@ -366,29 +370,43 @@ def test_stateful_mcp_reuses_session_per_thread(
     runtime._mcp_client = FakeMCPClient()
 
     async def exercise_runtime():
-        thread_1_tools_first = await runtime._get_mcp_tools(
+        session_1_tools_first = await runtime._get_mcp_tools(
             ("repo",),
             thread_id="thread-1",
+            mcp_session_id="session-1",
         )
-        thread_1_tools_second = await runtime._get_mcp_tools(
-            ("repo",),
-            thread_id="thread-1",
-        )
-        thread_2_tools = await runtime._get_mcp_tools(
+        session_1_tools_second = await runtime._get_mcp_tools(
             ("repo",),
             thread_id="thread-2",
+            mcp_session_id="session-1",
         )
-        await runtime._exit_stack.aclose()
-        return thread_1_tools_first, thread_1_tools_second, thread_2_tools
+        session_2_tools = await runtime._get_mcp_tools(
+            ("repo",),
+            thread_id="thread-1",
+            mcp_session_id="session-2",
+        )
+        runtime._agents[("medium", "thread-1", None, "session-1")] = object()
+        runtime._agents[("medium", "thread-1", None, "session-2")] = object()
+        await runtime.close_mcp_session("session-1")
+        assert len(closed_sessions) == 1
+        assert ("session-1", "repo") not in runtime._mcp_sessions
+        assert ("session-1", ("repo",)) not in runtime._mcp_tools_cache
+        assert ("medium", "thread-1", None, "session-1") not in runtime._agents
+        assert ("medium", "thread-1", None, "session-2") in runtime._agents
+        await runtime.close_mcp_session("session-2")
+        return session_1_tools_first, session_1_tools_second, session_2_tools
 
-    thread_1_tools_first, thread_1_tools_second, thread_2_tools = asyncio.run(
+    session_1_tools_first, session_1_tools_second, session_2_tools = asyncio.run(
         exercise_runtime()
     )
 
     assert len(created_sessions) == 2
     assert len(load_calls) == 2
-    assert thread_1_tools_first[0].session is thread_1_tools_second[0].session
-    assert thread_1_tools_first[0].session is not thread_2_tools[0].session
+    assert len(closed_sessions) == 2
+    assert session_1_tools_first[0].session is session_1_tools_second[0].session
+    assert session_1_tools_first[0].session is not session_2_tools[0].session
+    assert closed_sessions[0] is session_1_tools_first[0].session
+    assert closed_sessions[1] is session_2_tools[0].session
 
 
 def test_rebuild_rag_index_clears_cached_agents(
@@ -664,9 +682,10 @@ def test_invoke_mcp_tool_command_calls_configured_tool(tmp_path: Path) -> None:
         )
     )
 
-    async def fake_get_mcp_tools(server_names, *, thread_id=None):
+    async def fake_get_mcp_tools(server_names, *, thread_id=None, mcp_session_id=None):
         assert server_names == ("repo",)
         assert thread_id == "thread-1"
+        assert mcp_session_id is None
         return [FakeTool()]
 
     runtime._get_mcp_tools = fake_get_mcp_tools  # type: ignore[assignment]

--- a/tests/test_main_native_commands.py
+++ b/tests/test_main_native_commands.py
@@ -62,12 +62,14 @@ class _DummyRuntime:
         tool_name: str,
         raw_args: str,
         thread_id: str,
+        mcp_session_id: str | None = None,
         server_name: str | None = None,
     ):
         self.invocation = {
             "tool_name": tool_name,
             "raw_args": raw_args,
             "thread_id": thread_id,
+            "mcp_session_id": mcp_session_id,
             "server_name": server_name,
         }
         return {"ok": True}
@@ -96,6 +98,7 @@ async def test_handle_native_command_applies_template_for_mcp_tool(monkeypatch) 
     assert result == ""
     assert runtime.invocation is not None
     assert runtime.invocation["raw_args"] == '{"path":"README.md"}'
+    assert runtime.invocation["mcp_session_id"] is None
 
 
 def test_build_skill_command_prompt_requires_skill_and_request() -> None:


### PR DESCRIPTION
## Summary

- Store a Chainlit session-scoped MCP session id in `cl.user_session`.
- Scope stateful MCP sessions, tool caches, and agent caches by that session id.
- Clean up session-bound MCP context managers when Chainlit ends the chat.
- Keep LangGraph thread ids as the durable checkpoint and RAG boundary.

## Why

Stateful MCP clients were keyed around LangGraph thread state, which can outlive or differ from the live Chainlit UI session. This made MCP session lifetime broader than the user session and left cleanup dependent on process shutdown.

## Validation

- `uv run pytest`

## Notes

`deepagent.toml` has separate unstaged local ToolUniverse changes and is intentionally not part of this PR.