### PR TITLE
Retry MCP tool calls after closed-resource errors by refreshing session

### DIFF
--- a/deepagent_runtime.py
+++ b/deepagent_runtime.py
@@ -1642,7 +1642,36 @@ class AgentRuntime:
                 raise ValueError(
                     f"Command arguments for MCP tool '{tool_name}' must be valid JSON."
                 ) from None
-        return await selected_tool.ainvoke(parsed_args)
+        try:
+            return await selected_tool.ainvoke(parsed_args)
+        except Exception as exc:
+            if not self._is_closed_mcp_resource_error(exc):
+                raise
+            logger.info(
+                "MCP tool '%s' failed with closed resource; refreshing session and retrying once.",
+                tool_name,
+            )
+            await self._refresh_mcp_scope(
+                thread_id=thread_id,
+                mcp_session_id=mcp_session_id,
+            )
+            refreshed_tools = await self._get_mcp_tools(
+                candidate_servers,
+                thread_id=thread_id,
+                mcp_session_id=mcp_session_id,
+                refresh=True,
+            )
+            refreshed_tool = next(
+                (
+                    tool
+                    for tool in refreshed_tools
+                    if str(getattr(tool, "name", "")).strip() == tool_name
+                ),
+                None,
+            )
+            if refreshed_tool is None:
+                raise
+            return await refreshed_tool.ainvoke(parsed_args)
 
     def _sanitize_tools_for_model(self, tools: list[Any]) -> list[Any]:
         return sanitize_tools_for_model(self.config.model_provider, tools)
@@ -1709,6 +1738,7 @@ class AgentRuntime:
         *,
         thread_id: str | None = None,
         mcp_session_id: str | None = None,
+        refresh: bool = False,
     ) -> list[Any]:
         if not server_names or self._mcp_client is None:
             return []
@@ -1720,6 +1750,8 @@ class AgentRuntime:
         cache_key = (tool_scope, tuple(server_names))
 
         async with self._mcp_lock:
+            if refresh:
+                self._mcp_tools_cache.pop(cache_key, None)
             cached = self._mcp_tools_cache.get(cache_key)
             if cached is not None:
                 return list(cached)
@@ -1747,6 +1779,25 @@ class AgentRuntime:
 
             self._mcp_tools_cache[cache_key] = tools
             return list(tools)
+
+    async def _refresh_mcp_scope(
+        self,
+        *,
+        thread_id: str | None,
+        mcp_session_id: str | None,
+    ) -> None:
+        mcp_scope = self._mcp_scope(
+            mcp_session_id=mcp_session_id,
+            thread_id=thread_id,
+        )
+        if mcp_scope is None:
+            return
+        await self.close_mcp_session(mcp_scope)
+
+    @staticmethod
+    def _is_closed_mcp_resource_error(exc: Exception) -> bool:
+        message = str(exc).strip().lower()
+        return "closedresourceerror" in message or "resource is closed" in message
 
     async def _build_main_tools(
         self,


### PR DESCRIPTION
### Motivation
- Follow-up MCP tool calls in the same chat session were failing with `closedResourceError`/"resource is closed" due to stale stateful MCP sessions and cached tool objects.

### Description
- Added retry handling in `invoke_mcp_tool_command` to catch closed-resource failures, refresh the MCP session scope, reload tools, and retry the same tool once in `deepagent_runtime.py`.
- Extended `_get_mcp_tools` with a `refresh` flag to allow invalidating the `_mcp_tools_cache` and rebuilding tool objects on demand.
- Added `_refresh_mcp_scope` to close/reset the current stateful MCP scope and `_is_closed_mcp_resource_error` to detect closed-resource error messages.
- The retry path reloads tools for the candidate servers and attempts the tool invocation once more after refreshing state.

### Testing
- Ran `python -m py_compile deepagent_runtime.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f26a1503188324b6241460eb4a727f)