### PR TITLE
Switch Chainlit streaming to astream_events and raise recursion limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ export DEEPAGENT_MODEL_PROVIDER="ollama"
 export DEEPAGENT_MODEL_BASE_URL="http://127.0.0.1:11434"
 export DEEPAGENT_MODEL_NAME="gpt-oss:20b"
 export DEEPAGENT_MODEL_REASONING="medium"
+export DEEPAGENT_RECURSION_LIMIT="200"
 # export DEEPAGENT_MODEL_API_KEY="optional-for-secured-openai-compatible-servers"
 export DEEPAGENT_CONFIG="deepagent.toml"
 export CHAINLIT_AUTH_SECRET="replace-with-a-long-random-string"
@@ -46,6 +47,12 @@ export CHAINLIT_AUTH_PASSWORD="change-me"
 - they override the matching `[model]` values in `deepagent.toml`
 - `DEEPAGENT_MODEL_API_KEY` is only needed for secured OpenAI-compatible servers
 - `OLLAMA_BASE_URL`, `OLLAMA_MODEL`, and `OLLAMA_REASONING` remain supported as Ollama-only compatibility aliases
+
+`DEEPAGENT_RECURSION_LIMIT` is optional:
+
+- it overrides `[agent].recursion_limit` in `deepagent.toml`
+- it controls the maximum LangGraph steps for a single agent run
+- raise it when long tool-heavy Deep Agent runs hit `GraphRecursionError`
 
 `CHAINLIT_AUTH_SECRET`, `CHAINLIT_AUTH_USERNAME`, and `CHAINLIT_AUTH_PASSWORD` are optional:
 
@@ -122,6 +129,7 @@ ollama pull nomic-embed-text
 This repo now includes a live [deepagent.toml](deepagent.toml) with:
 
 - model defaults for provider, base URL, model name, and reasoning effort
+- a higher LangGraph recursion limit for longer tool-heavy Deep Agent runs
 - a real `repo` MCP server pinned to `npx @modelcontextprotocol/server-filesystem@2025.8.21`
 - a `repo-researcher` subagent using [prompts/repo-researcher.md](prompts/repo-researcher.md)
 - the repo-local `skills/` source for both the main agent and the subagent
@@ -172,6 +180,24 @@ Notes:
 - `reasoning_effort` sets the default Chainlit reasoning level for new chats. Ollama uses that level directly; OpenAI-compatible servers may ignore it.
 - `DEEPAGENT_MODEL_PROVIDER`, `DEEPAGENT_MODEL_BASE_URL`, `DEEPAGENT_MODEL_NAME`, `DEEPAGENT_MODEL_API_KEY`, and `DEEPAGENT_MODEL_REASONING` override the TOML defaults when set.
 - `OLLAMA_BASE_URL`, `OLLAMA_MODEL`, and `OLLAMA_REASONING` still work as Ollama-only compatibility aliases.
+
+## Agent Runtime Config
+
+The `[agent]` table configures main-agent runtime behavior:
+
+```toml
+[agent]
+recursion_limit = 200
+skills = ["skills"]
+mcp_servers = ["repo"]
+```
+
+Notes:
+
+- `recursion_limit` is the LangGraph step limit for one agent run.
+- The built-in default is `100`; this repo's `deepagent.toml` sets it to `200`.
+- `DEEPAGENT_RECURSION_LIMIT` overrides this value when set.
+- Increase it for long tool-heavy runs that hit `GraphRecursionError`; lower it if you want runaway loops to stop sooner.
 
 ## Optional: Enable Workspace Docs RAG
 
@@ -286,6 +312,7 @@ args = ["-y", "@modelcontextprotocol/server-filesystem@2025.8.21", "."]
 cwd = "."
 
 [agent]
+recursion_limit = 200
 skills = ["skills"]
 mcp_servers = ["repo"]
 summarization_middleware_enabled = false
@@ -323,6 +350,7 @@ Supported subagent fields:
 
 Main `[agent]` additions:
 
+- `recursion_limit`: optional positive integer LangGraph step limit for a single agent run. Defaults to `100` unless overridden by `DEEPAGENT_RECURSION_LIMIT`.
 - `custom_instruction`: optional string appended to the **main/supervisor** agent system prompt. This setting does **not** get applied to separately configured prompts such as the `async_researcher` graph prompt.
 - `summarization_middleware_enabled`: optional boolean (default `false`) to add LangChain's summarization middleware to the main agent and sync subagents.
 - `summarization_trigger_tokens`: optional positive integer token threshold that triggers summarization when reached.

--- a/chainlit_bridge.py
+++ b/chainlit_bridge.py
@@ -18,6 +18,15 @@ DEFAULT_AUTO_COLLAPSE_DELAY_SECONDS = 3.0
 RESPONSE_STREAM_FLUSH_INTERVAL_SECONDS = 0.05
 RESPONSE_STREAM_FLUSH_CHARS = 1024
 CHAINLIT_APP_CONFIG_PATH = Path(__file__).resolve().parent / "chainlit.toml"
+LANGGRAPH_STREAM_MODES = {
+    "values",
+    "updates",
+    "custom",
+    "messages",
+    "checkpoints",
+    "tasks",
+    "debug",
+}
 
 
 def load_auto_collapse_delay_seconds() -> float:
@@ -97,6 +106,42 @@ def namespace_label(ns: tuple[str, ...], metadata: dict[str, Any]) -> str:
             continue
         labels.append(segment.split(":", 1)[0])
     return " / ".join(labels)
+
+
+def langgraph_part_from_event_chunk(chunk: Any) -> dict[str, Any] | None:
+    if isinstance(chunk, dict):
+        mode = chunk.get("type")
+        if isinstance(mode, str) and mode in LANGGRAPH_STREAM_MODES and "data" in chunk:
+            return chunk
+        return None
+
+    if not isinstance(chunk, tuple):
+        return None
+
+    if len(chunk) == 3:
+        ns, mode, data = chunk
+    elif len(chunk) == 2:
+        first, data = chunk
+        if isinstance(first, tuple):
+            ns = first
+            mode = "values"
+        else:
+            ns = ()
+            mode = first
+    else:
+        return None
+
+    if not isinstance(mode, str) or mode not in LANGGRAPH_STREAM_MODES:
+        return None
+
+    if isinstance(ns, tuple):
+        namespace = ns
+    elif ns in (None, ""):
+        namespace = ()
+    else:
+        return None
+
+    return {"type": mode, "ns": namespace, "data": data}
 
 
 def reasoning_text_from_token(token: Any) -> str:
@@ -571,6 +616,22 @@ class ChainlitEventBridge:
             return
         if kind == "updates":
             await self._handle_update_chunk(part)
+
+    async def handle_event(self, event: dict[str, Any]) -> None:
+        if event.get("event") != "on_chain_stream":
+            return
+        if event.get("parent_ids"):
+            return
+
+        data = event.get("data")
+        if not isinstance(data, dict):
+            return
+
+        part = langgraph_part_from_event_chunk(data.get("chunk"))
+        if part is None:
+            return
+
+        await self.handle_part(part)
 
     async def finish(self) -> None:
         await self._flush_response_stream()

--- a/deepagent.toml
+++ b/deepagent.toml
@@ -36,6 +36,7 @@ args = ["-y", "@modelcontextprotocol/server-filesystem@2025.8.21", "."]
 cwd = "."
 
 [agent]
+recursion_limit = 200
 skills = ["skills"]
 mcp_servers = ["repo"]
 

--- a/deepagent_runtime.py
+++ b/deepagent_runtime.py
@@ -59,6 +59,7 @@ DEFAULT_OLLAMA_BASE_URL = "http://127.0.0.1:11434"
 DEFAULT_REASONING_LEVEL: ReasoningLevel = "medium"
 DEFAULT_TEMPERATURE = 0.0
 DEFAULT_EXTENSIONS_CONFIG = "deepagent.toml"
+DEFAULT_RECURSION_LIMIT = 100
 PROJECT_ROOT = Path(__file__).resolve().parent
 DEEPAGENT_ARTIFACTS_DIRECTORY = Path(".files/deepagent")
 logger = logging.getLogger(__name__)
@@ -153,6 +154,25 @@ def normalize_model_temperature(value: Any | None) -> float:
     if not math.isfinite(temperature):
         return DEFAULT_TEMPERATURE
     return temperature
+
+
+def normalize_recursion_limit(
+    value: Any | None,
+    *,
+    default: int = DEFAULT_RECURSION_LIMIT,
+    field_name: str = "recursion_limit",
+) -> int:
+    if value is None or str(value).strip() == "":
+        return default
+
+    try:
+        recursion_limit = int(str(value).strip())
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{field_name} must be a positive integer.") from exc
+
+    if recursion_limit <= 0:
+        raise ValueError(f"{field_name} must be a positive integer.")
+    return recursion_limit
 
 
 def normalize_model_base_url(
@@ -524,6 +544,7 @@ class ExtensionsConfig:
     config_path: Path | None
     mcp_tool_name_prefix: bool = True
     mcp_stateful: bool = False
+    recursion_limit: int = DEFAULT_RECURSION_LIMIT
     mcp_servers: dict[str, dict[str, Any]] | None = None
     skills: tuple[str, ...] = ()
     agent_mcp_servers: tuple[str, ...] = ()
@@ -740,6 +761,10 @@ def parse_extensions_config(raw_config: dict[str, Any], config_path: Path) -> Ex
     if agent_section and not isinstance(agent_section, dict):
         raise ValueError("The top-level 'agent' config must be a table/object.")
 
+    recursion_limit = normalize_recursion_limit(
+        agent_section.get("recursion_limit"),
+        field_name="The top-level 'agent.recursion_limit' config",
+    )
     raw_mcp_servers = mcp_section.get("servers", {})
     mcp_servers: dict[str, dict[str, Any]] = {}
     for name, raw_server in raw_mcp_servers.items():
@@ -909,6 +934,7 @@ def parse_extensions_config(raw_config: dict[str, Any], config_path: Path) -> Ex
         config_path=config_path,
         mcp_tool_name_prefix=bool(mcp_section.get("tool_name_prefix", True)),
         mcp_stateful=bool(mcp_section.get("stateful", False)),
+        recursion_limit=recursion_limit,
         mcp_servers=mcp_servers or None,
         skills=skill_paths,
         agent_mcp_servers=raw_agent_mcp_servers,
@@ -973,6 +999,7 @@ class RuntimeConfig:
     default_reasoning: ReasoningLevel
     persistence_mode: PersistenceMode
     extensions: ExtensionsConfig
+    recursion_limit: int = DEFAULT_RECURSION_LIMIT
     rag_requested: bool = False
     rag: ResolvedRagConfig | None = None
     rag_error: str | None = None
@@ -1042,6 +1069,11 @@ class RuntimeConfig:
             generic_model_reasoning or model_reasoning_alias,
             default=model_defaults.reasoning_effort,
         )
+        recursion_limit = normalize_recursion_limit(
+            os.getenv("DEEPAGENT_RECURSION_LIMIT"),
+            default=file_config.extensions.recursion_limit,
+            field_name="DEEPAGENT_RECURSION_LIMIT",
+        )
         rag_requested = file_config.rag.enabled
         rag = None
         rag_error = None
@@ -1066,6 +1098,7 @@ class RuntimeConfig:
             default_reasoning=default_reasoning,
             persistence_mode="postgres" if database_url else "memory",
             extensions=file_config.extensions,
+            recursion_limit=recursion_limit,
             rag_requested=rag_requested,
             rag=rag,
             rag_error=rag_error,

--- a/main.py
+++ b/main.py
@@ -115,6 +115,13 @@ def store_settings(settings: AppSettings) -> None:
     cl.user_session.set(SESSION_SETTINGS_KEY, settings_payload(settings))
 
 
+def build_langgraph_config(settings: AppSettings, *, recursion_limit: int) -> dict[str, Any]:
+    return {
+        "configurable": {"thread_id": settings.thread_id},
+        "recursion_limit": recursion_limit,
+    }
+
+
 def build_rag_action() -> cl.Action:
     return cl.Action(
         name=REBUILD_RAG_INDEX_ACTION,
@@ -944,7 +951,10 @@ async def on_message(message: cl.Message) -> None:
     bridge = ChainlitEventBridge(prompt=message.content, run_task_list=run_task_list)
     await bridge.start()
 
-    config = {"configurable": {"thread_id": settings.thread_id}}
+    config = build_langgraph_config(
+        settings,
+        recursion_limit=runtime.config.recursion_limit,
+    )
     payload = {
         "messages": [
             {
@@ -953,12 +963,12 @@ async def on_message(message: cl.Message) -> None:
             }
         ]
     }
-    stream = agent.astream(
+    stream = agent.astream_events(
         payload,
         config=config,
+        version="v2",
         stream_mode=["messages", "updates"],
         subgraphs=True,
-        version="v2",
     )
 
     try:
@@ -967,7 +977,7 @@ async def on_message(message: cl.Message) -> None:
                 part = await anext(stream)
             except StopAsyncIteration:
                 break
-            await bridge.handle_part(part)
+            await bridge.handle_event(part)
     except asyncio.CancelledError:
         with suppress(Exception):
             await stream.aclose()

--- a/tests/test_chainlit_bridge_streaming.py
+++ b/tests/test_chainlit_bridge_streaming.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 
 import chainlit_bridge
@@ -92,3 +94,74 @@ async def test_response_stream_batches_fast_chunks_until_finish(monkeypatch) -> 
 
     assert response_message.tokens == ["A", "BC"]
     assert response_message.update_count == 1
+
+
+@pytest.mark.anyio
+async def test_astream_events_chain_stream_tuple_chunk_is_normalized() -> None:
+    bridge = ChainlitEventBridge(prompt="hello")
+    handled_parts: list[dict[str, Any]] = []
+
+    async def handle_part(part: dict[str, Any]) -> None:
+        handled_parts.append(part)
+
+    bridge.handle_part = handle_part  # type: ignore[method-assign]
+
+    await bridge.handle_event(
+        {
+            "event": "on_chain_stream",
+            "data": {
+                "chunk": (
+                    ("tools:abc",),
+                    "updates",
+                    {"tools": {"messages": []}},
+                ),
+            },
+        }
+    )
+
+    assert handled_parts == [
+        {
+            "type": "updates",
+            "ns": ("tools:abc",),
+            "data": {"tools": {"messages": []}},
+        }
+    ]
+
+
+@pytest.mark.anyio
+async def test_astream_events_ignores_non_langgraph_stream_chunks() -> None:
+    bridge = ChainlitEventBridge(prompt="hello")
+    handled_parts: list[dict[str, Any]] = []
+
+    async def handle_part(part: dict[str, Any]) -> None:
+        handled_parts.append(part)
+
+    bridge.handle_part = handle_part  # type: ignore[method-assign]
+
+    await bridge.handle_event(
+        {
+            "event": "on_chat_model_stream",
+            "data": {"chunk": "hello"},
+        }
+    )
+    await bridge.handle_event(
+        {
+            "event": "on_chain_stream",
+            "data": {"chunk": {"output": "not a LangGraph stream part"}},
+        }
+    )
+    await bridge.handle_event(
+        {
+            "event": "on_chain_stream",
+            "parent_ids": ["root-run-id"],
+            "data": {
+                "chunk": (
+                    (),
+                    "messages",
+                    ("duplicate nested token", {}),
+                ),
+            },
+        }
+    )
+
+    assert handled_parts == []

--- a/tests/test_deepagent_runtime_rag.py
+++ b/tests/test_deepagent_runtime_rag.py
@@ -208,6 +208,47 @@ models = ["gpt-oss:20b", "gemma4:27b"]
     assert config.model_choices == ("gpt-oss:20b", "gemma4:27b")
 
 
+def test_runtime_config_reads_recursion_limit_from_toml(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    config_path = tmp_path / "deepagent.toml"
+    config_path.write_text(
+        """
+[agent]
+recursion_limit = 64
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DEEPAGENT_CONFIG", str(config_path))
+    monkeypatch.delenv("DEEPAGENT_RECURSION_LIMIT", raising=False)
+
+    config = deepagent_runtime.RuntimeConfig.from_env()
+
+    assert config.recursion_limit == 64
+    assert config.extensions.recursion_limit == 64
+
+
+def test_runtime_config_env_overrides_recursion_limit(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    config_path = tmp_path / "deepagent.toml"
+    config_path.write_text(
+        """
+[agent]
+recursion_limit = 64
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DEEPAGENT_CONFIG", str(config_path))
+    monkeypatch.setenv("DEEPAGENT_RECURSION_LIMIT", "88")
+
+    config = deepagent_runtime.RuntimeConfig.from_env()
+
+    assert config.recursion_limit == 88
+
+
 def test_build_deepagent_backend_stores_large_tool_results_inside_project(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_main_native_commands.py
+++ b/tests/test_main_native_commands.py
@@ -119,6 +119,17 @@ def test_resolve_model_name_for_message_ignores_override_when_disabled() -> None
     assert resolved == "gpt-oss:20b"
 
 
+def test_build_langgraph_config_includes_recursion_limit() -> None:
+    settings = SimpleNamespace(thread_id="thread-1")
+
+    config = main.build_langgraph_config(settings, recursion_limit=100)
+
+    assert config == {
+        "configurable": {"thread_id": "thread-1"},
+        "recursion_limit": 100,
+    }
+
+
 @pytest.mark.anyio
 async def test_publish_modes_ignores_missing_modes_column_error(monkeypatch) -> None:
     class _Emitter:


### PR DESCRIPTION
## Summary
- switch the Chainlit runtime to `astream_events` while keeping the existing bridge logic for LangGraph stream chunks
- add a configurable LangGraph `recursion_limit` path through `deepagent.toml`, `RuntimeConfig`, and the Chat / env overrides
- set the repo default recursion limit to `200` and document it in the README
- add bridge and runtime tests for event normalization and config parsing

## Testing
- `uv run pytest`