### PR TITLE
Throttle rapid final response streaming in Chainlit

### DIFF
--- a/chainlit_bridge.py
+++ b/chainlit_bridge.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import ast
 import json
+import time
 import tomllib
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -14,6 +15,8 @@ from chainlit.utils import utc_now
 from response_exports import attach_response_export_actions
 
 DEFAULT_AUTO_COLLAPSE_DELAY_SECONDS = 3.0
+RESPONSE_STREAM_FLUSH_INTERVAL_SECONDS = 0.05
+RESPONSE_STREAM_FLUSH_CHARS = 1024
 CHAINLIT_APP_CONFIG_PATH = Path(__file__).resolve().parent / "chainlit.toml"
 
 
@@ -417,6 +420,11 @@ class RunTaskList:
             return
         self._finish_running_reasoning()
         response_for_id = for_id or self.response_for_id
+        response_task = self.tasks_by_key.get(self.RESPONSE_KEY)
+        if response_task is not None and response_task.status == cl.TaskStatus.RUNNING:
+            if response_for_id is not None:
+                response_task.forId = response_for_id
+            return
         self._ensure_task(
             self.RESPONSE_KEY,
             "final response",
@@ -541,6 +549,9 @@ class ChainlitEventBridge:
         self.run_task_list = run_task_list
         self.response_message: cl.Message | None = None
         self.response_buffer = ""
+        self.pending_response_stream = ""
+        self.response_task_started = False
+        self.last_response_flush_at = 0.0
         self.response_streamed_from_messages = False
         self.reasoning_steps: dict[str, cl.Step] = {}
         self.reasoning_buffers: dict[str, str] = {}
@@ -562,6 +573,7 @@ class ChainlitEventBridge:
             await self._handle_update_chunk(part)
 
     async def finish(self) -> None:
+        await self._flush_response_stream()
         await self._close_all_open_steps()
         if self.response_message is not None:
             attach_response_export_actions(
@@ -666,13 +678,38 @@ class ChainlitEventBridge:
         delta = text[len(self.response_buffer) :] if text.startswith(self.response_buffer) else text
         if not delta:
             return
-        if self.run_task_list is not None and self.response_message is not None:
+        if (
+            not self.response_task_started
+            and self.run_task_list is not None
+            and self.response_message is not None
+        ):
             await self.run_task_list.mark_response_started(
                 for_id=getattr(self.response_message, "id", None)
             )
-        if self.response_message is not None:
-            await self.response_message.stream_token(delta)
+            self.response_task_started = True
         self.response_buffer += delta
+        self.pending_response_stream += delta
+        if self._should_flush_response_stream():
+            await self._flush_response_stream()
+
+    def _should_flush_response_stream(self) -> bool:
+        if len(self.pending_response_stream) >= RESPONSE_STREAM_FLUSH_CHARS:
+            return True
+        if not self.last_response_flush_at:
+            return True
+        return (
+            time.monotonic() - self.last_response_flush_at
+            >= RESPONSE_STREAM_FLUSH_INTERVAL_SECONDS
+        )
+
+    async def _flush_response_stream(self) -> None:
+        if not self.pending_response_stream:
+            return
+        pending = self.pending_response_stream
+        if self.response_message is not None:
+            await self.response_message.stream_token(pending)
+        self.pending_response_stream = ""
+        self.last_response_flush_at = time.monotonic()
 
     async def _stream_tool_call(self, source: str, chunk: dict[str, Any]) -> None:
         call_id = str(chunk.get("id") or f"{source}:{chunk.get('index', '0')}")

--- a/tests/test_chainlit_bridge_streaming.py
+++ b/tests/test_chainlit_bridge_streaming.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import pytest
+
+import chainlit_bridge
+from chainlit_bridge import ChainlitEventBridge, RunTaskList
+
+
+class _TaskStatus:
+    RUNNING = "running"
+    DONE = "done"
+    FAILED = "failed"
+    READY = "ready"
+
+
+class _Task:
+    def __init__(self, title: str, status: str, forId: str | None = None) -> None:
+        self.title = title
+        self.status = status
+        self.forId = forId
+
+
+class _TaskList:
+    def __init__(self) -> None:
+        self.status = "Ready"
+        self.tasks: list[_Task] = []
+        self.send_count = 0
+
+    async def send(self) -> None:
+        self.send_count += 1
+
+
+class _ResponseMessage:
+    id = "message-1"
+
+    def __init__(self) -> None:
+        self.tokens: list[str] = []
+        self.update_count = 0
+
+    async def stream_token(self, token: str) -> None:
+        self.tokens.append(token)
+
+    async def update(self) -> None:
+        self.update_count += 1
+
+
+@pytest.fixture(autouse=True)
+def _patch_chainlit_tasks(monkeypatch) -> None:
+    monkeypatch.setattr(chainlit_bridge.cl, "TaskStatus", _TaskStatus)
+    monkeypatch.setattr(chainlit_bridge.cl, "Task", _Task)
+
+
+@pytest.mark.anyio
+async def test_response_task_starts_once_for_rapid_response_tokens() -> None:
+    task_list = _TaskList()
+    run_task_list = RunTaskList(task_list)  # type: ignore[arg-type]
+
+    await run_task_list.start(response_for_id="message-1")
+    await run_task_list.mark_response_started(for_id="message-1")
+    await run_task_list.mark_response_started(for_id="message-1")
+    await run_task_list.mark_response_started(for_id="message-1")
+
+    assert task_list.send_count == 2
+    assert [task.title for task in task_list.tasks] == [
+        "main-agent reasoning",
+        "final response",
+    ]
+    assert task_list.tasks[-1].status == _TaskStatus.RUNNING
+
+
+@pytest.mark.anyio
+async def test_response_stream_batches_fast_chunks_until_finish(monkeypatch) -> None:
+    response_message = _ResponseMessage()
+    bridge = ChainlitEventBridge(prompt="hello")
+    bridge.response_message = response_message  # type: ignore[assignment]
+
+    monkeypatch.setattr(chainlit_bridge.time, "monotonic", lambda: 100.0)
+    monkeypatch.setattr(
+        chainlit_bridge,
+        "attach_response_export_actions",
+        lambda *args, **kwargs: None,
+    )
+
+    await bridge._stream_response("A")
+    await bridge._stream_response("B")
+    await bridge._stream_response("C")
+
+    assert response_message.tokens == ["A"]
+    assert bridge.response_buffer == "ABC"
+
+    await bridge.finish()
+
+    assert response_message.tokens == ["A", "BC"]
+    assert response_message.update_count == 1


### PR DESCRIPTION
**Summary**
- Prevent repeated task-list updates while the final assistant response is streaming.
- Batch rapid response chunks before flushing them to Chainlit.
- Flush any pending response text before final message export actions are attached.
- Add regression coverage for bursty response streaming and task-list behavior.

**Testing**
- Added focused unit tests for response-task idempotence and buffered streaming.
- Full test suite passed locally (`56 passed`).