### PR TITLE
Add configurable Chainlit modes for per-message reasoning

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ provider = "ollama"
 base_url = "http://127.0.0.1:11434"
 temperature = 0
 name = "gpt-oss:20b"
+models = ["gpt-oss:20b", "gemma4:27b"]
 reasoning_effort = "medium"
 ```
 
@@ -163,6 +164,7 @@ Notes:
 
 - `provider` selects `ChatOllama` or `ChatOpenAI`.
 - Preferred shared fields are `base_url`, `name`, `temperature`, and `reasoning_effort`.
+- `models` is an optional list of model IDs surfaced in Chainlit settings and modes so users can switch models per session or per message.
 - `api_key` is optional and only used for `provider = "openai_compatible"`. When omitted, the runtime sends a placeholder token that local servers like LM Studio accept.
 - Legacy Ollama `endpoint` and `port` are still accepted when `provider = "ollama"` or omitted.
 - `reasoning_effort` sets the default Chainlit reasoning level for new chats. Ollama uses that level directly; OpenAI-compatible servers may ignore it.

--- a/README.md
+++ b/README.md
@@ -328,6 +328,8 @@ Example:
 
 ```toml
 [chainlit]
+# Set false to disable per-message reasoning overrides from the Modes picker.
+reasoning_mode_enabled = true
 commands = [
   { name = "ask-researcher", description = "Delegate to repo-researcher.", target = "subagent", value = "repo-researcher", template = "{input}" },
   { name = "repo-readme", description = "Run an MCP tool directly.", target = "mcp_tool", value = "repo_read_file", mcp_server = "repo", template = "{\"path\":\"README.md\"}" },
@@ -344,6 +346,7 @@ commands = [
 Notes:
 
 - The `[chainlit]` table for native commands belongs in `deepagent.toml`, alongside `[model]`, `[agent]`, `[mcp]`, `[[subagents]]`, and `[[async_subagents]]`.
+- `[chainlit].reasoning_mode_enabled = false` hides the Reasoning mode group and ignores per-message reasoning overrides from UI modes.
 - Command `name` is invoked as `/<name>` and must be unique.
 - `template` is optional and may include `{input}`.
 - For `mcp_tool`, user command arguments must be valid JSON, e.g. `/repo-readme {"path":"README.md"}`.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ The app is wired for:
 - per-response download buttons for Markdown and PDF exports
 - Postgres-backed LangGraph checkpoints and durable `/memories/` when `DATABASE_URL` is set
 - repo files mounted for the agent under `/workspace/`
+- Chainlit Modes support for per-message reasoning selection (`Low`, `Medium`, `High`)
 
 ## Environment
 

--- a/README.md
+++ b/README.md
@@ -328,6 +328,8 @@ Example:
 
 ```toml
 [chainlit]
+# Set false to hide model selection in chat settings and Modes.
+model_mode_enabled = true
 # Set false to disable per-message reasoning overrides from the Modes picker.
 reasoning_mode_enabled = true
 commands = [
@@ -346,6 +348,7 @@ commands = [
 Notes:
 
 - The `[chainlit]` table for native commands belongs in `deepagent.toml`, alongside `[model]`, `[agent]`, `[mcp]`, `[[subagents]]`, and `[[async_subagents]]`.
+- `[chainlit].model_mode_enabled = false` hides the Model selector in chat settings and the Model mode group, and ignores per-message model overrides from UI modes.
 - `[chainlit].reasoning_mode_enabled = false` hides the Reasoning mode group and ignores per-message reasoning overrides from UI modes.
 - Command `name` is invoked as `/<name>` and must be unique.
 - `template` is optional and may include `{input}`.

--- a/deepagent.toml
+++ b/deepagent.toml
@@ -1,9 +1,11 @@
 [model]
 provider = "ollama"
 base_url = "http://127.0.0.1:11434"
-temperature = 0
+temperature = 0.3
+
 name = "gemma4:26b"
-#name = "gpt-oss:20b"
+#models = ["gpt-oss:20b", "gemma4:26b", "qwen3.6:27b"]
+
 reasoning_effort = "medium"
 
 # For LM Studio or another OpenAI-compatible server, switch to:

--- a/deepagent.toml.example
+++ b/deepagent.toml.example
@@ -32,6 +32,8 @@ skills = ["skills"]
 mcp_servers = ["repo"]
 
 [chainlit]
+# Set false to disable per-message reasoning overrides from the Modes picker.
+reasoning_mode_enabled = true
 # Native slash commands available from the Chainlit composer.
 commands = [
   { name = "summarize-docs", description = "Summarize repository docs.", target = "prompt", value = "Summarize the repository documentation changes.", template = "Summarize docs for: {input}" },

--- a/deepagent.toml.example
+++ b/deepagent.toml.example
@@ -3,6 +3,7 @@ provider = "ollama"
 base_url = "http://127.0.0.1:11434"
 temperature = 0
 name = "gpt-oss:20b"
+models = ["gpt-oss:20b", "gemma4:27b"]
 reasoning_effort = "medium"
 # For LM Studio or another OpenAI-compatible server, switch to:
 # provider = "openai_compatible"

--- a/deepagent.toml.example
+++ b/deepagent.toml.example
@@ -32,6 +32,8 @@ skills = ["skills"]
 mcp_servers = ["repo"]
 
 [chainlit]
+# Set false to hide model selection in chat settings and Modes.
+model_mode_enabled = true
 # Set false to disable per-message reasoning overrides from the Modes picker.
 reasoning_mode_enabled = true
 # Native slash commands available from the Chainlit composer.

--- a/deepagent_runtime.py
+++ b/deepagent_runtime.py
@@ -468,6 +468,7 @@ class ExtensionsConfig:
     subagents: tuple[SubagentConfig, ...] = ()
     async_subagents: tuple[AsyncSubagentConfig, ...] = ()
     chainlit_commands: tuple[ChainlitCommandConfig, ...] = ()
+    chainlit_reasoning_mode_enabled: bool = True
 
     @property
     def enabled(self) -> bool:
@@ -744,6 +745,11 @@ def parse_extensions_config(raw_config: dict[str, Any], config_path: Path) -> Ex
     raw_chainlit_commands = chainlit_section.get("commands", [])
     if not isinstance(raw_chainlit_commands, list):
         raise ValueError("The top-level 'chainlit.commands' config must be an array of tables.")
+    raw_reasoning_mode_enabled = chainlit_section.get("reasoning_mode_enabled", True)
+    if not isinstance(raw_reasoning_mode_enabled, bool):
+        raise ValueError(
+            "The top-level 'chainlit.reasoning_mode_enabled' config must be a boolean."
+        )
 
     chainlit_commands: list[ChainlitCommandConfig] = []
     seen_commands: set[str] = set()
@@ -806,6 +812,7 @@ def parse_extensions_config(raw_config: dict[str, Any], config_path: Path) -> Ex
         subagents=tuple(subagents),
         async_subagents=tuple(async_subagents),
         chainlit_commands=tuple(chainlit_commands),
+        chainlit_reasoning_mode_enabled=raw_reasoning_mode_enabled,
     )
 
 

--- a/deepagent_runtime.py
+++ b/deepagent_runtime.py
@@ -468,6 +468,7 @@ class ExtensionsConfig:
     subagents: tuple[SubagentConfig, ...] = ()
     async_subagents: tuple[AsyncSubagentConfig, ...] = ()
     chainlit_commands: tuple[ChainlitCommandConfig, ...] = ()
+    chainlit_model_mode_enabled: bool = True
     chainlit_reasoning_mode_enabled: bool = True
 
     @property
@@ -746,9 +747,14 @@ def parse_extensions_config(raw_config: dict[str, Any], config_path: Path) -> Ex
     if not isinstance(raw_chainlit_commands, list):
         raise ValueError("The top-level 'chainlit.commands' config must be an array of tables.")
     raw_reasoning_mode_enabled = chainlit_section.get("reasoning_mode_enabled", True)
+    raw_model_mode_enabled = chainlit_section.get("model_mode_enabled", True)
     if not isinstance(raw_reasoning_mode_enabled, bool):
         raise ValueError(
             "The top-level 'chainlit.reasoning_mode_enabled' config must be a boolean."
+        )
+    if not isinstance(raw_model_mode_enabled, bool):
+        raise ValueError(
+            "The top-level 'chainlit.model_mode_enabled' config must be a boolean."
         )
 
     chainlit_commands: list[ChainlitCommandConfig] = []
@@ -812,6 +818,7 @@ def parse_extensions_config(raw_config: dict[str, Any], config_path: Path) -> Ex
         subagents=tuple(subagents),
         async_subagents=tuple(async_subagents),
         chainlit_commands=tuple(chainlit_commands),
+        chainlit_model_mode_enabled=raw_model_mode_enabled,
         chainlit_reasoning_mode_enabled=raw_reasoning_mode_enabled,
     )
 

--- a/deepagent_runtime.py
+++ b/deepagent_runtime.py
@@ -486,6 +486,7 @@ class ModelDefaults:
     base_url: str = DEFAULT_OLLAMA_BASE_URL
     name: str = DEFAULT_MODEL
     api_key: str | None = None
+    models: tuple[str, ...] = ()
     name_is_explicit: bool = False
     reasoning_effort: ReasoningLevel = DEFAULT_REASONING_LEVEL
     temperature: float = DEFAULT_TEMPERATURE
@@ -505,9 +506,18 @@ def parse_model_defaults(raw_config: dict[str, Any]) -> ModelDefaults:
 
     provider = normalize_model_provider(raw_model.get("provider"))
     raw_name = str(raw_model.get("name", "")).strip()
-    if provider == "openai_compatible" and not raw_name:
+    raw_models = raw_model.get("models", [])
+    if raw_models and not isinstance(raw_models, list):
+        raise ValueError("The [model].models config must be an array of strings.")
+    parsed_models: list[str] = []
+    for raw_candidate in raw_models:
+        candidate = str(raw_candidate or "").strip()
+        if candidate and candidate not in parsed_models:
+            parsed_models.append(candidate)
+
+    if provider == "openai_compatible" and not raw_name and not parsed_models:
         raise ValueError(
-            "OpenAI-compatible model config must define a non-empty 'name'."
+            "OpenAI-compatible model config must define a non-empty 'name' or 'models'."
         )
 
     raw_base_url = str(raw_model.get("base_url", "")).strip()
@@ -533,9 +543,10 @@ def parse_model_defaults(raw_config: dict[str, Any]) -> ModelDefaults:
     return ModelDefaults(
         provider=provider,
         base_url=base_url,
-        name=raw_name or DEFAULT_MODEL,
+        name=raw_name or (parsed_models[0] if parsed_models else DEFAULT_MODEL),
         api_key=normalize_optional_string(raw_model.get("api_key")),
-        name_is_explicit=bool(raw_name),
+        models=tuple(parsed_models),
+        name_is_explicit=bool(raw_name or parsed_models),
         reasoning_effort=normalize_reasoning_level(
             raw_model.get("reasoning_effort"),
             default=DEFAULT_REASONING_LEVEL,
@@ -828,6 +839,7 @@ class RuntimeConfig:
     database_url: str | None
     model_provider: ModelProvider
     model_name: str
+    model_choices: tuple[str, ...]
     model_base_url: str
     model_api_key: str | None
     model_temperature: float
@@ -883,6 +895,14 @@ class RuntimeConfig:
             )
 
         model_name = generic_model_name or model_name_alias or model_defaults.name
+        model_choices = tuple(
+            dict.fromkeys(
+                [
+                    model_name,
+                    *model_defaults.models,
+                ]
+            )
+        )
         model_base_url = normalize_model_base_url(
             generic_model_base_url or model_base_url_alias or model_defaults.base_url,
             required_message="The model base URL cannot be empty.",
@@ -912,6 +932,7 @@ class RuntimeConfig:
             database_url=database_url,
             model_provider=model_provider,
             model_name=model_name,
+            model_choices=model_choices,
             model_base_url=model_base_url,
             model_api_key=model_api_key,
             model_temperature=model_defaults.temperature,
@@ -924,17 +945,23 @@ class RuntimeConfig:
         )
 
 
-def build_model(config: RuntimeConfig, reasoning_level: ReasoningLevel) -> Any:
+def build_model(
+    config: RuntimeConfig,
+    reasoning_level: ReasoningLevel,
+    *,
+    model_name: str | None = None,
+) -> Any:
+    selected_model = str(model_name or config.model_name).strip() or config.model_name
     if config.model_provider == "ollama":
         return ChatOllama(
-            model=config.model_name,
+            model=selected_model,
             base_url=config.model_base_url,
             reasoning=reasoning_level,
             temperature=config.model_temperature,
         )
 
     kwargs: dict[str, Any] = {
-        "model": config.model_name,
+        "model": selected_model,
         "base_url": config.model_base_url,
         "api_key": config.model_api_key or "deepagent",
         "temperature": config.model_temperature,
@@ -1201,6 +1228,7 @@ def create_configured_graph(
 class AppSettings:
     reasoning_level: ReasoningLevel
     thread_id: str
+    model_name: str
 
 
 class AgentRuntime:
@@ -1214,7 +1242,7 @@ class AgentRuntime:
         self._agent_lock = asyncio.Lock()
         self._mcp_lock = asyncio.Lock()
         self._agents: dict[
-            tuple[ReasoningLevel, str | None, str | None, str | None],
+            tuple[ReasoningLevel, str, str | None, str | None, str | None],
             object,
         ] = {}
         self._mcp_client: MultiServerMCPClient | None = None
@@ -1320,16 +1348,19 @@ class AgentRuntime:
         self,
         reasoning_level: ReasoningLevel,
         *,
+        model_name: str | None = None,
         thread_id: str | None = None,
         async_subagent_url_override: str | None = None,
         mcp_session_id: str | None = None,
     ):
+        selected_model = str(model_name or self.config.model_name).strip() or self.config.model_name
         mcp_scope = self._mcp_scope(
             mcp_session_id=mcp_session_id,
             thread_id=thread_id,
         )
         cache_key = (
             reasoning_level,
+            selected_model,
             thread_id,
             async_subagent_url_override,
             mcp_scope,
@@ -1337,7 +1368,10 @@ class AgentRuntime:
         async with self._agent_lock:
             agent = self._agents.get(cache_key)
             if agent is None:
-                model = self._build_model(reasoning_level)
+                model = self._build_model(
+                    reasoning_level,
+                    model_name=selected_model,
+                )
                 rag_tool_enabled = self._rag_service is not None
                 main_tools = sanitize_tools_for_model(
                     self.config.model_provider,
@@ -1488,8 +1522,13 @@ class AgentRuntime:
     def _tool_supports_openai_compatible_schema(tool: Any) -> bool:
         return tool_supports_openai_compatible_schema(tool)
 
-    def _build_model(self, reasoning_level: ReasoningLevel) -> Any:
-        return build_model(self.config, reasoning_level)
+    def _build_model(
+        self,
+        reasoning_level: ReasoningLevel,
+        *,
+        model_name: str | None = None,
+    ) -> Any:
+        return build_model(self.config, reasoning_level, model_name=model_name)
 
     def _mcp_scope(
         self,

--- a/main.py
+++ b/main.py
@@ -409,9 +409,10 @@ def build_modes(
     settings: AppSettings,
     *,
     available_models: tuple[str, ...],
+    reasoning_mode_enabled: bool = True,
 ) -> list[cl.Mode]:
     reasoning_levels = ["low", "medium", "high"]
-    return [
+    modes = [
         cl.Mode(
             id="model_name",
             name="Model",
@@ -426,42 +427,51 @@ def build_modes(
                 for model_name in available_models
             ],
         ),
-        cl.Mode(
-            id="reasoning_level",
-            name="Reasoning",
-            options=[
-                cl.ModeOption(
-                    id=level,
-                    name=level.capitalize(),
-                    description=(
-                        "Deeper reasoning with higher latency"
-                        if level == "high"
-                        else (
-                            "Balanced quality and speed"
-                            if level == "medium"
-                            else "Fastest responses with lighter reasoning"
-                        )
-                    ),
-                    icon=(
-                        "brain"
-                        if level == "high"
-                        else ("sparkles" if level == "medium" else "zap")
-                    ),
-                    default=level == settings.reasoning_level,
-                )
-                for level in reasoning_levels
-            ],
-        ),
     ]
+    if reasoning_mode_enabled:
+        modes.append(
+            cl.Mode(
+                id="reasoning_level",
+                name="Reasoning",
+                options=[
+                    cl.ModeOption(
+                        id=level,
+                        name=level.capitalize(),
+                        description=(
+                            "Deeper reasoning with higher latency"
+                            if level == "high"
+                            else (
+                                "Balanced quality and speed"
+                                if level == "medium"
+                                else "Fastest responses with lighter reasoning"
+                            )
+                        ),
+                        icon=(
+                            "brain"
+                            if level == "high"
+                            else ("sparkles" if level == "medium" else "zap")
+                        ),
+                        default=level == settings.reasoning_level,
+                    )
+                    for level in reasoning_levels
+                ],
+            )
+        )
+    return modes
 
 
 async def publish_modes(
     settings: AppSettings,
     *,
     available_models: tuple[str, ...],
+    reasoning_mode_enabled: bool = True,
 ) -> None:
     await cl.context.emitter.set_modes(
-        build_modes(settings, available_models=available_models)
+        build_modes(
+            settings,
+            available_models=available_models,
+            reasoning_mode_enabled=reasoning_mode_enabled,
+        )
     )
 
 
@@ -506,7 +516,11 @@ def coerce_settings(
 def resolve_reasoning_level_for_message(
     message: cl.Message,
     settings: AppSettings,
+    *,
+    reasoning_mode_enabled: bool = True,
 ) -> str:
+    if not reasoning_mode_enabled:
+        return settings.reasoning_level
     raw_modes = getattr(message, "modes", None)
     if not isinstance(raw_modes, dict):
         return settings.reasoning_level
@@ -610,7 +624,11 @@ async def on_chat_start() -> None:
         thread_id=current_chainlit_thread_id(),
     )
     store_settings(settings)
-    await publish_modes(settings, available_models=runtime.config.model_choices)
+    await publish_modes(
+        settings,
+        available_models=runtime.config.model_choices,
+        reasoning_mode_enabled=runtime.config.extensions.chainlit_reasoning_mode_enabled,
+    )
     await build_chat_settings(
         settings,
         available_models=runtime.config.model_choices,
@@ -697,7 +715,11 @@ async def on_chat_resume(thread: ThreadDict) -> None:
         available_models=runtime.config.model_choices,
     )
     store_settings(settings)
-    await publish_modes(settings, available_models=runtime.config.model_choices)
+    await publish_modes(
+        settings,
+        available_models=runtime.config.model_choices,
+        reasoning_mode_enabled=runtime.config.extensions.chainlit_reasoning_mode_enabled,
+    )
     await build_chat_settings(
         settings,
         available_models=runtime.config.model_choices,
@@ -731,7 +753,11 @@ async def on_settings_update(raw_settings: dict[str, Any]) -> None:
         available_models=runtime.config.model_choices,
     )
     store_settings(settings)
-    await publish_modes(settings, available_models=runtime.config.model_choices)
+    await publish_modes(
+        settings,
+        available_models=runtime.config.model_choices,
+        reasoning_mode_enabled=runtime.config.extensions.chainlit_reasoning_mode_enabled,
+    )
 
 
 @cl.action_callback(DOWNLOAD_MARKDOWN_ACTION)
@@ -807,7 +833,11 @@ async def on_message(message: cl.Message) -> None:
         default_model_name=runtime.config.model_name,
         available_models=runtime.config.model_choices,
     )
-    effective_reasoning_level = resolve_reasoning_level_for_message(message, settings)
+    effective_reasoning_level = resolve_reasoning_level_for_message(
+        message,
+        settings,
+        reasoning_mode_enabled=runtime.config.extensions.chainlit_reasoning_mode_enabled,
+    )
     effective_model_name = resolve_model_name_for_message(
         message,
         settings,

--- a/main.py
+++ b/main.py
@@ -381,6 +381,42 @@ def build_chat_settings(settings: AppSettings) -> cl.ChatSettings:
     )
 
 
+def build_modes(settings: AppSettings) -> list[cl.Mode]:
+    reasoning_levels = ["low", "medium", "high"]
+    return [
+        cl.Mode(
+            id="reasoning_level",
+            name="Reasoning",
+            options=[
+                cl.ModeOption(
+                    id=level,
+                    name=level.capitalize(),
+                    description=(
+                        "Deeper reasoning with higher latency"
+                        if level == "high"
+                        else (
+                            "Balanced quality and speed"
+                            if level == "medium"
+                            else "Fastest responses with lighter reasoning"
+                        )
+                    ),
+                    icon=(
+                        "brain"
+                        if level == "high"
+                        else ("sparkles" if level == "medium" else "zap")
+                    ),
+                    default=level == settings.reasoning_level,
+                )
+                for level in reasoning_levels
+            ],
+        )
+    ]
+
+
+async def publish_modes(settings: AppSettings) -> None:
+    await cl.context.emitter.set_modes(build_modes(settings))
+
+
 def coerce_settings(raw_settings: AppSettings | dict[str, Any] | None) -> AppSettings:
     if raw_settings is None:
         raw_settings = {}
@@ -395,6 +431,16 @@ def coerce_settings(raw_settings: AppSettings | dict[str, Any] | None) -> AppSet
     if not thread_id:
         thread_id = current_chainlit_thread_id()
     return AppSettings(reasoning_level=reasoning_level, thread_id=thread_id.strip())
+
+
+def resolve_reasoning_level_for_message(
+    message: cl.Message,
+    settings: AppSettings,
+) -> str:
+    raw_modes = getattr(message, "modes", None)
+    if not isinstance(raw_modes, dict):
+        return settings.reasoning_level
+    return normalize_reasoning_level(raw_modes.get("reasoning_level"))
 
 
 if AUTH_ENABLED:
@@ -474,6 +520,7 @@ async def on_chat_start() -> None:
         thread_id=current_chainlit_thread_id(),
     )
     store_settings(settings)
+    await publish_modes(settings)
     await build_chat_settings(settings).send()
     persistence_line = (
         "- Persistence: Postgres-backed LangGraph checkpoints and `/memories/`\n"
@@ -553,6 +600,7 @@ async def on_chat_resume(thread: ThreadDict) -> None:
     )
     settings = coerce_settings(raw_settings)
     store_settings(settings)
+    await publish_modes(settings)
     await build_chat_settings(settings).send()
     async_url_override = async_subagent_url_override()
     agent = await runtime.get_agent(
@@ -575,6 +623,7 @@ async def on_chat_resume(thread: ThreadDict) -> None:
 async def on_settings_update(raw_settings: dict[str, Any]) -> None:
     settings = coerce_settings(raw_settings)
     store_settings(settings)
+    await publish_modes(settings)
 
 
 @cl.action_callback(DOWNLOAD_MARKDOWN_ACTION)
@@ -639,6 +688,13 @@ async def upload_rag_file(action: cl.Action) -> None:
 @cl.on_message
 async def on_message(message: cl.Message) -> None:
     settings = coerce_settings(cl.user_session.get(SESSION_SETTINGS_KEY))
+    effective_reasoning_level = resolve_reasoning_level_for_message(message, settings)
+    if effective_reasoning_level != settings.reasoning_level:
+        settings = AppSettings(
+            reasoning_level=effective_reasoning_level,
+            thread_id=settings.thread_id,
+        )
+        store_settings(settings)
     runtime = await get_runtime_or_notify()
     if runtime is None:
         return

--- a/main.py
+++ b/main.py
@@ -466,13 +466,22 @@ async def publish_modes(
     available_models: tuple[str, ...],
     reasoning_mode_enabled: bool = True,
 ) -> None:
-    await cl.context.emitter.set_modes(
-        build_modes(
-            settings,
-            available_models=available_models,
-            reasoning_mode_enabled=reasoning_mode_enabled,
+    try:
+        await cl.context.emitter.set_modes(
+            build_modes(
+                settings,
+                available_models=available_models,
+                reasoning_mode_enabled=reasoning_mode_enabled,
+            )
         )
-    )
+    except Exception as exc:
+        message = str(exc).lower()
+        missing_modes_column = "modes" in message and (
+            ("column" in message and "does not exist" in message)
+            or "no such column" in message
+        )
+        if not missing_modes_column:
+            raise
 
 
 def coerce_settings(

--- a/main.py
+++ b/main.py
@@ -105,6 +105,7 @@ def current_mcp_session_id() -> str:
 
 def settings_payload(settings: AppSettings) -> dict[str, str]:
     return {
+        "model_name": settings.model_name,
         "reasoning_level": settings.reasoning_level,
         "thread_id": settings.thread_id,
     }
@@ -354,10 +355,33 @@ async def ask_for_rag_upload() -> list[UploadedRagFile]:
     ]
 
 
-def build_chat_settings(settings: AppSettings) -> cl.ChatSettings:
+def resolve_model_name(
+    value: Any | None,
+    *,
+    available_models: tuple[str, ...],
+    default: str,
+) -> str:
+    candidate = str(value or "").strip()
+    if candidate in available_models:
+        return candidate
+    return default
+
+
+def build_chat_settings(
+    settings: AppSettings,
+    *,
+    available_models: tuple[str, ...],
+) -> cl.ChatSettings:
     reasoning_levels = ["low", "medium", "high"]
     return cl.ChatSettings(
         [
+            Select(
+                id="model_name",
+                label="Model",
+                values=list(available_models),
+                initial_index=available_models.index(settings.model_name),
+                description="Select a configured model for this chat session.",
+            ),
             Select(
                 id="reasoning_level",
                 label="Reasoning Level",
@@ -381,9 +405,27 @@ def build_chat_settings(settings: AppSettings) -> cl.ChatSettings:
     )
 
 
-def build_modes(settings: AppSettings) -> list[cl.Mode]:
+def build_modes(
+    settings: AppSettings,
+    *,
+    available_models: tuple[str, ...],
+) -> list[cl.Mode]:
     reasoning_levels = ["low", "medium", "high"]
     return [
+        cl.Mode(
+            id="model_name",
+            name="Model",
+            options=[
+                cl.ModeOption(
+                    id=model_name,
+                    name=model_name,
+                    description="Use this model for the current message.",
+                    icon="bot",
+                    default=model_name == settings.model_name,
+                )
+                for model_name in available_models
+            ],
+        ),
         cl.Mode(
             id="reasoning_level",
             name="Reasoning",
@@ -409,19 +451,43 @@ def build_modes(settings: AppSettings) -> list[cl.Mode]:
                 )
                 for level in reasoning_levels
             ],
-        )
+        ),
     ]
 
 
-async def publish_modes(settings: AppSettings) -> None:
-    await cl.context.emitter.set_modes(build_modes(settings))
+async def publish_modes(
+    settings: AppSettings,
+    *,
+    available_models: tuple[str, ...],
+) -> None:
+    await cl.context.emitter.set_modes(
+        build_modes(settings, available_models=available_models)
+    )
 
 
-def coerce_settings(raw_settings: AppSettings | dict[str, Any] | None) -> AppSettings:
+def coerce_settings(
+    raw_settings: AppSettings | dict[str, Any] | None,
+    *,
+    default_model_name: str,
+    available_models: tuple[str, ...],
+) -> AppSettings:
     if raw_settings is None:
         raw_settings = {}
     if isinstance(raw_settings, AppSettings):
-        return raw_settings
+        return AppSettings(
+            model_name=resolve_model_name(
+                raw_settings.model_name,
+                available_models=available_models,
+                default=default_model_name,
+            ),
+            reasoning_level=normalize_reasoning_level(raw_settings.reasoning_level),
+            thread_id=raw_settings.thread_id,
+        )
+    model_name = resolve_model_name(
+        raw_settings.get("model_name"),
+        available_models=available_models,
+        default=default_model_name,
+    )
     reasoning_level = normalize_reasoning_level(
         raw_settings.get("reasoning_level", DEFAULT_REASONING_LEVEL)
     )
@@ -430,7 +496,11 @@ def coerce_settings(raw_settings: AppSettings | dict[str, Any] | None) -> AppSet
     ).strip()
     if not thread_id:
         thread_id = current_chainlit_thread_id()
-    return AppSettings(reasoning_level=reasoning_level, thread_id=thread_id.strip())
+    return AppSettings(
+        model_name=model_name,
+        reasoning_level=reasoning_level,
+        thread_id=thread_id.strip(),
+    )
 
 
 def resolve_reasoning_level_for_message(
@@ -440,7 +510,26 @@ def resolve_reasoning_level_for_message(
     raw_modes = getattr(message, "modes", None)
     if not isinstance(raw_modes, dict):
         return settings.reasoning_level
-    return normalize_reasoning_level(raw_modes.get("reasoning_level"))
+    return normalize_reasoning_level(
+        raw_modes.get("reasoning_level"),
+        default=settings.reasoning_level,
+    )
+
+
+def resolve_model_name_for_message(
+    message: cl.Message,
+    settings: AppSettings,
+    *,
+    available_models: tuple[str, ...],
+) -> str:
+    raw_modes = getattr(message, "modes", None)
+    if not isinstance(raw_modes, dict):
+        return settings.model_name
+    return resolve_model_name(
+        raw_modes.get("model_name"),
+        available_models=available_models,
+        default=settings.model_name,
+    )
 
 
 if AUTH_ENABLED:
@@ -516,12 +605,16 @@ async def on_chat_start() -> None:
     run_task_list = await get_run_task_list()
     await run_task_list.show_ready()
     settings = AppSettings(
+        model_name=runtime.config.model_name,
         reasoning_level=runtime.config.default_reasoning,
         thread_id=current_chainlit_thread_id(),
     )
     store_settings(settings)
-    await publish_modes(settings)
-    await build_chat_settings(settings).send()
+    await publish_modes(settings, available_models=runtime.config.model_choices)
+    await build_chat_settings(
+        settings,
+        available_models=runtime.config.model_choices,
+    ).send()
     persistence_line = (
         "- Persistence: Postgres-backed LangGraph checkpoints and `/memories/`\n"
         if runtime.persistence_enabled
@@ -598,13 +691,21 @@ async def on_chat_resume(thread: ThreadDict) -> None:
     raw_settings = (
         metadata.get(SESSION_SETTINGS_KEY) if isinstance(metadata, dict) else None
     )
-    settings = coerce_settings(raw_settings)
+    settings = coerce_settings(
+        raw_settings,
+        default_model_name=runtime.config.model_name,
+        available_models=runtime.config.model_choices,
+    )
     store_settings(settings)
-    await publish_modes(settings)
-    await build_chat_settings(settings).send()
+    await publish_modes(settings, available_models=runtime.config.model_choices)
+    await build_chat_settings(
+        settings,
+        available_models=runtime.config.model_choices,
+    ).send()
     async_url_override = async_subagent_url_override()
     agent = await runtime.get_agent(
         settings.reasoning_level,
+        model_name=settings.model_name,
         thread_id=settings.thread_id,
         async_subagent_url_override=async_url_override,
         mcp_session_id=mcp_session_id,
@@ -621,9 +722,16 @@ async def on_chat_resume(thread: ThreadDict) -> None:
 
 @cl.on_settings_update
 async def on_settings_update(raw_settings: dict[str, Any]) -> None:
-    settings = coerce_settings(raw_settings)
+    runtime = await get_runtime_or_notify()
+    if runtime is None:
+        return
+    settings = coerce_settings(
+        raw_settings,
+        default_model_name=runtime.config.model_name,
+        available_models=runtime.config.model_choices,
+    )
     store_settings(settings)
-    await publish_modes(settings)
+    await publish_modes(settings, available_models=runtime.config.model_choices)
 
 
 @cl.action_callback(DOWNLOAD_MARKDOWN_ACTION)
@@ -666,7 +774,11 @@ async def upload_rag_file(action: cl.Action) -> None:
     if runtime is None:
         return
 
-    settings = coerce_settings(cl.user_session.get(SESSION_SETTINGS_KEY))
+    settings = coerce_settings(
+        cl.user_session.get(SESSION_SETTINGS_KEY),
+        default_model_name=runtime.config.model_name,
+        available_models=runtime.config.model_choices,
+    )
     uploads = await ask_for_rag_upload()
     if not uploads:
         await cl.Message(content="No files were uploaded.", author="System").send()
@@ -687,17 +799,20 @@ async def upload_rag_file(action: cl.Action) -> None:
 
 @cl.on_message
 async def on_message(message: cl.Message) -> None:
-    settings = coerce_settings(cl.user_session.get(SESSION_SETTINGS_KEY))
-    effective_reasoning_level = resolve_reasoning_level_for_message(message, settings)
-    if effective_reasoning_level != settings.reasoning_level:
-        settings = AppSettings(
-            reasoning_level=effective_reasoning_level,
-            thread_id=settings.thread_id,
-        )
-        store_settings(settings)
     runtime = await get_runtime_or_notify()
     if runtime is None:
         return
+    settings = coerce_settings(
+        cl.user_session.get(SESSION_SETTINGS_KEY),
+        default_model_name=runtime.config.model_name,
+        available_models=runtime.config.model_choices,
+    )
+    effective_reasoning_level = resolve_reasoning_level_for_message(message, settings)
+    effective_model_name = resolve_model_name_for_message(
+        message,
+        settings,
+        available_models=runtime.config.model_choices,
+    )
     mcp_session_id = current_mcp_session_id()
     run_task_list = await get_run_task_list()
     uploaded_files = message_uploaded_rag_files(message)
@@ -755,7 +870,8 @@ async def on_message(message: cl.Message) -> None:
 
     async_url_override = async_subagent_url_override()
     agent = await runtime.get_agent(
-        settings.reasoning_level,
+        effective_reasoning_level,
+        model_name=effective_model_name,
         thread_id=settings.thread_id,
         async_subagent_url_override=async_url_override,
         mcp_session_id=mcp_session_id,

--- a/main.py
+++ b/main.py
@@ -371,17 +371,22 @@ def build_chat_settings(
     settings: AppSettings,
     *,
     available_models: tuple[str, ...],
+    model_mode_enabled: bool = True,
 ) -> cl.ChatSettings:
     reasoning_levels = ["low", "medium", "high"]
-    return cl.ChatSettings(
-        [
+    inputs: list[Any] = []
+    if model_mode_enabled:
+        inputs.append(
             Select(
                 id="model_name",
                 label="Model",
                 values=list(available_models),
                 initial_index=available_models.index(settings.model_name),
                 description="Select a configured model for this chat session.",
-            ),
+            )
+        )
+    inputs.extend(
+        [
             Select(
                 id="reasoning_level",
                 label="Reasoning Level",
@@ -403,31 +408,35 @@ def build_chat_settings(
             ),
         ]
     )
+    return cl.ChatSettings(inputs)
 
 
 def build_modes(
     settings: AppSettings,
     *,
     available_models: tuple[str, ...],
+    model_mode_enabled: bool = True,
     reasoning_mode_enabled: bool = True,
 ) -> list[cl.Mode]:
     reasoning_levels = ["low", "medium", "high"]
-    modes = [
-        cl.Mode(
-            id="model_name",
-            name="Model",
-            options=[
-                cl.ModeOption(
-                    id=model_name,
-                    name=model_name,
-                    description="Use this model for the current message.",
-                    icon="bot",
-                    default=model_name == settings.model_name,
-                )
-                for model_name in available_models
-            ],
-        ),
-    ]
+    modes: list[cl.Mode] = []
+    if model_mode_enabled:
+        modes.append(
+            cl.Mode(
+                id="model_name",
+                name="Model",
+                options=[
+                    cl.ModeOption(
+                        id=model_name,
+                        name=model_name,
+                        description="Use this model for the current message.",
+                        icon="bot",
+                        default=model_name == settings.model_name,
+                    )
+                    for model_name in available_models
+                ],
+            )
+        )
     if reasoning_mode_enabled:
         modes.append(
             cl.Mode(
@@ -464,6 +473,7 @@ async def publish_modes(
     settings: AppSettings,
     *,
     available_models: tuple[str, ...],
+    model_mode_enabled: bool = True,
     reasoning_mode_enabled: bool = True,
 ) -> None:
     try:
@@ -471,6 +481,7 @@ async def publish_modes(
             build_modes(
                 settings,
                 available_models=available_models,
+                model_mode_enabled=model_mode_enabled,
                 reasoning_mode_enabled=reasoning_mode_enabled,
             )
         )
@@ -544,7 +555,10 @@ def resolve_model_name_for_message(
     settings: AppSettings,
     *,
     available_models: tuple[str, ...],
+    model_mode_enabled: bool = True,
 ) -> str:
+    if not model_mode_enabled:
+        return settings.model_name
     raw_modes = getattr(message, "modes", None)
     if not isinstance(raw_modes, dict):
         return settings.model_name
@@ -636,11 +650,13 @@ async def on_chat_start() -> None:
     await publish_modes(
         settings,
         available_models=runtime.config.model_choices,
+        model_mode_enabled=runtime.config.extensions.chainlit_model_mode_enabled,
         reasoning_mode_enabled=runtime.config.extensions.chainlit_reasoning_mode_enabled,
     )
     await build_chat_settings(
         settings,
         available_models=runtime.config.model_choices,
+        model_mode_enabled=runtime.config.extensions.chainlit_model_mode_enabled,
     ).send()
     persistence_line = (
         "- Persistence: Postgres-backed LangGraph checkpoints and `/memories/`\n"
@@ -727,11 +743,13 @@ async def on_chat_resume(thread: ThreadDict) -> None:
     await publish_modes(
         settings,
         available_models=runtime.config.model_choices,
+        model_mode_enabled=runtime.config.extensions.chainlit_model_mode_enabled,
         reasoning_mode_enabled=runtime.config.extensions.chainlit_reasoning_mode_enabled,
     )
     await build_chat_settings(
         settings,
         available_models=runtime.config.model_choices,
+        model_mode_enabled=runtime.config.extensions.chainlit_model_mode_enabled,
     ).send()
     async_url_override = async_subagent_url_override()
     agent = await runtime.get_agent(
@@ -765,6 +783,7 @@ async def on_settings_update(raw_settings: dict[str, Any]) -> None:
     await publish_modes(
         settings,
         available_models=runtime.config.model_choices,
+        model_mode_enabled=runtime.config.extensions.chainlit_model_mode_enabled,
         reasoning_mode_enabled=runtime.config.extensions.chainlit_reasoning_mode_enabled,
     )
 
@@ -851,6 +870,7 @@ async def on_message(message: cl.Message) -> None:
         message,
         settings,
         available_models=runtime.config.model_choices,
+        model_mode_enabled=runtime.config.extensions.chainlit_model_mode_enabled,
     )
     mcp_session_id = current_mcp_session_id()
     run_task_list = await get_run_task_list()

--- a/tests/test_deepagent_runtime_rag.py
+++ b/tests/test_deepagent_runtime_rag.py
@@ -523,6 +523,7 @@ description = "Researches the repo"
 system_prompt = "Do research"
 
 [chainlit]
+model_mode_enabled = false
 reasoning_mode_enabled = false
 commands = [
   { name = "ask-researcher", description = "Delegate to subagent", target = "subagent", value = "repo-researcher" },
@@ -540,6 +541,7 @@ commands = [
     assert extensions.chainlit_commands[0].name == "ask-researcher"
     assert extensions.chainlit_commands[1].target == "mcp_tool"
     assert extensions.chainlit_commands[2].template == "Rewrite: {input}"
+    assert extensions.chainlit_model_mode_enabled is False
     assert extensions.chainlit_reasoning_mode_enabled is False
 
 
@@ -558,6 +560,24 @@ reasoning_mode_enabled = "no"
     monkeypatch.setenv("DEEPAGENT_CONFIG", str(config_path))
 
     with pytest.raises(ValueError, match="reasoning_mode_enabled"):
+        deepagent_runtime.load_extensions_config()
+
+
+def test_load_extensions_config_rejects_non_boolean_model_mode_flag(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    config_path = tmp_path / "deepagent.toml"
+    config_path.write_text(
+        """
+[chainlit]
+model_mode_enabled = "no"
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DEEPAGENT_CONFIG", str(config_path))
+
+    with pytest.raises(ValueError, match="model_mode_enabled"):
         deepagent_runtime.load_extensions_config()
 
 

--- a/tests/test_deepagent_runtime_rag.py
+++ b/tests/test_deepagent_runtime_rag.py
@@ -523,6 +523,7 @@ description = "Researches the repo"
 system_prompt = "Do research"
 
 [chainlit]
+reasoning_mode_enabled = false
 commands = [
   { name = "ask-researcher", description = "Delegate to subagent", target = "subagent", value = "repo-researcher" },
   { name = "run-tool", description = "Call MCP tool", target = "mcp_tool", value = "repo_read_file", mcp_server = "repo" },
@@ -539,6 +540,25 @@ commands = [
     assert extensions.chainlit_commands[0].name == "ask-researcher"
     assert extensions.chainlit_commands[1].target == "mcp_tool"
     assert extensions.chainlit_commands[2].template == "Rewrite: {input}"
+    assert extensions.chainlit_reasoning_mode_enabled is False
+
+
+def test_load_extensions_config_rejects_non_boolean_reasoning_mode_flag(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    config_path = tmp_path / "deepagent.toml"
+    config_path.write_text(
+        """
+[chainlit]
+reasoning_mode_enabled = "no"
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DEEPAGENT_CONFIG", str(config_path))
+
+    with pytest.raises(ValueError, match="reasoning_mode_enabled"):
+        deepagent_runtime.load_extensions_config()
 
 
 def test_load_extensions_config_rejects_unknown_chainlit_subagent(

--- a/tests/test_deepagent_runtime_rag.py
+++ b/tests/test_deepagent_runtime_rag.py
@@ -61,6 +61,7 @@ def make_runtime_config(
         database_url=None,
         model_provider="ollama",
         model_name="gpt-oss:20b",
+        model_choices=("gpt-oss:20b",),
         model_base_url="http://127.0.0.1:11434",
         model_api_key=None,
         model_temperature=0.0,
@@ -182,6 +183,29 @@ mcp_servers = ["repo"]
     config = deepagent_runtime.load_extensions_config()
 
     assert config.mcp_stateful is True
+
+
+def test_runtime_config_reads_model_choices_from_toml(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    config_path = tmp_path / "deepagent.toml"
+    config_path.write_text(
+        """
+[model]
+provider = "ollama"
+base_url = "http://127.0.0.1:11434"
+name = "gpt-oss:20b"
+models = ["gpt-oss:20b", "gemma4:27b"]
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DEEPAGENT_CONFIG", str(config_path))
+
+    config = deepagent_runtime.RuntimeConfig.from_env()
+
+    assert config.model_name == "gpt-oss:20b"
+    assert config.model_choices == ("gpt-oss:20b", "gemma4:27b")
 
 
 def test_build_deepagent_backend_stores_large_tool_results_inside_project(

--- a/tests/test_main_native_commands.py
+++ b/tests/test_main_native_commands.py
@@ -105,6 +105,35 @@ def test_resolve_model_name_for_message_falls_back_to_settings() -> None:
     assert resolved == "gpt-oss:20b"
 
 
+@pytest.mark.anyio
+async def test_publish_modes_ignores_missing_modes_column_error(monkeypatch) -> None:
+    class _Emitter:
+        async def set_modes(self, _modes):
+            raise RuntimeError('column "modes" does not exist')
+
+    monkeypatch.setattr(main.cl, "context", SimpleNamespace(emitter=_Emitter()))
+
+    await main.publish_modes(
+        SimpleNamespace(model_name="gpt-oss:20b", reasoning_level="medium"),
+        available_models=("gpt-oss:20b",),
+    )
+
+
+@pytest.mark.anyio
+async def test_publish_modes_raises_for_unrelated_errors(monkeypatch) -> None:
+    class _Emitter:
+        async def set_modes(self, _modes):
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr(main.cl, "context", SimpleNamespace(emitter=_Emitter()))
+
+    with pytest.raises(RuntimeError, match="boom"):
+        await main.publish_modes(
+            SimpleNamespace(model_name="gpt-oss:20b", reasoning_level="medium"),
+            available_models=("gpt-oss:20b",),
+        )
+
+
 class _DummyRuntime:
     def __init__(self, command=None) -> None:
         self.invocation: dict[str, str | None] | None = None

--- a/tests/test_main_native_commands.py
+++ b/tests/test_main_native_commands.py
@@ -105,6 +105,20 @@ def test_resolve_model_name_for_message_falls_back_to_settings() -> None:
     assert resolved == "gpt-oss:20b"
 
 
+def test_resolve_model_name_for_message_ignores_override_when_disabled() -> None:
+    message = SimpleNamespace(content="hello", modes={"model_name": "gemma4:27b"})
+    settings = SimpleNamespace(model_name="gpt-oss:20b")
+
+    resolved = main.resolve_model_name_for_message(
+        message,
+        settings,
+        available_models=("gpt-oss:20b", "gemma4:27b"),
+        model_mode_enabled=False,
+    )
+
+    assert resolved == "gpt-oss:20b"
+
+
 @pytest.mark.anyio
 async def test_publish_modes_ignores_missing_modes_column_error(monkeypatch) -> None:
     class _Emitter:

--- a/tests/test_main_native_commands.py
+++ b/tests/test_main_native_commands.py
@@ -57,6 +57,41 @@ def test_resolve_reasoning_level_for_message_uses_mode_override() -> None:
     assert resolved == "high"
 
 
+def test_resolve_reasoning_level_for_message_falls_back_to_settings_default() -> None:
+    message = SimpleNamespace(content="hello", modes={})
+    settings = SimpleNamespace(reasoning_level="low")
+
+    resolved = main.resolve_reasoning_level_for_message(message, settings)
+
+    assert resolved == "low"
+
+
+def test_resolve_model_name_for_message_uses_mode_override() -> None:
+    message = SimpleNamespace(content="hello", modes={"model_name": "gemma4:27b"})
+    settings = SimpleNamespace(model_name="gpt-oss:20b")
+
+    resolved = main.resolve_model_name_for_message(
+        message,
+        settings,
+        available_models=("gpt-oss:20b", "gemma4:27b"),
+    )
+
+    assert resolved == "gemma4:27b"
+
+
+def test_resolve_model_name_for_message_falls_back_to_settings() -> None:
+    message = SimpleNamespace(content="hello", modes={"model_name": "unknown"})
+    settings = SimpleNamespace(model_name="gpt-oss:20b")
+
+    resolved = main.resolve_model_name_for_message(
+        message,
+        settings,
+        available_models=("gpt-oss:20b", "gemma4:27b"),
+    )
+
+    assert resolved == "gpt-oss:20b"
+
+
 class _DummyRuntime:
     def __init__(self, command=None) -> None:
         self.invocation: dict[str, str | None] | None = None

--- a/tests/test_main_native_commands.py
+++ b/tests/test_main_native_commands.py
@@ -66,6 +66,19 @@ def test_resolve_reasoning_level_for_message_falls_back_to_settings_default() ->
     assert resolved == "low"
 
 
+def test_resolve_reasoning_level_for_message_ignores_override_when_disabled() -> None:
+    message = SimpleNamespace(content="hello", modes={"reasoning_level": "high"})
+    settings = SimpleNamespace(reasoning_level="low")
+
+    resolved = main.resolve_reasoning_level_for_message(
+        message,
+        settings,
+        reasoning_mode_enabled=False,
+    )
+
+    assert resolved == "low"
+
+
 def test_resolve_model_name_for_message_uses_mode_override() -> None:
     message = SimpleNamespace(content="hello", modes={"model_name": "gemma4:27b"})
     settings = SimpleNamespace(model_name="gpt-oss:20b")

--- a/tests/test_main_native_commands.py
+++ b/tests/test_main_native_commands.py
@@ -39,6 +39,24 @@ def test_resolve_native_command_returns_none_without_command() -> None:
     assert parsed is None
 
 
+def test_resolve_reasoning_level_for_message_defaults_to_settings() -> None:
+    message = SimpleNamespace(content="hello")
+    settings = SimpleNamespace(reasoning_level="medium")
+
+    resolved = main.resolve_reasoning_level_for_message(message, settings)
+
+    assert resolved == "medium"
+
+
+def test_resolve_reasoning_level_for_message_uses_mode_override() -> None:
+    message = SimpleNamespace(content="hello", modes={"reasoning_level": "high"})
+    settings = SimpleNamespace(reasoning_level="medium")
+
+    resolved = main.resolve_reasoning_level_for_message(message, settings)
+
+    assert resolved == "high"
+
+
 class _DummyRuntime:
     def __init__(self, command=None) -> None:
         self.invocation: dict[str, str | None] | None = None


### PR DESCRIPTION
### Motivation
- Align the app with Chainlit's Modes concept so reasoning effort can be selected via the UI modes picker rather than only chat settings.
- Allow per-message mode overrides so a single message can request a different reasoning level for that run.
- Preserve existing session-level settings while making the reasoning level configurable and discoverable in the UI.

### Description
- Added `build_modes(settings)` and `publish_modes(settings)` to declare and publish a `Reasoning` `cl.Mode` (options: `low`, `medium`, `high`) to the Chainlit UI via `cl.context.emitter.set_modes(...)`.
- Added `resolve_reasoning_level_for_message(message, settings)` to read `message.modes` and coerce the `reasoning_level` via `normalize_reasoning_level`.
- Updated lifecycle hooks to publish modes: call `publish_modes(settings)` in `on_chat_start`, `on_chat_resume`, and `on_settings_update` so the picker stays in sync with session settings.
- Applied per-message override in `on_message` by resolving an effective reasoning level and updating `AppSettings` for that run when different from the stored session value.
- Added unit tests `test_resolve_reasoning_level_for_message_defaults_to_settings` and `test_resolve_reasoning_level_for_message_uses_mode_override` in `tests/test_main_native_commands.py` and documented the feature in `README.md`.

### Testing
- Ran `pytest -q tests/test_main_native_commands.py` in the bare environment which failed due to a missing external `chainlit` dependency (module not available in that execution environment).
- Ran the tests under the project environment with `uv run pytest -q tests/test_main_native_commands.py` which completed successfully with `11 passed` (no failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eabdb5aa408324a5f64f0b028c39fd)