### PR TITLE
Append configurable main-agent instruction from deepagent.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,7 @@ Supported subagent fields:
 
 Main `[agent]` additions:
 
+- `custom_instruction`: optional string appended to the **main/supervisor** agent system prompt. This setting does **not** get applied to separately configured prompts such as the `async_researcher` graph prompt.
 - `summarization_middleware_enabled`: optional boolean (default `false`) to add LangChain's summarization middleware to the main agent and sync subagents.
 - `summarization_trigger_tokens`: optional positive integer token threshold that triggers summarization when reached.
 - `summarization_keep_tokens`: optional positive integer token budget to keep in conversation history after summarization.

--- a/deepagent.toml.example
+++ b/deepagent.toml.example
@@ -30,6 +30,8 @@ url = "http://localhost:8000/mcp"
 # This directory should contain one or more skill folders, each with its own SKILL.md.
 skills = ["skills"]
 mcp_servers = ["repo"]
+# Optional instruction appended to the main agent system prompt.
+# custom_instruction = "Always ask clarifying questions before editing files."
 # Set true to add LangChain's SummarizationMiddleware to the main agent and sync subagents.
 summarization_middleware_enabled = false
 # Optional token thresholds used when the installed LangChain middleware supports them.

--- a/deepagent_runtime.py
+++ b/deepagent_runtime.py
@@ -1326,6 +1326,7 @@ def create_configured_graph(
     *,
     include_async_subagents: bool,
     system_prompt: str = SYSTEM_PROMPT,
+    apply_custom_instruction: bool = False,
 ) -> Any:
     config = RuntimeConfig.from_env()
     subagent_specs = build_graph_subagent_specs(
@@ -1348,7 +1349,11 @@ def create_configured_graph(
         system_prompt=compose_rag_system_prompt(
             compose_agent_system_prompt(
                 system_prompt,
-                config.extensions.custom_instruction,
+                (
+                    config.extensions.custom_instruction
+                    if apply_custom_instruction
+                    else None
+                ),
             ),
             rag_enabled=config.rag is not None,
         ),

--- a/deepagent_runtime.py
+++ b/deepagent_runtime.py
@@ -536,6 +536,7 @@ class ExtensionsConfig:
     summarization_middleware_enabled: bool = False
     summarization_trigger_tokens: int | None = None
     summarization_keep_tokens: int | None = None
+    custom_instruction: str | None = None
 
     @property
     def enabled(self) -> bool:
@@ -747,6 +748,7 @@ def parse_extensions_config(raw_config: dict[str, Any], config_path: Path) -> Ex
         mcp_servers[str(name)] = normalize_mcp_server_config(raw_server, base_dir)
 
     raw_skill_paths = agent_section.get("skills", [])
+    custom_instruction = normalize_optional_string(agent_section.get("custom_instruction"))
     raw_summarization_middleware_enabled = agent_section.get(
         "summarization_middleware_enabled",
         False,
@@ -919,6 +921,18 @@ def parse_extensions_config(raw_config: dict[str, Any], config_path: Path) -> Ex
         summarization_middleware_enabled=raw_summarization_middleware_enabled,
         summarization_trigger_tokens=raw_summarization_trigger_tokens,
         summarization_keep_tokens=raw_summarization_keep_tokens,
+        custom_instruction=custom_instruction,
+    )
+
+
+def compose_agent_system_prompt(base_prompt: str, custom_instruction: str | None) -> str:
+    instruction = (custom_instruction or "").strip()
+    if not instruction:
+        return base_prompt
+    return (
+        f"{base_prompt}\n\n"
+        "Custom user instruction from [agent].custom_instruction in deepagent.toml:\n"
+        f"{instruction}"
     )
 
 
@@ -1332,7 +1346,10 @@ def create_configured_graph(
         model=build_model(config, config.default_reasoning),
         tools=sanitize_tools_for_model(config.model_provider, tools) or None,
         system_prompt=compose_rag_system_prompt(
-            system_prompt,
+            compose_agent_system_prompt(
+                system_prompt,
+                config.extensions.custom_instruction,
+            ),
             rag_enabled=config.rag is not None,
         ),
         middleware=build_agent_middleware(
@@ -1534,7 +1551,10 @@ class AgentRuntime:
                     model=model,
                     tools=main_tools or None,
                     system_prompt=compose_rag_system_prompt(
-                        SYSTEM_PROMPT,
+                        compose_agent_system_prompt(
+                            SYSTEM_PROMPT,
+                            self.config.extensions.custom_instruction,
+                        ),
                         rag_enabled=rag_tool_enabled,
                     ),
                     middleware=middleware,

--- a/langgraph_app.py
+++ b/langgraph_app.py
@@ -18,6 +18,7 @@ findings with concrete file paths or sources when relevant.
 supervisor = create_configured_graph(
     include_async_subagents=True,
     system_prompt=SYSTEM_PROMPT,
+    apply_custom_instruction=True,
 )
 
 async_researcher = create_configured_graph(


### PR DESCRIPTION
### Motivation
- Allow runtime configuration to append a user-provided instruction to the main agent system prompt so projects can enforce workspace-specific guidance via `deepagent.toml`.
- Ensure the custom instruction is applied consistently both for graph creation and when instantiating the runtime agent so behavior is predictable across startup paths.

### Description
- Add `custom_instruction: str | None` to `ExtensionsConfig` and parse `agent.custom_instruction` in `parse_extensions_config` so the value flows from the TOML into runtime config.
- Introduce `compose_agent_system_prompt(base_prompt, custom_instruction)` to append the non-empty custom instruction to the base system prompt.
- Wire the composed prompt into `create_configured_graph` and the agent creation path in `AgentRuntime` so the instruction is applied for configured graphs and live agents.
- Document the new optional setting in `deepagent.toml.example` under the `[agent]` section.

### Testing
- Ran `python -m compileall deepagent_runtime.py` and the file compiled successfully.
- No additional automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3aa2b76a8832483af522fd5f34b19)