### PR TITLE
Add Chainlit config flag to disable startup status message

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,8 @@ Example:
 model_mode_enabled = true
 # Set false to disable per-message reasoning overrides from the Modes picker.
 reasoning_mode_enabled = true
+# Set false to hide the initial startup status message ("Workspace agent ready...").
+startup_status_enabled = true
 commands = [
   { name = "ask-researcher", description = "Delegate to repo-researcher.", target = "subagent", value = "repo-researcher", template = "{input}" },
   { name = "repo-readme", description = "Run an MCP tool directly.", target = "mcp_tool", value = "repo_read_file", mcp_server = "repo", template = "{\"path\":\"README.md\"}" },
@@ -350,6 +352,7 @@ Notes:
 - The `[chainlit]` table for native commands belongs in `deepagent.toml`, alongside `[model]`, `[agent]`, `[mcp]`, `[[subagents]]`, and `[[async_subagents]]`.
 - `[chainlit].model_mode_enabled = false` hides the Model selector in chat settings and the Model mode group, and ignores per-message model overrides from UI modes.
 - `[chainlit].reasoning_mode_enabled = false` hides the Reasoning mode group and ignores per-message reasoning overrides from UI modes.
+- `[chainlit].startup_status_enabled = false` disables the initial startup status message that summarizes runtime configuration.
 - Command `name` is invoked as `/<name>` and must be unique.
 - `template` is optional and may include `{input}`.
 - For `mcp_tool`, user command arguments must be valid JSON, e.g. `/repo-readme {"path":"README.md"}`.

--- a/deepagent.toml.example
+++ b/deepagent.toml.example
@@ -36,6 +36,8 @@ mcp_servers = ["repo"]
 model_mode_enabled = true
 # Set false to disable per-message reasoning overrides from the Modes picker.
 reasoning_mode_enabled = true
+# Set false to disable the initial startup status message in chat.
+startup_status_enabled = true
 # Native slash commands available from the Chainlit composer.
 commands = [
   { name = "summarize-docs", description = "Summarize repository docs.", target = "prompt", value = "Summarize the repository documentation changes.", template = "Summarize docs for: {input}" },

--- a/deepagent_runtime.py
+++ b/deepagent_runtime.py
@@ -470,6 +470,7 @@ class ExtensionsConfig:
     chainlit_commands: tuple[ChainlitCommandConfig, ...] = ()
     chainlit_model_mode_enabled: bool = True
     chainlit_reasoning_mode_enabled: bool = True
+    chainlit_startup_status_enabled: bool = True
 
     @property
     def enabled(self) -> bool:
@@ -748,6 +749,7 @@ def parse_extensions_config(raw_config: dict[str, Any], config_path: Path) -> Ex
         raise ValueError("The top-level 'chainlit.commands' config must be an array of tables.")
     raw_reasoning_mode_enabled = chainlit_section.get("reasoning_mode_enabled", True)
     raw_model_mode_enabled = chainlit_section.get("model_mode_enabled", True)
+    raw_startup_status_enabled = chainlit_section.get("startup_status_enabled", True)
     if not isinstance(raw_reasoning_mode_enabled, bool):
         raise ValueError(
             "The top-level 'chainlit.reasoning_mode_enabled' config must be a boolean."
@@ -755,6 +757,10 @@ def parse_extensions_config(raw_config: dict[str, Any], config_path: Path) -> Ex
     if not isinstance(raw_model_mode_enabled, bool):
         raise ValueError(
             "The top-level 'chainlit.model_mode_enabled' config must be a boolean."
+        )
+    if not isinstance(raw_startup_status_enabled, bool):
+        raise ValueError(
+            "The top-level 'chainlit.startup_status_enabled' config must be a boolean."
         )
 
     chainlit_commands: list[ChainlitCommandConfig] = []
@@ -820,6 +826,7 @@ def parse_extensions_config(raw_config: dict[str, Any], config_path: Path) -> Ex
         chainlit_commands=tuple(chainlit_commands),
         chainlit_model_mode_enabled=raw_model_mode_enabled,
         chainlit_reasoning_mode_enabled=raw_reasoning_mode_enabled,
+        chainlit_startup_status_enabled=raw_startup_status_enabled,
     )
 
 

--- a/main.py
+++ b/main.py
@@ -699,24 +699,25 @@ async def on_chat_start() -> None:
         extensions_line += f"Command notes:\n{note_lines}\n"
     if extensions.config_path is not None:
         extensions_line += f"- Extensions config: `{extensions.config_path.name}`\n"
-    startup_message = cl.Message(
-        content=(
-            "Workspace agent ready.\n\n"
-            f"- Model provider: `{format_model_provider(runtime.config.model_provider)}`\n"
-            f"- Model: `{runtime.config.model_name}`\n"
-            f"- Thread ID: `{settings.thread_id}`\n"
-            f"{persistence_line}"
-            f"{history_line}"
-            f"{rag_status_line(runtime)}"
-            f"{extensions_line}"
-            "- Real repo files live under `/workspace/`\n"
-            "- Agent memory is available under `/memories/`"
-        ),
-        author="System",
-    )
-    if runtime.rag_enabled:
-        startup_message.actions = rag_actions()
-    await startup_message.send()
+    if runtime.config.extensions.chainlit_startup_status_enabled:
+        startup_message = cl.Message(
+            content=(
+                "Workspace agent ready.\n\n"
+                f"- Model provider: `{format_model_provider(runtime.config.model_provider)}`\n"
+                f"- Model: `{runtime.config.model_name}`\n"
+                f"- Thread ID: `{settings.thread_id}`\n"
+                f"{persistence_line}"
+                f"{history_line}"
+                f"{rag_status_line(runtime)}"
+                f"{extensions_line}"
+                "- Real repo files live under `/workspace/`\n"
+                "- Agent memory is available under `/memories/`"
+            ),
+            author="System",
+        )
+        if runtime.rag_enabled:
+            startup_message.actions = rag_actions()
+        await startup_message.send()
 
 
 @cl.on_chat_resume

--- a/tests/test_deepagent_runtime_rag.py
+++ b/tests/test_deepagent_runtime_rag.py
@@ -525,6 +525,7 @@ system_prompt = "Do research"
 [chainlit]
 model_mode_enabled = false
 reasoning_mode_enabled = false
+startup_status_enabled = false
 commands = [
   { name = "ask-researcher", description = "Delegate to subagent", target = "subagent", value = "repo-researcher" },
   { name = "run-tool", description = "Call MCP tool", target = "mcp_tool", value = "repo_read_file", mcp_server = "repo" },
@@ -543,6 +544,25 @@ commands = [
     assert extensions.chainlit_commands[2].template == "Rewrite: {input}"
     assert extensions.chainlit_model_mode_enabled is False
     assert extensions.chainlit_reasoning_mode_enabled is False
+    assert extensions.chainlit_startup_status_enabled is False
+
+
+def test_load_extensions_config_rejects_non_boolean_startup_status_flag(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    config_path = tmp_path / "deepagent.toml"
+    config_path.write_text(
+        """
+[chainlit]
+startup_status_enabled = "no"
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DEEPAGENT_CONFIG", str(config_path))
+
+    with pytest.raises(ValueError, match="startup_status_enabled"):
+        deepagent_runtime.load_extensions_config()
 
 
 def test_load_extensions_config_rejects_non_boolean_reasoning_mode_flag(


### PR DESCRIPTION
### Motivation
- Provide a config switch to hide the large initial "Workspace agent ready" status message shown in Chainlit so embedding the app into other UIs or workflows can avoid the startup wall of text.

### Description
- Add a new `chainlit_startup_status_enabled` field to `ExtensionsConfig` with a default of `true` and parse the TOML key `[chainlit].startup_status_enabled` in `parse_extensions_config` in `deepagent_runtime.py` with boolean validation.
- Make `on_chat_start` in `main.py` skip sending the startup `cl.Message` unless `runtime.config.extensions.chainlit_startup_status_enabled` is `True`.
- Document the new `startup_status_enabled` option in `deepagent.toml.example` and `README.md` and update example config snippets.
- Add/extend tests in `tests/test_deepagent_runtime_rag.py` to assert the flag is parsed and that non-boolean values raise a `ValueError`.

### Testing
- Ran `pytest -q tests/test_deepagent_runtime_rag.py tests/test_main_native_commands.py` which failed to collect due to missing optional test dependencies (`langchain` and `chainlit`) in the execution environment.
- Ran `python -m compileall deepagent_runtime.py main.py tests/test_deepagent_runtime_rag.py` which succeeded, confirming syntax correctness of modified modules.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eadc4633c4832494c784a8963dd75c)