### PR TITLE
Fix slash command skill path handling

### DIFF
--- a/deepagent_runtime.py
+++ b/deepagent_runtime.py
@@ -1015,13 +1015,32 @@ def _load_skill_command_bucket(
     return tuple(commands_by_name.values())
 
 
+def _resolve_chainlit_project_root(
+    *,
+    backend: CompositeBackend | None,
+    project_root: Path | None,
+) -> Path:
+    if project_root is not None:
+        return project_root
+
+    if backend is not None:
+        workspace_backend = backend.routes.get("/workspace/")
+        if isinstance(workspace_backend, FilesystemBackend):
+            return workspace_backend.cwd
+
+    return PROJECT_ROOT
+
+
 def build_chainlit_command_catalog(
     extensions: ExtensionsConfig,
     *,
     backend: CompositeBackend | None = None,
     project_root: Path | None = None,
 ) -> tuple[tuple[ChainlitCommandConfig, ...], tuple[str, ...]]:
-    resolved_project_root = project_root or PROJECT_ROOT
+    resolved_project_root = _resolve_chainlit_project_root(
+        backend=backend,
+        project_root=project_root,
+    )
     backend = backend or build_deepagent_backend(project_root=resolved_project_root)
     notes: list[str] = []
     merged_commands = list(extensions.chainlit_commands)

--- a/deepagent_runtime.py
+++ b/deepagent_runtime.py
@@ -441,6 +441,22 @@ class SkillCommandMetadata:
         )
 
 
+def virtual_workspace_path_to_local(path_value: str, project_root: Path | None = None) -> str:
+    normalized = path_value.strip().replace("\\", "/")
+    workspace_prefix = "/workspace"
+    if normalized != workspace_prefix and not normalized.startswith(f"{workspace_prefix}/"):
+        return path_value
+
+    root = (project_root or PROJECT_ROOT).resolve()
+    relative = PurePosixPath(normalized.removeprefix(workspace_prefix).lstrip("/"))
+    local_path = (root / Path(*relative.parts)).resolve()
+    try:
+        local_path.relative_to(root)
+    except ValueError:
+        return path_value
+    return str(local_path)
+
+
 @dataclass(frozen=True)
 class ExtensionsConfig:
     config_path: Path | None
@@ -955,6 +971,7 @@ def _load_skill_command_bucket(
     backend: CompositeBackend,
     source_paths: tuple[str, ...],
     source: Literal["agent_skill", "subagent_skill"],
+    project_root: Path | None = None,
     owner: str | None = None,
 ) -> tuple[SkillCommandMetadata, ...]:
     commands_by_name: dict[str, SkillCommandMetadata] = {}
@@ -982,7 +999,7 @@ def _load_skill_command_bucket(
             metadata = SkillCommandMetadata(
                 name=command_name,
                 description=str(skill["description"]).strip(),
-                path=str(skill["path"]).strip(),
+                path=virtual_workspace_path_to_local(str(skill["path"]), project_root),
                 source=source,
                 owner=owner,
             )
@@ -1004,7 +1021,8 @@ def build_chainlit_command_catalog(
     backend: CompositeBackend | None = None,
     project_root: Path | None = None,
 ) -> tuple[tuple[ChainlitCommandConfig, ...], tuple[str, ...]]:
-    backend = backend or build_deepagent_backend(project_root=project_root)
+    resolved_project_root = project_root or PROJECT_ROOT
+    backend = backend or build_deepagent_backend(project_root=resolved_project_root)
     notes: list[str] = []
     merged_commands = list(extensions.chainlit_commands)
     explicit_names = {command.name: command for command in extensions.chainlit_commands}
@@ -1013,6 +1031,7 @@ def build_chainlit_command_catalog(
         backend=backend,
         source_paths=extensions.skills,
         source="agent_skill",
+        project_root=resolved_project_root,
     )
     subagent_commands_by_name: dict[str, SkillCommandMetadata] = {}
     for subagent in extensions.subagents:
@@ -1020,6 +1039,7 @@ def build_chainlit_command_catalog(
             backend=backend,
             source_paths=subagent.skills,
             source="subagent_skill",
+            project_root=resolved_project_root,
             owner=subagent.name,
         ):
             previous = subagent_commands_by_name.pop(metadata.name, None)

--- a/tests/test_deepagent_runtime_rag.py
+++ b/tests/test_deepagent_runtime_rag.py
@@ -23,6 +23,7 @@ from deepagent_runtime import (
     build_deepagent_backend,
     deepagent_artifacts_root,
     deepagent_artifacts_route_prefix,
+    virtual_workspace_path_to_local,
 )
 from rag_runtime import (
     DEFAULT_OLLAMA_EMBEDDING_MODEL,
@@ -104,6 +105,26 @@ def write_skill(
         ),
         encoding="utf-8",
     )
+
+
+def test_virtual_workspace_path_to_local_maps_project_files(tmp_path: Path) -> None:
+    assert virtual_workspace_path_to_local(
+        "/workspace/skills/reviewer/SKILL.md",
+        tmp_path,
+    ) == str(tmp_path / "skills/reviewer/SKILL.md")
+
+
+def test_virtual_workspace_path_to_local_leaves_unknown_paths_unchanged(
+    tmp_path: Path,
+) -> None:
+    assert virtual_workspace_path_to_local(
+        "/memories/skills/reviewer/SKILL.md",
+        tmp_path,
+    ) == "/memories/skills/reviewer/SKILL.md"
+    assert virtual_workspace_path_to_local(
+        "/workspace/../outside/SKILL.md",
+        tmp_path,
+    ) == "/workspace/../outside/SKILL.md"
 
 
 def test_runtime_config_reports_rag_error_for_openai_auto_embeddings(
@@ -552,8 +573,8 @@ def test_build_chainlit_command_catalog_includes_main_and_subagent_skills(
 
     assert [command.name for command in commands] == ["reviewer", "repo-guide"]
     assert commands[0].target == "skill"
-    assert commands[0].value == "/workspace/skills/reviewer/SKILL.md"
-    assert commands[1].value == "/workspace/subskills/repo-guide/SKILL.md"
+    assert commands[0].value == str(tmp_path / "skills/reviewer/SKILL.md")
+    assert commands[1].value == str(tmp_path / "subskills/repo-guide/SKILL.md")
     assert notes == ()
 
 
@@ -628,7 +649,7 @@ def test_build_chainlit_command_catalog_prefers_main_agent_skill_over_subagent_s
     assert len(commands) == 1
     assert commands[0].target == "skill"
     assert commands[0].description == "Main reviewer"
-    assert commands[0].value == "/workspace/skills/reviewer/SKILL.md"
+    assert commands[0].value == str(tmp_path / "skills/reviewer/SKILL.md")
     assert len(notes) == 1
     assert "main agent skill" in notes[0]
 
@@ -661,7 +682,7 @@ def test_build_chainlit_command_catalog_uses_later_skill_source_in_same_bucket(
 
     assert len(commands) == 1
     assert commands[0].description == "Later reviewer"
-    assert commands[0].value == "/workspace/skills-b/reviewer/SKILL.md"
+    assert commands[0].value == str(tmp_path / "skills-b/reviewer/SKILL.md")
     assert notes == ()
 
 

--- a/tests/test_deepagent_runtime_rag.py
+++ b/tests/test_deepagent_runtime_rag.py
@@ -578,6 +578,30 @@ def test_build_chainlit_command_catalog_includes_main_and_subagent_skills(
     assert notes == ()
 
 
+def test_build_chainlit_command_catalog_uses_backend_workspace_root_when_project_root_missing(
+    tmp_path: Path,
+) -> None:
+    write_skill(
+        tmp_path,
+        "skills/reviewer",
+        name="reviewer",
+        description="Review code for bugs.",
+    )
+    extensions = ExtensionsConfig(
+        config_path=None,
+        skills=("/workspace/skills/",),
+    )
+
+    commands, notes = build_chainlit_command_catalog(
+        extensions,
+        backend=build_deepagent_backend(project_root=tmp_path),
+    )
+
+    assert len(commands) == 1
+    assert commands[0].value == str(tmp_path / "skills/reviewer/SKILL.md")
+    assert notes == ()
+
+
 def test_build_chainlit_command_catalog_prefers_explicit_command_over_skill(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

- Convert `/workspace/...` skill paths to absolute local repo paths for generated Chainlit skill commands.
- Keep Deep Agents skill discovery on virtual workspace paths while making slash-command prompts compatible with MCP filesystem path checks.
- Add regression coverage for virtual-to-local path conversion and generated skill command values.

## Root Cause

Generated skill slash commands told the agent to read `/workspace/skills/.../SKILL.md`. That path is valid for the Deep Agents backend, but the MCP filesystem server checks host filesystem paths and rejected `/workspace/...` as outside the allowed repository directory.

## Validation

- `.venv/bin/python -m pytest` passed on this branch: 36 passed, 2 warnings.