### PR TITLE
Add configurable summarization middleware support

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,8 @@ cwd = "."
 skills = ["skills"]
 mcp_servers = ["repo"]
 summarization_middleware_enabled = false
+summarization_trigger_tokens = 6000
+summarization_keep_tokens = 2400
 
 [[subagents]]
 name = "repo-researcher"
@@ -320,6 +322,8 @@ Supported subagent fields:
 Main `[agent]` additions:
 
 - `summarization_middleware_enabled`: optional boolean (default `false`) to add LangChain's summarization middleware to the main agent and sync subagents.
+- `summarization_trigger_tokens`: optional positive integer token threshold that triggers summarization when reached.
+- `summarization_keep_tokens`: optional positive integer token budget to keep in conversation history after summarization.
 
 ## Chainlit Native Commands
 

--- a/README.md
+++ b/README.md
@@ -286,6 +286,7 @@ cwd = "."
 [agent]
 skills = ["skills"]
 mcp_servers = ["repo"]
+summarization_middleware_enabled = false
 
 [[subagents]]
 name = "repo-researcher"
@@ -315,6 +316,10 @@ Supported subagent fields:
 - `skills`: optional list of skill source paths for that subagent
 - `mcp_servers`: optional list of MCP server names to attach to that subagent
 - `model`: optional model override
+
+Main `[agent]` additions:
+
+- `summarization_middleware_enabled`: optional boolean (default `false`) to add LangChain's summarization middleware to the main agent and sync subagents.
 
 ## Chainlit Native Commands
 

--- a/deepagent.toml.example
+++ b/deepagent.toml.example
@@ -32,6 +32,9 @@ skills = ["skills"]
 mcp_servers = ["repo"]
 # Set true to add LangChain's SummarizationMiddleware to the main agent and sync subagents.
 summarization_middleware_enabled = false
+# Optional token thresholds used when the installed LangChain middleware supports them.
+summarization_trigger_tokens = 6000
+summarization_keep_tokens = 2400
 
 [chainlit]
 # Set false to hide model selection in chat settings and Modes.

--- a/deepagent.toml.example
+++ b/deepagent.toml.example
@@ -30,6 +30,8 @@ url = "http://localhost:8000/mcp"
 # This directory should contain one or more skill folders, each with its own SKILL.md.
 skills = ["skills"]
 mcp_servers = ["repo"]
+# Set true to add LangChain's SummarizationMiddleware to the main agent and sync subagents.
+summarization_middleware_enabled = false
 
 [chainlit]
 # Set false to hide model selection in chat settings and Modes.

--- a/deepagent_runtime.py
+++ b/deepagent_runtime.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
 import json
 import logging
 import math
@@ -271,8 +272,60 @@ class ToolExecutionResilienceMiddleware(AgentMiddleware[Any, Any, Any]):
             return self._error_tool_message(request, exc)
 
 
-def build_agent_middleware() -> list[AgentMiddleware[Any, Any, Any]]:
-    return [ToolExecutionResilienceMiddleware()]
+def _build_summarization_middleware(
+    *,
+    config: RuntimeConfig,
+    reasoning_level: ReasoningLevel,
+    model_name: str | None = None,
+) -> AgentMiddleware[Any, Any, Any] | None:
+    try:
+        from langchain.agents.middleware import SummarizationMiddleware
+    except Exception:
+        logger.warning(
+            "Summarization middleware is enabled but unavailable in the installed LangChain version."
+        )
+        return None
+
+    kwargs: dict[str, Any] = {}
+    signature = inspect.signature(SummarizationMiddleware)
+    if "model" in signature.parameters:
+        kwargs["model"] = build_model(
+            config,
+            reasoning_level,
+            model_name=model_name,
+        )
+
+    try:
+        middleware = SummarizationMiddleware(**kwargs)
+    except Exception as exc:
+        logger.warning(
+            "Failed to initialize summarization middleware; continuing without it: %s",
+            exc,
+        )
+        return None
+    return middleware
+
+
+def build_agent_middleware(
+    *,
+    config: RuntimeConfig | None = None,
+    reasoning_level: ReasoningLevel | None = None,
+    model_name: str | None = None,
+) -> list[AgentMiddleware[Any, Any, Any]]:
+    middleware: list[AgentMiddleware[Any, Any, Any]] = [ToolExecutionResilienceMiddleware()]
+    if (
+        config
+        and config.extensions.summarization_middleware_enabled
+        and reasoning_level is not None
+    ):
+        summarization_middleware = _build_summarization_middleware(
+            config=config,
+            reasoning_level=reasoning_level,
+            model_name=model_name,
+        )
+        if summarization_middleware is not None:
+            middleware.append(summarization_middleware)
+    return middleware
 
 
 def resolve_local_path(path_value: str, base_dir: Path) -> Path:
@@ -471,6 +524,7 @@ class ExtensionsConfig:
     chainlit_model_mode_enabled: bool = True
     chainlit_reasoning_mode_enabled: bool = True
     chainlit_startup_status_enabled: bool = True
+    summarization_middleware_enabled: bool = False
 
     @property
     def enabled(self) -> bool:
@@ -682,6 +736,14 @@ def parse_extensions_config(raw_config: dict[str, Any], config_path: Path) -> Ex
         mcp_servers[str(name)] = normalize_mcp_server_config(raw_server, base_dir)
 
     raw_skill_paths = agent_section.get("skills", [])
+    raw_summarization_middleware_enabled = agent_section.get(
+        "summarization_middleware_enabled",
+        False,
+    )
+    if not isinstance(raw_summarization_middleware_enabled, bool):
+        raise ValueError(
+            "The top-level 'agent.summarization_middleware_enabled' config must be a boolean."
+        )
     skill_paths = tuple(
         normalize_skill_source_path(str(path_value), base_dir)
         for path_value in raw_skill_paths
@@ -827,6 +889,7 @@ def parse_extensions_config(raw_config: dict[str, Any], config_path: Path) -> Ex
         chainlit_model_mode_enabled=raw_model_mode_enabled,
         chainlit_reasoning_mode_enabled=raw_reasoning_mode_enabled,
         chainlit_startup_status_enabled=raw_startup_status_enabled,
+        summarization_middleware_enabled=raw_summarization_middleware_enabled,
     )
 
 
@@ -1198,7 +1261,10 @@ def build_graph_subagent_specs(
     *,
     include_async_subagents: bool,
 ) -> list[Any]:
-    middleware = build_agent_middleware()
+    middleware = build_agent_middleware(
+        config=config,
+        reasoning_level=config.default_reasoning,
+    )
     subagent_specs: list[Any] = [
         subagent.to_deepagents_spec(middleware=middleware)
         for subagent in config.extensions.subagents
@@ -1238,7 +1304,10 @@ def create_configured_graph(
             system_prompt,
             rag_enabled=config.rag is not None,
         ),
-        middleware=build_agent_middleware(),
+        middleware=build_agent_middleware(
+            config=config,
+            reasoning_level=config.default_reasoning,
+        ),
         backend=build_deepagent_backend(),
         skills=list(config.extensions.skills) or None,
         subagents=subagent_specs or None,
@@ -1401,7 +1470,11 @@ class AgentRuntime:
                         mcp_session_id=mcp_session_id,
                     ),
                 )
-                middleware = build_agent_middleware()
+                middleware = build_agent_middleware(
+                    config=self.config,
+                    reasoning_level=reasoning_level,
+                    model_name=selected_model,
+                )
                 subagent_specs: list[Any] = [
                     subagent.to_deepagents_spec(
                         tools=sanitize_tools_for_model(

--- a/deepagent_runtime.py
+++ b/deepagent_runtime.py
@@ -294,6 +294,15 @@ def _build_summarization_middleware(
             reasoning_level,
             model_name=model_name,
         )
+    if config.extensions.summarization_trigger_tokens is not None:
+        if "max_tokens_before_summary" in signature.parameters:
+            kwargs["max_tokens_before_summary"] = (
+                config.extensions.summarization_trigger_tokens
+            )
+        elif "trigger" in signature.parameters:
+            kwargs["trigger"] = ("tokens", config.extensions.summarization_trigger_tokens)
+    if config.extensions.summarization_keep_tokens is not None and "keep" in signature.parameters:
+        kwargs["keep"] = ("tokens", config.extensions.summarization_keep_tokens)
 
     try:
         middleware = SummarizationMiddleware(**kwargs)
@@ -525,6 +534,8 @@ class ExtensionsConfig:
     chainlit_reasoning_mode_enabled: bool = True
     chainlit_startup_status_enabled: bool = True
     summarization_middleware_enabled: bool = False
+    summarization_trigger_tokens: int | None = None
+    summarization_keep_tokens: int | None = None
 
     @property
     def enabled(self) -> bool:
@@ -740,9 +751,25 @@ def parse_extensions_config(raw_config: dict[str, Any], config_path: Path) -> Ex
         "summarization_middleware_enabled",
         False,
     )
+    raw_summarization_trigger_tokens = agent_section.get("summarization_trigger_tokens")
+    raw_summarization_keep_tokens = agent_section.get("summarization_keep_tokens")
     if not isinstance(raw_summarization_middleware_enabled, bool):
         raise ValueError(
             "The top-level 'agent.summarization_middleware_enabled' config must be a boolean."
+        )
+    if raw_summarization_trigger_tokens is not None and (
+        not isinstance(raw_summarization_trigger_tokens, int)
+        or raw_summarization_trigger_tokens <= 0
+    ):
+        raise ValueError(
+            "The top-level 'agent.summarization_trigger_tokens' config must be a positive integer."
+        )
+    if raw_summarization_keep_tokens is not None and (
+        not isinstance(raw_summarization_keep_tokens, int)
+        or raw_summarization_keep_tokens <= 0
+    ):
+        raise ValueError(
+            "The top-level 'agent.summarization_keep_tokens' config must be a positive integer."
         )
     skill_paths = tuple(
         normalize_skill_source_path(str(path_value), base_dir)
@@ -890,6 +917,8 @@ def parse_extensions_config(raw_config: dict[str, Any], config_path: Path) -> Ex
         chainlit_reasoning_mode_enabled=raw_reasoning_mode_enabled,
         chainlit_startup_status_enabled=raw_startup_status_enabled,
         summarization_middleware_enabled=raw_summarization_middleware_enabled,
+        summarization_trigger_tokens=raw_summarization_trigger_tokens,
+        summarization_keep_tokens=raw_summarization_keep_tokens,
     )
 
 
@@ -1261,12 +1290,14 @@ def build_graph_subagent_specs(
     *,
     include_async_subagents: bool,
 ) -> list[Any]:
-    middleware = build_agent_middleware(
-        config=config,
-        reasoning_level=config.default_reasoning,
-    )
     subagent_specs: list[Any] = [
-        subagent.to_deepagents_spec(middleware=middleware)
+        subagent.to_deepagents_spec(
+            middleware=build_agent_middleware(
+                config=config,
+                reasoning_level=config.default_reasoning,
+                model_name=subagent.model,
+            )
+        )
         for subagent in config.extensions.subagents
     ]
     if include_async_subagents:
@@ -1485,7 +1516,11 @@ class AgentRuntime:
                                 mcp_session_id=mcp_session_id,
                             ),
                         ),
-                        middleware=middleware,
+                        middleware=build_agent_middleware(
+                            config=self.config,
+                            reasoning_level=reasoning_level,
+                            model_name=subagent.model or selected_model,
+                        ),
                     )
                     for subagent in self.config.extensions.subagents
                 ]

--- a/tests/test_deepagent_runtime_rag.py
+++ b/tests/test_deepagent_runtime_rag.py
@@ -342,6 +342,46 @@ def test_get_agent_includes_rag_tool_when_ready(
     assert any(isinstance(item, ToolExecutionResilienceMiddleware) for item in middleware)
 
 
+def test_get_agent_includes_summarization_middleware_when_enabled(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_create_deep_agent(*, tools=None, **kwargs):
+        captured["tools"] = tools or []
+        captured["kwargs"] = kwargs
+        return object()
+
+    class FakeSummarizationMiddleware:
+        def __init__(self, **kwargs) -> None:
+            self.kwargs = kwargs
+
+    monkeypatch.setattr(deepagent_runtime, "create_deep_agent", fake_create_deep_agent)
+    monkeypatch.setattr(
+        "langchain.agents.middleware.SummarizationMiddleware",
+        FakeSummarizationMiddleware,
+    )
+
+    runtime = AgentRuntime(
+        make_runtime_config(
+            tmp_path,
+            extensions=ExtensionsConfig(
+                config_path=None,
+                summarization_middleware_enabled=True,
+            ),
+        )
+    )
+    runtime._store = InMemoryStore()
+    runtime._checkpointer = MemorySaver()
+
+    asyncio.run(runtime.get_agent("medium", thread_id="thread-1"))
+
+    middleware = captured["kwargs"]["middleware"]
+    assert any(isinstance(item, ToolExecutionResilienceMiddleware) for item in middleware)
+    assert any(isinstance(item, FakeSummarizationMiddleware) for item in middleware)
+
+
 def test_get_agent_omits_rag_tool_when_service_is_missing(
     tmp_path: Path,
     monkeypatch,
@@ -545,6 +585,43 @@ commands = [
     assert extensions.chainlit_model_mode_enabled is False
     assert extensions.chainlit_reasoning_mode_enabled is False
     assert extensions.chainlit_startup_status_enabled is False
+
+
+def test_load_extensions_config_parses_summarization_middleware_flag(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    config_path = tmp_path / "deepagent.toml"
+    config_path.write_text(
+        """
+[agent]
+summarization_middleware_enabled = true
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DEEPAGENT_CONFIG", str(config_path))
+
+    extensions = deepagent_runtime.load_extensions_config()
+
+    assert extensions.summarization_middleware_enabled is True
+
+
+def test_load_extensions_config_rejects_non_boolean_summarization_middleware_flag(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    config_path = tmp_path / "deepagent.toml"
+    config_path.write_text(
+        """
+[agent]
+summarization_middleware_enabled = "yes"
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DEEPAGENT_CONFIG", str(config_path))
+
+    with pytest.raises(ValueError, match="summarization_middleware_enabled"):
+        deepagent_runtime.load_extensions_config()
 
 
 def test_load_extensions_config_rejects_non_boolean_startup_status_flag(

--- a/tests/test_deepagent_runtime_rag.py
+++ b/tests/test_deepagent_runtime_rag.py
@@ -354,13 +354,21 @@ def test_get_agent_includes_summarization_middleware_when_enabled(
         return object()
 
     class FakeSummarizationMiddleware:
-        def __init__(self, **kwargs) -> None:
+        def __init__(self, model=None, trigger=None, keep=None, **kwargs) -> None:
+            self.model = model
+            self.trigger = trigger
+            self.keep = keep
             self.kwargs = kwargs
 
     monkeypatch.setattr(deepagent_runtime, "create_deep_agent", fake_create_deep_agent)
     monkeypatch.setattr(
         "langchain.agents.middleware.SummarizationMiddleware",
         FakeSummarizationMiddleware,
+    )
+    monkeypatch.setattr(
+        deepagent_runtime,
+        "build_model",
+        lambda *_args, model_name=None, **_kwargs: f"model::{model_name or 'default'}",
     )
 
     runtime = AgentRuntime(
@@ -369,6 +377,16 @@ def test_get_agent_includes_summarization_middleware_when_enabled(
             extensions=ExtensionsConfig(
                 config_path=None,
                 summarization_middleware_enabled=True,
+                summarization_trigger_tokens=5000,
+                summarization_keep_tokens=2000,
+                subagents=(
+                    SubagentConfig(
+                        name="repo-researcher",
+                        description="Researches the repo",
+                        system_prompt="Do research",
+                        model="gpt-oss:120b",
+                    ),
+                ),
             ),
         )
     )
@@ -379,7 +397,22 @@ def test_get_agent_includes_summarization_middleware_when_enabled(
 
     middleware = captured["kwargs"]["middleware"]
     assert any(isinstance(item, ToolExecutionResilienceMiddleware) for item in middleware)
-    assert any(isinstance(item, FakeSummarizationMiddleware) for item in middleware)
+    summarizers = [
+        item for item in middleware if isinstance(item, FakeSummarizationMiddleware)
+    ]
+    assert len(summarizers) == 1
+    assert summarizers[0].model == "model::gpt-oss:20b"
+    assert summarizers[0].trigger == ("tokens", 5000)
+    assert summarizers[0].keep == ("tokens", 2000)
+    subagent_specs = captured["kwargs"]["subagents"]
+    subagent_middleware = subagent_specs[0]["middleware"]
+    subagent_summarizers = [
+        item
+        for item in subagent_middleware
+        if isinstance(item, FakeSummarizationMiddleware)
+    ]
+    assert len(subagent_summarizers) == 1
+    assert subagent_summarizers[0].model == "model::gpt-oss:120b"
 
 
 def test_get_agent_omits_rag_tool_when_service_is_missing(
@@ -596,6 +629,8 @@ def test_load_extensions_config_parses_summarization_middleware_flag(
         """
 [agent]
 summarization_middleware_enabled = true
+summarization_trigger_tokens = 6000
+summarization_keep_tokens = 2400
 """.strip(),
         encoding="utf-8",
     )
@@ -604,6 +639,8 @@ summarization_middleware_enabled = true
     extensions = deepagent_runtime.load_extensions_config()
 
     assert extensions.summarization_middleware_enabled is True
+    assert extensions.summarization_trigger_tokens == 6000
+    assert extensions.summarization_keep_tokens == 2400
 
 
 def test_load_extensions_config_rejects_non_boolean_summarization_middleware_flag(
@@ -621,6 +658,25 @@ summarization_middleware_enabled = "yes"
     monkeypatch.setenv("DEEPAGENT_CONFIG", str(config_path))
 
     with pytest.raises(ValueError, match="summarization_middleware_enabled"):
+        deepagent_runtime.load_extensions_config()
+
+
+def test_load_extensions_config_rejects_invalid_summarization_token_thresholds(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    config_path = tmp_path / "deepagent.toml"
+    config_path.write_text(
+        """
+[agent]
+summarization_trigger_tokens = 0
+summarization_keep_tokens = "many"
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DEEPAGENT_CONFIG", str(config_path))
+
+    with pytest.raises(ValueError, match="summarization_trigger_tokens"):
         deepagent_runtime.load_extensions_config()
 
 


### PR DESCRIPTION
### Motivation
- Provide an opt-in way to add LangChain's summarization middleware to the main agent and sync subagents via configuration. 
- Keep existing behavior and resilience middleware unchanged while allowing projects to enable summarization when their LangChain version supports it. 

### Description
- Add `summarization_middleware_enabled` to `ExtensionsConfig` and parse `agent.summarization_middleware_enabled` with boolean validation in `parse_extensions_config` and `load_extensions_config`. 
- Implement `_build_summarization_middleware` which tries to import `langchain.agents.middleware.SummarizationMiddleware`, inspects its signature to pass a `model` when supported, and logs/ignores failures to preserve runtime robustness. 
- Replace the simple `build_agent_middleware()` with a new signature that accepts `config`, `reasoning_level`, and `model_name`, always includes `ToolExecutionResilienceMiddleware`, and conditionally appends the summarization middleware when enabled. 
- Wire middleware construction through graph and runtime creation (`create_configured_graph`, `build_graph_subagent_specs`, and `AgentRuntime.get_agent`) so the summarization middleware is created with the current model and reasoning context. 
- Add tests to cover middleware injection and config parsing/validation and update `deepagent.toml.example` and `README.md` to document the new `agent.summarization_middleware_enabled` option. 

### Testing
- Ran `uv run pytest tests/test_deepagent_runtime_rag.py -q`, which completed successfully (`27 passed, 1 warning`). 
- Ran the full test suite with `uv run pytest -q`, which completed successfully (`53 passed, 2 warnings`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0dad47afc83249d90b11a1f566232)