### PR TITLE
Keep MCP session open after Chainlit chat end

### DIFF
--- a/main.py
+++ b/main.py
@@ -994,9 +994,3 @@ async def on_chat_end() -> None:
     notifier = cl.user_session.get(SESSION_ASYNC_TASK_NOTIFIER_KEY)
     if isinstance(notifier, AsyncTaskNotifier):
         notifier.cancel()
-    runtime = AgentRuntime.current()
-    if runtime is not None:
-        with suppress(Exception):
-            await runtime.close_mcp_session(
-                cl.user_session.get(SESSION_MCP_SESSION_ID_KEY)
-            )


### PR DESCRIPTION
### Motivation
- Skill-driven responses in the Chainlit UI could trigger the `@cl.on_chat_end` handler which closed the stateful MCP session via `runtime.close_mcp_session(...)`, preventing follow-up turns from reusing the same MCP context.

### Description
- Removed the call to `runtime.close_mcp_session(...)` from the `@cl.on_chat_end` handler in `main.py`, so chat-end only cancels the async task notifier (`AsyncTaskNotifier`) and no longer tears down MCP sessions.

### Testing
- Ran `python -m py_compile main.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2751abe688324af3af6eb97483420)