### PR TITLE
Add configurable Chainlit starters via deepagent.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,11 @@ commands = [
   { name = "repo-readme", description = "Run an MCP tool directly.", target = "mcp_tool", value = "repo_read_file", mcp_server = "repo", template = "{\"path\":\"README.md\"}" },
   { name = "summarize", description = "Apply a prompt template.", target = "prompt", value = "Summarize the input", template = "Summarize this:\n{input}" }
 ]
+starters = [
+  { label = "Morning routine ideation", message = "Can you help me create a personalized morning routine that improves my productivity?", icon = "/public/idea.svg" },
+  { label = "Explain superconductors", message = "Explain superconductors like I'm five years old.", icon = "/public/learn.svg" },
+  { label = "Python email report script", message = "Write a script to automate sending daily email reports in Python and explain setup.", icon = "/public/terminal.svg", command = "code" },
+]
 ```
 
 `target` modes:
@@ -347,6 +352,7 @@ Notes:
 - Each discovered skill also becomes `/<skill-name>` automatically. For example, a skill with `name: reviewer` is available as `/reviewer`.
 - Skill-backed commands always force the main agent to read the selected `SKILL.md` first and use it for that turn.
 - If a configured `[chainlit].commands` entry and a skill share the same slash name, the configured command wins.
+- `starters` are optional and map directly to Chainlit `Starter` items (`label`, `message`, optional `icon`, optional `command`).
 
 ## Add Async Subagents
 

--- a/README.md
+++ b/README.md
@@ -328,11 +328,12 @@ Example:
 
 ```toml
 [chainlit]
-show_startup_message = true
 # Set false to hide model selection in chat settings and Modes.
 model_mode_enabled = true
 # Set false to disable per-message reasoning overrides from the Modes picker.
 reasoning_mode_enabled = true
+# Set false to hide the startup status/welcome message in the UI.
+show_startup_message = true
 commands = [
   { name = "ask-researcher", description = "Delegate to repo-researcher.", target = "subagent", value = "repo-researcher", template = "{input}" },
   { name = "repo-readme", description = "Run an MCP tool directly.", target = "mcp_tool", value = "repo_read_file", mcp_server = "repo", template = "{\"path\":\"README.md\"}" },

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ The app is wired for:
 - per-response download buttons for Markdown and PDF exports
 - Postgres-backed LangGraph checkpoints and durable `/memories/` when `DATABASE_URL` is set
 - repo files mounted for the agent under `/workspace/`
+- Chainlit Modes support for per-message reasoning selection (`Low`, `Medium`, `High`)
 
 ## Environment
 
@@ -143,6 +144,7 @@ provider = "ollama"
 base_url = "http://127.0.0.1:11434"
 temperature = 0
 name = "gpt-oss:20b"
+models = ["gpt-oss:20b", "gemma4:27b"]
 reasoning_effort = "medium"
 ```
 
@@ -162,6 +164,7 @@ Notes:
 
 - `provider` selects `ChatOllama` or `ChatOpenAI`.
 - Preferred shared fields are `base_url`, `name`, `temperature`, and `reasoning_effort`.
+- `models` is an optional list of model IDs surfaced in Chainlit settings and modes so users can switch models per session or per message.
 - `api_key` is optional and only used for `provider = "openai_compatible"`. When omitted, the runtime sends a placeholder token that local servers like LM Studio accept.
 - Legacy Ollama `endpoint` and `port` are still accepted when `provider = "ollama"` or omitted.
 - `reasoning_effort` sets the default Chainlit reasoning level for new chats. Ollama uses that level directly; OpenAI-compatible servers may ignore it.
@@ -326,6 +329,10 @@ Example:
 ```toml
 [chainlit]
 show_startup_message = true
+# Set false to hide model selection in chat settings and Modes.
+model_mode_enabled = true
+# Set false to disable per-message reasoning overrides from the Modes picker.
+reasoning_mode_enabled = true
 commands = [
   { name = "ask-researcher", description = "Delegate to repo-researcher.", target = "subagent", value = "repo-researcher", template = "{input}" },
   { name = "repo-readme", description = "Run an MCP tool directly.", target = "mcp_tool", value = "repo_read_file", mcp_server = "repo", template = "{\"path\":\"README.md\"}" },
@@ -347,6 +354,8 @@ starters = [
 Notes:
 
 - The `[chainlit]` table for native commands belongs in `deepagent.toml`, alongside `[model]`, `[agent]`, `[mcp]`, `[[subagents]]`, and `[[async_subagents]]`.
+- `[chainlit].model_mode_enabled = false` hides the Model selector in chat settings and the Model mode group, and ignores per-message model overrides from UI modes.
+- `[chainlit].reasoning_mode_enabled = false` hides the Reasoning mode group and ignores per-message reasoning overrides from UI modes.
 - Command `name` is invoked as `/<name>` and must be unique.
 - `template` is optional and may include `{input}`.
 - For `mcp_tool`, user command arguments must be valid JSON, e.g. `/repo-readme {"path":"README.md"}`.

--- a/README.md
+++ b/README.md
@@ -325,6 +325,7 @@ Example:
 
 ```toml
 [chainlit]
+show_startup_message = true
 commands = [
   { name = "ask-researcher", description = "Delegate to repo-researcher.", target = "subagent", value = "repo-researcher", template = "{input}" },
   { name = "repo-readme", description = "Run an MCP tool directly.", target = "mcp_tool", value = "repo_read_file", mcp_server = "repo", template = "{\"path\":\"README.md\"}" },
@@ -353,6 +354,7 @@ Notes:
 - Skill-backed commands always force the main agent to read the selected `SKILL.md` first and use it for that turn.
 - If a configured `[chainlit].commands` entry and a skill share the same slash name, the configured command wins.
 - `starters` are optional and map directly to Chainlit `Starter` items (`label`, `message`, optional `icon`, optional `command`).
+- `show_startup_message` is optional (default `true`); set it to `false` to hide the startup status/welcome wall of text in the Chainlit UI.
 
 ## Add Async Subagents
 

--- a/deepagent.toml
+++ b/deepagent.toml
@@ -72,6 +72,8 @@ skills = ["skills"]
 mcp_servers = ["repo"]
 
 [chainlit]
+# Set false to hide the startup status/welcome message in the UI.
+show_startup_message = true
 commands = [
   { name = "ask-researcher", description = "Delegate to repo-researcher.", target = "subagent", value = "repo-researcher", template = "{input}" },
   { name = "repo-readme", description = "Run an MCP tool directly.", target = "mcp_tool", value = "repo_read_file", mcp_server = "repo", template = "{\"path\":\"README.md\"}" },

--- a/deepagent.toml
+++ b/deepagent.toml
@@ -74,6 +74,10 @@ skills = ["skills"]
 mcp_servers = ["repo"]
 
 [chainlit]
+# Set false to hide model selection in chat settings and Modes.
+model_mode_enabled = true
+# Set false to disable per-message reasoning overrides from the Modes picker.
+reasoning_mode_enabled = true
 # Set false to hide the startup status/welcome message in the UI.
 show_startup_message = true
 commands = [
@@ -82,7 +86,7 @@ commands = [
   { name = "summarize", description = "Apply a prompt template.", target = "prompt", value = "Summarize the input", template = "Summarize this:\n{input}" }
 ]
 starters = [
-  { label = "Morning routine ideation", message = "Can you help me create a personalized morning routine that would help increase my productivity throughout the day?", icon = "/public/idea.svg" },
+  { label = "Morning routine ideation", message = "Can you help me create a personalized morning routine that improves my productivity?", icon = "/public/idea.svg" },
   { label = "Explain superconductors", message = "Explain superconductors like I'm five years old.", icon = "/public/learn.svg" },
-  { label = "Python script for daily email reports", message = "Write a script to automate sending daily email reports in Python, and walk me through how I would set it up.", icon = "/public/terminal.svg", command = "code" }
+  { label = "Python email report script", message = "Write a script to automate sending daily email reports in Python and explain setup.", icon = "/public/terminal.svg", command = "code" }
 ]

--- a/deepagent.toml
+++ b/deepagent.toml
@@ -1,9 +1,11 @@
 [model]
 provider = "ollama"
 base_url = "http://127.0.0.1:11434"
-temperature = 0
+temperature = 0.3
+
 name = "gemma4:26b"
-#name = "gpt-oss:20b"
+#models = ["gpt-oss:20b", "gemma4:26b", "qwen3.6:27b"]
+
 reasoning_effort = "medium"
 
 # For LM Studio or another OpenAI-compatible server, switch to:

--- a/deepagent.toml
+++ b/deepagent.toml
@@ -77,3 +77,8 @@ commands = [
   { name = "repo-readme", description = "Run an MCP tool directly.", target = "mcp_tool", value = "repo_read_file", mcp_server = "repo", template = "{\"path\":\"README.md\"}" },
   { name = "summarize", description = "Apply a prompt template.", target = "prompt", value = "Summarize the input", template = "Summarize this:\n{input}" }
 ]
+starters = [
+  { label = "Morning routine ideation", message = "Can you help me create a personalized morning routine that would help increase my productivity throughout the day?", icon = "/public/idea.svg" },
+  { label = "Explain superconductors", message = "Explain superconductors like I'm five years old.", icon = "/public/learn.svg" },
+  { label = "Python script for daily email reports", message = "Write a script to automate sending daily email reports in Python, and walk me through how I would set it up.", icon = "/public/terminal.svg", command = "code" }
+]

--- a/deepagent.toml.example
+++ b/deepagent.toml.example
@@ -31,6 +31,8 @@ skills = ["skills"]
 mcp_servers = ["repo"]
 
 [chainlit]
+# Set false to hide the startup status/welcome message in the UI.
+show_startup_message = true
 # Native slash commands available from the Chainlit composer.
 commands = [
   { name = "summarize-docs", description = "Summarize repository docs.", target = "prompt", value = "Summarize the repository documentation changes.", template = "Summarize docs for: {input}" },

--- a/deepagent.toml.example
+++ b/deepagent.toml.example
@@ -37,6 +37,11 @@ commands = [
   { name = "ask-researcher", description = "Delegate to repo-researcher subagent.", target = "subagent", value = "repo-researcher", template = "{input}" },
   { name = "repo-readme", description = "Call MCP filesystem read_file on README.md.", target = "mcp_tool", value = "repo_read_file", mcp_server = "repo", template = "{\"path\": \"README.md\"}" },
 ]
+starters = [
+  { label = "Morning routine ideation", message = "Can you help me create a personalized morning routine that improves my productivity?", icon = "/public/idea.svg" },
+  { label = "Explain superconductors", message = "Explain superconductors like I'm five years old.", icon = "/public/learn.svg" },
+  { label = "Python email report script", message = "Write a script to automate sending daily email reports in Python and explain setup.", icon = "/public/terminal.svg", command = "code" },
+]
 
 [rag]
 enabled = true

--- a/deepagent.toml.example
+++ b/deepagent.toml.example
@@ -32,12 +32,12 @@ skills = ["skills"]
 mcp_servers = ["repo"]
 
 [chainlit]
-# Set false to hide the startup status/welcome message in the UI.
-show_startup_message = true
 # Set false to hide model selection in chat settings and Modes.
 model_mode_enabled = true
 # Set false to disable per-message reasoning overrides from the Modes picker.
 reasoning_mode_enabled = true
+# Set false to hide the startup status/welcome message in the UI.
+show_startup_message = true
 # Native slash commands available from the Chainlit composer.
 commands = [
   { name = "summarize-docs", description = "Summarize repository docs.", target = "prompt", value = "Summarize the repository documentation changes.", template = "Summarize docs for: {input}" },

--- a/deepagent.toml.example
+++ b/deepagent.toml.example
@@ -3,6 +3,7 @@ provider = "ollama"
 base_url = "http://127.0.0.1:11434"
 temperature = 0
 name = "gpt-oss:20b"
+models = ["gpt-oss:20b", "gemma4:27b"]
 reasoning_effort = "medium"
 # For LM Studio or another OpenAI-compatible server, switch to:
 # provider = "openai_compatible"
@@ -33,6 +34,10 @@ mcp_servers = ["repo"]
 [chainlit]
 # Set false to hide the startup status/welcome message in the UI.
 show_startup_message = true
+# Set false to hide model selection in chat settings and Modes.
+model_mode_enabled = true
+# Set false to disable per-message reasoning overrides from the Modes picker.
+reasoning_mode_enabled = true
 # Native slash commands available from the Chainlit composer.
 commands = [
   { name = "summarize-docs", description = "Summarize repository docs.", target = "prompt", value = "Summarize the repository documentation changes.", template = "Summarize docs for: {input}" },

--- a/deepagent_runtime.py
+++ b/deepagent_runtime.py
@@ -416,6 +416,14 @@ class ChainlitCommandConfig:
 
 
 @dataclass(frozen=True)
+class ChainlitStarterConfig:
+    label: str
+    message: str
+    icon: str | None = None
+    command: str | None = None
+
+
+@dataclass(frozen=True)
 class SkillCommandMetadata:
     name: str
     description: str
@@ -468,6 +476,7 @@ class ExtensionsConfig:
     subagents: tuple[SubagentConfig, ...] = ()
     async_subagents: tuple[AsyncSubagentConfig, ...] = ()
     chainlit_commands: tuple[ChainlitCommandConfig, ...] = ()
+    chainlit_starters: tuple[ChainlitStarterConfig, ...] = ()
 
     @property
     def enabled(self) -> bool:
@@ -477,6 +486,7 @@ class ExtensionsConfig:
             or self.subagents
             or self.async_subagents
             or self.chainlit_commands
+            or self.chainlit_starters
         )
 
 
@@ -785,6 +795,37 @@ def parse_extensions_config(raw_config: dict[str, Any], config_path: Path) -> Ex
         )
         seen_commands.add(name)
 
+    raw_chainlit_starters = chainlit_section.get("starters", [])
+    if not isinstance(raw_chainlit_starters, list):
+        raise ValueError("The top-level 'chainlit.starters' config must be an array of tables.")
+
+    chainlit_starters: list[ChainlitStarterConfig] = []
+    for index, raw_chainlit_starter in enumerate(raw_chainlit_starters, start=1):
+        if not isinstance(raw_chainlit_starter, dict):
+            raise ValueError(
+                f"Chainlit starter entry #{index} must be a table/object."
+            )
+        label = str(raw_chainlit_starter.get("label", "")).strip()
+        message = str(raw_chainlit_starter.get("message", "")).strip()
+        icon = normalize_optional_string(raw_chainlit_starter.get("icon"))
+        command = normalize_optional_string(raw_chainlit_starter.get("command"))
+        if not label:
+            raise ValueError(
+                f"Chainlit starter entry #{index} must include a non-empty 'label'."
+            )
+        if not message:
+            raise ValueError(
+                f"Chainlit starter '{label}' must include a non-empty 'message'."
+            )
+        chainlit_starters.append(
+            ChainlitStarterConfig(
+                label=label,
+                message=message,
+                icon=icon,
+                command=command,
+            )
+        )
+
     return ExtensionsConfig(
         config_path=config_path,
         mcp_tool_name_prefix=bool(mcp_section.get("tool_name_prefix", True)),
@@ -795,6 +836,7 @@ def parse_extensions_config(raw_config: dict[str, Any], config_path: Path) -> Ex
         subagents=tuple(subagents),
         async_subagents=tuple(async_subagents),
         chainlit_commands=tuple(chainlit_commands),
+        chainlit_starters=tuple(chainlit_starters),
     )
 
 

--- a/deepagent_runtime.py
+++ b/deepagent_runtime.py
@@ -477,6 +477,7 @@ class ExtensionsConfig:
     async_subagents: tuple[AsyncSubagentConfig, ...] = ()
     chainlit_commands: tuple[ChainlitCommandConfig, ...] = ()
     chainlit_starters: tuple[ChainlitStarterConfig, ...] = ()
+    chainlit_show_startup_message: bool = True
 
     @property
     def enabled(self) -> bool:
@@ -825,6 +826,9 @@ def parse_extensions_config(raw_config: dict[str, Any], config_path: Path) -> Ex
                 command=command,
             )
         )
+    raw_chainlit_show_startup_message = chainlit_section.get("show_startup_message", True)
+    if not isinstance(raw_chainlit_show_startup_message, bool):
+        raise ValueError("The top-level 'chainlit.show_startup_message' config must be a boolean.")
 
     return ExtensionsConfig(
         config_path=config_path,
@@ -837,6 +841,7 @@ def parse_extensions_config(raw_config: dict[str, Any], config_path: Path) -> Ex
         async_subagents=tuple(async_subagents),
         chainlit_commands=tuple(chainlit_commands),
         chainlit_starters=tuple(chainlit_starters),
+        chainlit_show_startup_message=raw_chainlit_show_startup_message,
     )
 
 

--- a/deepagent_runtime.py
+++ b/deepagent_runtime.py
@@ -476,10 +476,10 @@ class ExtensionsConfig:
     subagents: tuple[SubagentConfig, ...] = ()
     async_subagents: tuple[AsyncSubagentConfig, ...] = ()
     chainlit_commands: tuple[ChainlitCommandConfig, ...] = ()
-    chainlit_starters: tuple[ChainlitStarterConfig, ...] = ()
-    chainlit_show_startup_message: bool = True
     chainlit_model_mode_enabled: bool = True
     chainlit_reasoning_mode_enabled: bool = True
+    chainlit_show_startup_message: bool = True
+    chainlit_starters: tuple[ChainlitStarterConfig, ...] = ()
 
     @property
     def enabled(self) -> bool:
@@ -863,10 +863,10 @@ def parse_extensions_config(raw_config: dict[str, Any], config_path: Path) -> Ex
         subagents=tuple(subagents),
         async_subagents=tuple(async_subagents),
         chainlit_commands=tuple(chainlit_commands),
-        chainlit_starters=tuple(chainlit_starters),
-        chainlit_show_startup_message=raw_chainlit_show_startup_message,
         chainlit_model_mode_enabled=raw_model_mode_enabled,
         chainlit_reasoning_mode_enabled=raw_reasoning_mode_enabled,
+        chainlit_show_startup_message=raw_chainlit_show_startup_message,
+        chainlit_starters=tuple(chainlit_starters),
     )
 
 

--- a/deepagent_runtime.py
+++ b/deepagent_runtime.py
@@ -478,6 +478,8 @@ class ExtensionsConfig:
     chainlit_commands: tuple[ChainlitCommandConfig, ...] = ()
     chainlit_starters: tuple[ChainlitStarterConfig, ...] = ()
     chainlit_show_startup_message: bool = True
+    chainlit_model_mode_enabled: bool = True
+    chainlit_reasoning_mode_enabled: bool = True
 
     @property
     def enabled(self) -> bool:
@@ -497,6 +499,7 @@ class ModelDefaults:
     base_url: str = DEFAULT_OLLAMA_BASE_URL
     name: str = DEFAULT_MODEL
     api_key: str | None = None
+    models: tuple[str, ...] = ()
     name_is_explicit: bool = False
     reasoning_effort: ReasoningLevel = DEFAULT_REASONING_LEVEL
     temperature: float = DEFAULT_TEMPERATURE
@@ -516,9 +519,18 @@ def parse_model_defaults(raw_config: dict[str, Any]) -> ModelDefaults:
 
     provider = normalize_model_provider(raw_model.get("provider"))
     raw_name = str(raw_model.get("name", "")).strip()
-    if provider == "openai_compatible" and not raw_name:
+    raw_models = raw_model.get("models", [])
+    if raw_models and not isinstance(raw_models, list):
+        raise ValueError("The [model].models config must be an array of strings.")
+    parsed_models: list[str] = []
+    for raw_candidate in raw_models:
+        candidate = str(raw_candidate or "").strip()
+        if candidate and candidate not in parsed_models:
+            parsed_models.append(candidate)
+
+    if provider == "openai_compatible" and not raw_name and not parsed_models:
         raise ValueError(
-            "OpenAI-compatible model config must define a non-empty 'name'."
+            "OpenAI-compatible model config must define a non-empty 'name' or 'models'."
         )
 
     raw_base_url = str(raw_model.get("base_url", "")).strip()
@@ -544,9 +556,10 @@ def parse_model_defaults(raw_config: dict[str, Any]) -> ModelDefaults:
     return ModelDefaults(
         provider=provider,
         base_url=base_url,
-        name=raw_name or DEFAULT_MODEL,
+        name=raw_name or (parsed_models[0] if parsed_models else DEFAULT_MODEL),
         api_key=normalize_optional_string(raw_model.get("api_key")),
-        name_is_explicit=bool(raw_name),
+        models=tuple(parsed_models),
+        name_is_explicit=bool(raw_name or parsed_models),
         reasoning_effort=normalize_reasoning_level(
             raw_model.get("reasoning_effort"),
             default=DEFAULT_REASONING_LEVEL,
@@ -744,6 +757,16 @@ def parse_extensions_config(raw_config: dict[str, Any], config_path: Path) -> Ex
     raw_chainlit_commands = chainlit_section.get("commands", [])
     if not isinstance(raw_chainlit_commands, list):
         raise ValueError("The top-level 'chainlit.commands' config must be an array of tables.")
+    raw_reasoning_mode_enabled = chainlit_section.get("reasoning_mode_enabled", True)
+    raw_model_mode_enabled = chainlit_section.get("model_mode_enabled", True)
+    if not isinstance(raw_reasoning_mode_enabled, bool):
+        raise ValueError(
+            "The top-level 'chainlit.reasoning_mode_enabled' config must be a boolean."
+        )
+    if not isinstance(raw_model_mode_enabled, bool):
+        raise ValueError(
+            "The top-level 'chainlit.model_mode_enabled' config must be a boolean."
+        )
 
     chainlit_commands: list[ChainlitCommandConfig] = []
     seen_commands: set[str] = set()
@@ -842,6 +865,8 @@ def parse_extensions_config(raw_config: dict[str, Any], config_path: Path) -> Ex
         chainlit_commands=tuple(chainlit_commands),
         chainlit_starters=tuple(chainlit_starters),
         chainlit_show_startup_message=raw_chainlit_show_startup_message,
+        chainlit_model_mode_enabled=raw_model_mode_enabled,
+        chainlit_reasoning_mode_enabled=raw_reasoning_mode_enabled,
     )
 
 
@@ -875,6 +900,7 @@ class RuntimeConfig:
     database_url: str | None
     model_provider: ModelProvider
     model_name: str
+    model_choices: tuple[str, ...]
     model_base_url: str
     model_api_key: str | None
     model_temperature: float
@@ -930,6 +956,14 @@ class RuntimeConfig:
             )
 
         model_name = generic_model_name or model_name_alias or model_defaults.name
+        model_choices = tuple(
+            dict.fromkeys(
+                [
+                    model_name,
+                    *model_defaults.models,
+                ]
+            )
+        )
         model_base_url = normalize_model_base_url(
             generic_model_base_url or model_base_url_alias or model_defaults.base_url,
             required_message="The model base URL cannot be empty.",
@@ -959,6 +993,7 @@ class RuntimeConfig:
             database_url=database_url,
             model_provider=model_provider,
             model_name=model_name,
+            model_choices=model_choices,
             model_base_url=model_base_url,
             model_api_key=model_api_key,
             model_temperature=model_defaults.temperature,
@@ -971,17 +1006,23 @@ class RuntimeConfig:
         )
 
 
-def build_model(config: RuntimeConfig, reasoning_level: ReasoningLevel) -> Any:
+def build_model(
+    config: RuntimeConfig,
+    reasoning_level: ReasoningLevel,
+    *,
+    model_name: str | None = None,
+) -> Any:
+    selected_model = str(model_name or config.model_name).strip() or config.model_name
     if config.model_provider == "ollama":
         return ChatOllama(
-            model=config.model_name,
+            model=selected_model,
             base_url=config.model_base_url,
             reasoning=reasoning_level,
             temperature=config.model_temperature,
         )
 
     kwargs: dict[str, Any] = {
-        "model": config.model_name,
+        "model": selected_model,
         "base_url": config.model_base_url,
         "api_key": config.model_api_key or "deepagent",
         "temperature": config.model_temperature,
@@ -1248,6 +1289,7 @@ def create_configured_graph(
 class AppSettings:
     reasoning_level: ReasoningLevel
     thread_id: str
+    model_name: str
 
 
 class AgentRuntime:
@@ -1261,7 +1303,7 @@ class AgentRuntime:
         self._agent_lock = asyncio.Lock()
         self._mcp_lock = asyncio.Lock()
         self._agents: dict[
-            tuple[ReasoningLevel, str | None, str | None, str | None],
+            tuple[ReasoningLevel, str, str | None, str | None, str | None],
             object,
         ] = {}
         self._mcp_client: MultiServerMCPClient | None = None
@@ -1367,16 +1409,19 @@ class AgentRuntime:
         self,
         reasoning_level: ReasoningLevel,
         *,
+        model_name: str | None = None,
         thread_id: str | None = None,
         async_subagent_url_override: str | None = None,
         mcp_session_id: str | None = None,
     ):
+        selected_model = str(model_name or self.config.model_name).strip() or self.config.model_name
         mcp_scope = self._mcp_scope(
             mcp_session_id=mcp_session_id,
             thread_id=thread_id,
         )
         cache_key = (
             reasoning_level,
+            selected_model,
             thread_id,
             async_subagent_url_override,
             mcp_scope,
@@ -1384,7 +1429,10 @@ class AgentRuntime:
         async with self._agent_lock:
             agent = self._agents.get(cache_key)
             if agent is None:
-                model = self._build_model(reasoning_level)
+                model = self._build_model(
+                    reasoning_level,
+                    model_name=selected_model,
+                )
                 rag_tool_enabled = self._rag_service is not None
                 main_tools = sanitize_tools_for_model(
                     self.config.model_provider,
@@ -1535,8 +1583,13 @@ class AgentRuntime:
     def _tool_supports_openai_compatible_schema(tool: Any) -> bool:
         return tool_supports_openai_compatible_schema(tool)
 
-    def _build_model(self, reasoning_level: ReasoningLevel) -> Any:
-        return build_model(self.config, reasoning_level)
+    def _build_model(
+        self,
+        reasoning_level: ReasoningLevel,
+        *,
+        model_name: str | None = None,
+    ) -> Any:
+        return build_model(self.config, reasoning_level, model_name=model_name)
 
     def _mcp_scope(
         self,

--- a/main.py
+++ b/main.py
@@ -16,6 +16,7 @@ from chainlit.types import ThreadDict
 from async_task_notifications import AsyncTaskNotifier, async_subagent_url_override
 from chainlit_bridge import ChainlitEventBridge, RunTaskList
 from deepagent_runtime import (
+    ChainlitStarterConfig,
     DEFAULT_REASONING_LEVEL,
     AgentRuntime,
     AppSettings,
@@ -136,6 +137,20 @@ def build_upload_rag_action() -> cl.Action:
 
 def rag_actions() -> list[cl.Action]:
     return [build_rag_action(), build_upload_rag_action()]
+
+
+def build_chainlit_starters(
+    starter_configs: tuple[ChainlitStarterConfig, ...],
+) -> list[cl.Starter]:
+    return [
+        cl.Starter(
+            label=starter.label,
+            message=starter.message,
+            icon=starter.icon,
+            command=starter.command,
+        )
+        for starter in starter_configs
+    ]
 
 
 def build_native_command_specs(runtime: AgentRuntime) -> list[dict[str, Any]]:
@@ -420,6 +435,14 @@ async def get_runtime_or_notify() -> AgentRuntime | None:
     except Exception as exc:
         await cl.Message(content=f"Startup error: {exc}", author="System").send()
         return None
+
+
+@cl.set_starters
+async def set_starters() -> list[cl.Starter]:
+    runtime = await get_runtime_or_notify()
+    if runtime is None:
+        return []
+    return build_chainlit_starters(runtime.config.extensions.chainlit_starters)
 
 
 async def get_run_task_list() -> RunTaskList:

--- a/main.py
+++ b/main.py
@@ -539,24 +539,25 @@ async def on_chat_start() -> None:
         extensions_line += f"Command notes:\n{note_lines}\n"
     if extensions.config_path is not None:
         extensions_line += f"- Extensions config: `{extensions.config_path.name}`\n"
-    startup_message = cl.Message(
-        content=(
-            "Workspace agent ready.\n\n"
-            f"- Model provider: `{format_model_provider(runtime.config.model_provider)}`\n"
-            f"- Model: `{runtime.config.model_name}`\n"
-            f"- Thread ID: `{settings.thread_id}`\n"
-            f"{persistence_line}"
-            f"{history_line}"
-            f"{rag_status_line(runtime)}"
-            f"{extensions_line}"
-            "- Real repo files live under `/workspace/`\n"
-            "- Agent memory is available under `/memories/`"
-        ),
-        author="System",
-    )
-    if runtime.rag_enabled:
-        startup_message.actions = rag_actions()
-    await startup_message.send()
+    if extensions.chainlit_show_startup_message:
+        startup_message = cl.Message(
+            content=(
+                "Workspace agent ready.\n\n"
+                f"- Model provider: `{format_model_provider(runtime.config.model_provider)}`\n"
+                f"- Model: `{runtime.config.model_name}`\n"
+                f"- Thread ID: `{settings.thread_id}`\n"
+                f"{persistence_line}"
+                f"{history_line}"
+                f"{rag_status_line(runtime)}"
+                f"{extensions_line}"
+                "- Real repo files live under `/workspace/`\n"
+                "- Agent memory is available under `/memories/`"
+            ),
+            author="System",
+        )
+        if runtime.rag_enabled:
+            startup_message.actions = rag_actions()
+        await startup_message.send()
 
 
 @cl.on_chat_resume

--- a/main.py
+++ b/main.py
@@ -106,6 +106,7 @@ def current_mcp_session_id() -> str:
 
 def settings_payload(settings: AppSettings) -> dict[str, str]:
     return {
+        "model_name": settings.model_name,
         "reasoning_level": settings.reasoning_level,
         "thread_id": settings.thread_id,
     }
@@ -369,9 +370,37 @@ async def ask_for_rag_upload() -> list[UploadedRagFile]:
     ]
 
 
-def build_chat_settings(settings: AppSettings) -> cl.ChatSettings:
+def resolve_model_name(
+    value: Any | None,
+    *,
+    available_models: tuple[str, ...],
+    default: str,
+) -> str:
+    candidate = str(value or "").strip()
+    if candidate in available_models:
+        return candidate
+    return default
+
+
+def build_chat_settings(
+    settings: AppSettings,
+    *,
+    available_models: tuple[str, ...],
+    model_mode_enabled: bool = True,
+) -> cl.ChatSettings:
     reasoning_levels = ["low", "medium", "high"]
-    return cl.ChatSettings(
+    inputs: list[Any] = []
+    if model_mode_enabled:
+        inputs.append(
+            Select(
+                id="model_name",
+                label="Model",
+                values=list(available_models),
+                initial_index=available_models.index(settings.model_name),
+                description="Select a configured model for this chat session.",
+            )
+        )
+    inputs.extend(
         [
             Select(
                 id="reasoning_level",
@@ -394,13 +423,116 @@ def build_chat_settings(settings: AppSettings) -> cl.ChatSettings:
             ),
         ]
     )
+    return cl.ChatSettings(inputs)
 
 
-def coerce_settings(raw_settings: AppSettings | dict[str, Any] | None) -> AppSettings:
+def build_modes(
+    settings: AppSettings,
+    *,
+    available_models: tuple[str, ...],
+    model_mode_enabled: bool = True,
+    reasoning_mode_enabled: bool = True,
+) -> list[cl.Mode]:
+    reasoning_levels = ["low", "medium", "high"]
+    modes: list[cl.Mode] = []
+    if model_mode_enabled:
+        modes.append(
+            cl.Mode(
+                id="model_name",
+                name="Model",
+                options=[
+                    cl.ModeOption(
+                        id=model_name,
+                        name=model_name,
+                        description="Use this model for the current message.",
+                        icon="bot",
+                        default=model_name == settings.model_name,
+                    )
+                    for model_name in available_models
+                ],
+            )
+        )
+    if reasoning_mode_enabled:
+        modes.append(
+            cl.Mode(
+                id="reasoning_level",
+                name="Reasoning",
+                options=[
+                    cl.ModeOption(
+                        id=level,
+                        name=level.capitalize(),
+                        description=(
+                            "Deeper reasoning with higher latency"
+                            if level == "high"
+                            else (
+                                "Balanced quality and speed"
+                                if level == "medium"
+                                else "Fastest responses with lighter reasoning"
+                            )
+                        ),
+                        icon=(
+                            "brain"
+                            if level == "high"
+                            else ("sparkles" if level == "medium" else "zap")
+                        ),
+                        default=level == settings.reasoning_level,
+                    )
+                    for level in reasoning_levels
+                ],
+            )
+        )
+    return modes
+
+
+async def publish_modes(
+    settings: AppSettings,
+    *,
+    available_models: tuple[str, ...],
+    model_mode_enabled: bool = True,
+    reasoning_mode_enabled: bool = True,
+) -> None:
+    try:
+        await cl.context.emitter.set_modes(
+            build_modes(
+                settings,
+                available_models=available_models,
+                model_mode_enabled=model_mode_enabled,
+                reasoning_mode_enabled=reasoning_mode_enabled,
+            )
+        )
+    except Exception as exc:
+        message = str(exc).lower()
+        missing_modes_column = "modes" in message and (
+            ("column" in message and "does not exist" in message)
+            or "no such column" in message
+        )
+        if not missing_modes_column:
+            raise
+
+
+def coerce_settings(
+    raw_settings: AppSettings | dict[str, Any] | None,
+    *,
+    default_model_name: str,
+    available_models: tuple[str, ...],
+) -> AppSettings:
     if raw_settings is None:
         raw_settings = {}
     if isinstance(raw_settings, AppSettings):
-        return raw_settings
+        return AppSettings(
+            model_name=resolve_model_name(
+                raw_settings.model_name,
+                available_models=available_models,
+                default=default_model_name,
+            ),
+            reasoning_level=normalize_reasoning_level(raw_settings.reasoning_level),
+            thread_id=raw_settings.thread_id,
+        )
+    model_name = resolve_model_name(
+        raw_settings.get("model_name"),
+        available_models=available_models,
+        default=default_model_name,
+    )
     reasoning_level = normalize_reasoning_level(
         raw_settings.get("reasoning_level", DEFAULT_REASONING_LEVEL)
     )
@@ -409,7 +541,47 @@ def coerce_settings(raw_settings: AppSettings | dict[str, Any] | None) -> AppSet
     ).strip()
     if not thread_id:
         thread_id = current_chainlit_thread_id()
-    return AppSettings(reasoning_level=reasoning_level, thread_id=thread_id.strip())
+    return AppSettings(
+        model_name=model_name,
+        reasoning_level=reasoning_level,
+        thread_id=thread_id.strip(),
+    )
+
+
+def resolve_reasoning_level_for_message(
+    message: cl.Message,
+    settings: AppSettings,
+    *,
+    reasoning_mode_enabled: bool = True,
+) -> str:
+    if not reasoning_mode_enabled:
+        return settings.reasoning_level
+    raw_modes = getattr(message, "modes", None)
+    if not isinstance(raw_modes, dict):
+        return settings.reasoning_level
+    return normalize_reasoning_level(
+        raw_modes.get("reasoning_level"),
+        default=settings.reasoning_level,
+    )
+
+
+def resolve_model_name_for_message(
+    message: cl.Message,
+    settings: AppSettings,
+    *,
+    available_models: tuple[str, ...],
+    model_mode_enabled: bool = True,
+) -> str:
+    if not model_mode_enabled:
+        return settings.model_name
+    raw_modes = getattr(message, "modes", None)
+    if not isinstance(raw_modes, dict):
+        return settings.model_name
+    return resolve_model_name(
+        raw_modes.get("model_name"),
+        available_models=available_models,
+        default=settings.model_name,
+    )
 
 
 if AUTH_ENABLED:
@@ -493,11 +665,22 @@ async def on_chat_start() -> None:
     run_task_list = await get_run_task_list()
     await run_task_list.show_ready()
     settings = AppSettings(
+        model_name=runtime.config.model_name,
         reasoning_level=runtime.config.default_reasoning,
         thread_id=current_chainlit_thread_id(),
     )
     store_settings(settings)
-    await build_chat_settings(settings).send()
+    await publish_modes(
+        settings,
+        available_models=runtime.config.model_choices,
+        model_mode_enabled=runtime.config.extensions.chainlit_model_mode_enabled,
+        reasoning_mode_enabled=runtime.config.extensions.chainlit_reasoning_mode_enabled,
+    )
+    await build_chat_settings(
+        settings,
+        available_models=runtime.config.model_choices,
+        model_mode_enabled=runtime.config.extensions.chainlit_model_mode_enabled,
+    ).send()
     persistence_line = (
         "- Persistence: Postgres-backed LangGraph checkpoints and `/memories/`\n"
         if runtime.persistence_enabled
@@ -575,12 +758,27 @@ async def on_chat_resume(thread: ThreadDict) -> None:
     raw_settings = (
         metadata.get(SESSION_SETTINGS_KEY) if isinstance(metadata, dict) else None
     )
-    settings = coerce_settings(raw_settings)
+    settings = coerce_settings(
+        raw_settings,
+        default_model_name=runtime.config.model_name,
+        available_models=runtime.config.model_choices,
+    )
     store_settings(settings)
-    await build_chat_settings(settings).send()
+    await publish_modes(
+        settings,
+        available_models=runtime.config.model_choices,
+        model_mode_enabled=runtime.config.extensions.chainlit_model_mode_enabled,
+        reasoning_mode_enabled=runtime.config.extensions.chainlit_reasoning_mode_enabled,
+    )
+    await build_chat_settings(
+        settings,
+        available_models=runtime.config.model_choices,
+        model_mode_enabled=runtime.config.extensions.chainlit_model_mode_enabled,
+    ).send()
     async_url_override = async_subagent_url_override()
     agent = await runtime.get_agent(
         settings.reasoning_level,
+        model_name=settings.model_name,
         thread_id=settings.thread_id,
         async_subagent_url_override=async_url_override,
         mcp_session_id=mcp_session_id,
@@ -597,8 +795,21 @@ async def on_chat_resume(thread: ThreadDict) -> None:
 
 @cl.on_settings_update
 async def on_settings_update(raw_settings: dict[str, Any]) -> None:
-    settings = coerce_settings(raw_settings)
+    runtime = await get_runtime_or_notify()
+    if runtime is None:
+        return
+    settings = coerce_settings(
+        raw_settings,
+        default_model_name=runtime.config.model_name,
+        available_models=runtime.config.model_choices,
+    )
     store_settings(settings)
+    await publish_modes(
+        settings,
+        available_models=runtime.config.model_choices,
+        model_mode_enabled=runtime.config.extensions.chainlit_model_mode_enabled,
+        reasoning_mode_enabled=runtime.config.extensions.chainlit_reasoning_mode_enabled,
+    )
 
 
 @cl.action_callback(DOWNLOAD_MARKDOWN_ACTION)
@@ -641,7 +852,11 @@ async def upload_rag_file(action: cl.Action) -> None:
     if runtime is None:
         return
 
-    settings = coerce_settings(cl.user_session.get(SESSION_SETTINGS_KEY))
+    settings = coerce_settings(
+        cl.user_session.get(SESSION_SETTINGS_KEY),
+        default_model_name=runtime.config.model_name,
+        available_models=runtime.config.model_choices,
+    )
     uploads = await ask_for_rag_upload()
     if not uploads:
         await cl.Message(content="No files were uploaded.", author="System").send()
@@ -662,10 +877,25 @@ async def upload_rag_file(action: cl.Action) -> None:
 
 @cl.on_message
 async def on_message(message: cl.Message) -> None:
-    settings = coerce_settings(cl.user_session.get(SESSION_SETTINGS_KEY))
     runtime = await get_runtime_or_notify()
     if runtime is None:
         return
+    settings = coerce_settings(
+        cl.user_session.get(SESSION_SETTINGS_KEY),
+        default_model_name=runtime.config.model_name,
+        available_models=runtime.config.model_choices,
+    )
+    effective_reasoning_level = resolve_reasoning_level_for_message(
+        message,
+        settings,
+        reasoning_mode_enabled=runtime.config.extensions.chainlit_reasoning_mode_enabled,
+    )
+    effective_model_name = resolve_model_name_for_message(
+        message,
+        settings,
+        available_models=runtime.config.model_choices,
+        model_mode_enabled=runtime.config.extensions.chainlit_model_mode_enabled,
+    )
     mcp_session_id = current_mcp_session_id()
     run_task_list = await get_run_task_list()
     uploaded_files = message_uploaded_rag_files(message)
@@ -723,7 +953,8 @@ async def on_message(message: cl.Message) -> None:
 
     async_url_override = async_subagent_url_override()
     agent = await runtime.get_agent(
-        settings.reasoning_level,
+        effective_reasoning_level,
+        model_name=effective_model_name,
         thread_id=settings.thread_id,
         async_subagent_url_override=async_url_override,
         mcp_session_id=mcp_session_id,

--- a/tests/test_deepagent_runtime_rag.py
+++ b/tests/test_deepagent_runtime_rag.py
@@ -542,6 +542,62 @@ starters = [
     assert extensions.chainlit_starters[1].command == "code"
 
 
+def test_load_extensions_config_parses_chainlit_show_startup_message_flag(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    config_path = tmp_path / "deepagent.toml"
+    config_path.write_text(
+        """
+[chainlit]
+show_startup_message = false
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DEEPAGENT_CONFIG", str(config_path))
+
+    extensions = deepagent_runtime.load_extensions_config()
+
+    assert extensions.chainlit_show_startup_message is False
+
+
+def test_load_extensions_config_defaults_chainlit_show_startup_message_to_true(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    config_path = tmp_path / "deepagent.toml"
+    config_path.write_text(
+        """
+[chainlit]
+commands = []
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DEEPAGENT_CONFIG", str(config_path))
+
+    extensions = deepagent_runtime.load_extensions_config()
+
+    assert extensions.chainlit_show_startup_message is True
+
+
+def test_load_extensions_config_rejects_non_boolean_chainlit_show_startup_message(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    config_path = tmp_path / "deepagent.toml"
+    config_path.write_text(
+        """
+[chainlit]
+show_startup_message = "sometimes"
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DEEPAGENT_CONFIG", str(config_path))
+
+    with pytest.raises(ValueError, match="chainlit.show_startup_message"):
+        deepagent_runtime.load_extensions_config()
+
+
 def test_load_extensions_config_rejects_invalid_chainlit_starter(
     tmp_path: Path,
     monkeypatch,

--- a/tests/test_deepagent_runtime_rag.py
+++ b/tests/test_deepagent_runtime_rag.py
@@ -517,6 +517,51 @@ commands = [
     assert extensions.chainlit_commands[2].template == "Rewrite: {input}"
 
 
+def test_load_extensions_config_parses_chainlit_starters(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    config_path = tmp_path / "deepagent.toml"
+    config_path.write_text(
+        """
+[chainlit]
+starters = [
+  { label = "Explain superconductors", message = "Explain superconductors like I'm five years old.", icon = "/public/learn.svg" },
+  { label = "Write script", message = "Write a Python script for daily email reports.", command = "code" }
+]
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DEEPAGENT_CONFIG", str(config_path))
+
+    extensions = deepagent_runtime.load_extensions_config()
+
+    assert len(extensions.chainlit_starters) == 2
+    assert extensions.chainlit_starters[0].label == "Explain superconductors"
+    assert extensions.chainlit_starters[0].icon == "/public/learn.svg"
+    assert extensions.chainlit_starters[1].command == "code"
+
+
+def test_load_extensions_config_rejects_invalid_chainlit_starter(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    config_path = tmp_path / "deepagent.toml"
+    config_path.write_text(
+        """
+[chainlit]
+starters = [
+  { label = "", message = "hello" }
+]
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DEEPAGENT_CONFIG", str(config_path))
+
+    with pytest.raises(ValueError, match="non-empty 'label'"):
+        deepagent_runtime.load_extensions_config()
+
+
 def test_load_extensions_config_rejects_unknown_chainlit_subagent(
     tmp_path: Path,
     monkeypatch,

--- a/tests/test_deepagent_runtime_rag.py
+++ b/tests/test_deepagent_runtime_rag.py
@@ -61,6 +61,7 @@ def make_runtime_config(
         database_url=None,
         model_provider="ollama",
         model_name="gpt-oss:20b",
+        model_choices=("gpt-oss:20b",),
         model_base_url="http://127.0.0.1:11434",
         model_api_key=None,
         model_temperature=0.0,
@@ -182,6 +183,29 @@ mcp_servers = ["repo"]
     config = deepagent_runtime.load_extensions_config()
 
     assert config.mcp_stateful is True
+
+
+def test_runtime_config_reads_model_choices_from_toml(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    config_path = tmp_path / "deepagent.toml"
+    config_path.write_text(
+        """
+[model]
+provider = "ollama"
+base_url = "http://127.0.0.1:11434"
+name = "gpt-oss:20b"
+models = ["gpt-oss:20b", "gemma4:27b"]
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DEEPAGENT_CONFIG", str(config_path))
+
+    config = deepagent_runtime.RuntimeConfig.from_env()
+
+    assert config.model_name == "gpt-oss:20b"
+    assert config.model_choices == ("gpt-oss:20b", "gemma4:27b")
 
 
 def test_build_deepagent_backend_stores_large_tool_results_inside_project(
@@ -499,6 +523,8 @@ description = "Researches the repo"
 system_prompt = "Do research"
 
 [chainlit]
+model_mode_enabled = false
+reasoning_mode_enabled = false
 commands = [
   { name = "ask-researcher", description = "Delegate to subagent", target = "subagent", value = "repo-researcher" },
   { name = "run-tool", description = "Call MCP tool", target = "mcp_tool", value = "repo_read_file", mcp_server = "repo" },
@@ -515,6 +541,44 @@ commands = [
     assert extensions.chainlit_commands[0].name == "ask-researcher"
     assert extensions.chainlit_commands[1].target == "mcp_tool"
     assert extensions.chainlit_commands[2].template == "Rewrite: {input}"
+    assert extensions.chainlit_model_mode_enabled is False
+    assert extensions.chainlit_reasoning_mode_enabled is False
+
+
+def test_load_extensions_config_rejects_non_boolean_reasoning_mode_flag(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    config_path = tmp_path / "deepagent.toml"
+    config_path.write_text(
+        """
+[chainlit]
+reasoning_mode_enabled = "no"
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DEEPAGENT_CONFIG", str(config_path))
+
+    with pytest.raises(ValueError, match="reasoning_mode_enabled"):
+        deepagent_runtime.load_extensions_config()
+
+
+def test_load_extensions_config_rejects_non_boolean_model_mode_flag(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    config_path = tmp_path / "deepagent.toml"
+    config_path.write_text(
+        """
+[chainlit]
+model_mode_enabled = "no"
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DEEPAGENT_CONFIG", str(config_path))
+
+    with pytest.raises(ValueError, match="model_mode_enabled"):
+        deepagent_runtime.load_extensions_config()
 
 
 def test_load_extensions_config_parses_chainlit_starters(

--- a/tests/test_main_native_commands.py
+++ b/tests/test_main_native_commands.py
@@ -39,6 +39,115 @@ def test_resolve_native_command_returns_none_without_command() -> None:
     assert parsed is None
 
 
+def test_resolve_reasoning_level_for_message_defaults_to_settings() -> None:
+    message = SimpleNamespace(content="hello")
+    settings = SimpleNamespace(reasoning_level="medium")
+
+    resolved = main.resolve_reasoning_level_for_message(message, settings)
+
+    assert resolved == "medium"
+
+
+def test_resolve_reasoning_level_for_message_uses_mode_override() -> None:
+    message = SimpleNamespace(content="hello", modes={"reasoning_level": "high"})
+    settings = SimpleNamespace(reasoning_level="medium")
+
+    resolved = main.resolve_reasoning_level_for_message(message, settings)
+
+    assert resolved == "high"
+
+
+def test_resolve_reasoning_level_for_message_falls_back_to_settings_default() -> None:
+    message = SimpleNamespace(content="hello", modes={})
+    settings = SimpleNamespace(reasoning_level="low")
+
+    resolved = main.resolve_reasoning_level_for_message(message, settings)
+
+    assert resolved == "low"
+
+
+def test_resolve_reasoning_level_for_message_ignores_override_when_disabled() -> None:
+    message = SimpleNamespace(content="hello", modes={"reasoning_level": "high"})
+    settings = SimpleNamespace(reasoning_level="low")
+
+    resolved = main.resolve_reasoning_level_for_message(
+        message,
+        settings,
+        reasoning_mode_enabled=False,
+    )
+
+    assert resolved == "low"
+
+
+def test_resolve_model_name_for_message_uses_mode_override() -> None:
+    message = SimpleNamespace(content="hello", modes={"model_name": "gemma4:27b"})
+    settings = SimpleNamespace(model_name="gpt-oss:20b")
+
+    resolved = main.resolve_model_name_for_message(
+        message,
+        settings,
+        available_models=("gpt-oss:20b", "gemma4:27b"),
+    )
+
+    assert resolved == "gemma4:27b"
+
+
+def test_resolve_model_name_for_message_falls_back_to_settings() -> None:
+    message = SimpleNamespace(content="hello", modes={"model_name": "unknown"})
+    settings = SimpleNamespace(model_name="gpt-oss:20b")
+
+    resolved = main.resolve_model_name_for_message(
+        message,
+        settings,
+        available_models=("gpt-oss:20b", "gemma4:27b"),
+    )
+
+    assert resolved == "gpt-oss:20b"
+
+
+def test_resolve_model_name_for_message_ignores_override_when_disabled() -> None:
+    message = SimpleNamespace(content="hello", modes={"model_name": "gemma4:27b"})
+    settings = SimpleNamespace(model_name="gpt-oss:20b")
+
+    resolved = main.resolve_model_name_for_message(
+        message,
+        settings,
+        available_models=("gpt-oss:20b", "gemma4:27b"),
+        model_mode_enabled=False,
+    )
+
+    assert resolved == "gpt-oss:20b"
+
+
+@pytest.mark.anyio
+async def test_publish_modes_ignores_missing_modes_column_error(monkeypatch) -> None:
+    class _Emitter:
+        async def set_modes(self, _modes):
+            raise RuntimeError('column "modes" does not exist')
+
+    monkeypatch.setattr(main.cl, "context", SimpleNamespace(emitter=_Emitter()))
+
+    await main.publish_modes(
+        SimpleNamespace(model_name="gpt-oss:20b", reasoning_level="medium"),
+        available_models=("gpt-oss:20b",),
+    )
+
+
+@pytest.mark.anyio
+async def test_publish_modes_raises_for_unrelated_errors(monkeypatch) -> None:
+    class _Emitter:
+        async def set_modes(self, _modes):
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr(main.cl, "context", SimpleNamespace(emitter=_Emitter()))
+
+    with pytest.raises(RuntimeError, match="boom"):
+        await main.publish_modes(
+            SimpleNamespace(model_name="gpt-oss:20b", reasoning_level="medium"),
+            available_models=("gpt-oss:20b",),
+        )
+
+
 class _DummyRuntime:
     def __init__(self, command=None) -> None:
         self.invocation: dict[str, str | None] | None = None


### PR DESCRIPTION
### Motivation

- Provide support for configurable Chainlit Starters so users can define `Starter` items in the same `deepagent.toml` config used for other Chainlit extensions. 
- Allow project authors to expose common prompts/messages in the UI without modifying `main.py` or Chainlit UI files.

### Description

- Introduce `ChainlitStarterConfig` and add `chainlit_starters` to `ExtensionsConfig` to represent configured starters. 
- Parse and validate a new `[chainlit].starters` array in `deepagent_runtime.parse_extensions_config`, requiring `label` and `message` and accepting optional `icon` and `command`. 
- Wire starters into Chainlit by adding `build_chainlit_starters` and an `@cl.set_starters` handler in `main.py` that returns `cl.Starter` objects from runtime config. 
- Update docs and examples (`README.md`, `deepagent.toml`, `deepagent.toml.example`) and add unit tests for parsing and validation (`tests/test_deepagent_runtime_rag.py`).

### Testing

- Compiled the modified modules with `python -m compileall main.py deepagent_runtime.py` and compilation succeeded. 
- Ran the new/targeted pytest selection `pytest -q tests/test_deepagent_runtime_rag.py -k "chainlit_starters or parses_chainlit_commands or rejects_invalid_chainlit_starter"`, which failed in this environment due to missing external dependency (`langchain`) rather than the changes themselves. 
- Added unit tests to cover valid parsing of `starters` and rejection of invalid starter entries (tests added to `tests/test_deepagent_runtime_rag.py`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eabd4bf4188324912b2f106e6ee624)