### PR TITLE
Add a standalone CLI for running the agent without Chainlit

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,27 @@ Start the Chainlit app:
 chainlit run main.py -w
 ```
 
+Run the same underlying agent from a terminal without the Chainlit UI:
+
+```bash
+uv run chainagents --prompt "Summarize this repository" --thread-id cli
+```
+
+Useful CLI examples:
+
+```bash
+uv run chainagents --status --no-rag
+uv run chainagents --list-commands
+uv run chainagents --command ask-researcher --prompt "Find the config entrypoints"
+uv run chainagents --stdin --model gemma4:26b --reasoning high < prompt.txt
+uv run chainagents --rebuild-rag
+uv run chainagents --upload-rag notes.md --prompt "Use my uploaded notes"
+```
+
+Run `uv run chainagents --help` for all runtime flags, including model provider,
+base URL, API key, temperature, persistence, MCP session scope, async subagent
+URL, RAG controls, streaming, reasoning traces, tool traces, and JSON output.
+
 ## Model Config
 
 You can keep the model defaults in `deepagent.toml`:

--- a/agent_commands.py
+++ b/agent_commands.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any, Literal, NamedTuple
+
+
+class ParsedNativeCommand(NamedTuple):
+    command_name: str
+    raw_args: str
+
+
+@dataclass(frozen=True)
+class RuntimeCommandResult:
+    target: Literal["unknown", "prompt", "mcp_tool"]
+    command_name: str
+    description: str = ""
+    prompt: str | None = None
+    tool_result: Any = None
+
+
+def parse_native_command(raw_text: str) -> ParsedNativeCommand | None:
+    text = raw_text.strip()
+    if not text.startswith("/"):
+        return None
+    tokens = text[1:].split(None, 1)
+    if not tokens:
+        return None
+    return ParsedNativeCommand(
+        command_name=tokens[0].strip().lower(),
+        raw_args=tokens[1].strip() if len(tokens) > 1 else "",
+    )
+
+
+def resolve_native_command(
+    *,
+    raw_text: str,
+    selected_command: str | None = None,
+) -> ParsedNativeCommand | None:
+    parsed = parse_native_command(raw_text)
+    if parsed is not None:
+        return parsed
+
+    command_name = str(selected_command or "").strip().lstrip("/").lower()
+    if not command_name:
+        return None
+
+    return ParsedNativeCommand(
+        command_name=command_name,
+        raw_args=raw_text.strip(),
+    )
+
+
+def apply_native_template(template: str | None, raw_args: str) -> str:
+    if template is None:
+        return raw_args.strip()
+    return template.replace("{input}", raw_args.strip()).strip()
+
+
+def build_skill_command_prompt(*, skill_name: str, skill_path: str, raw_args: str) -> str:
+    prelude = (
+        f"Use the configured `{skill_name}` skill for this request.\n"
+        f"Read `{skill_path}` before taking any other action and follow it for this entire turn.\n"
+        "Skill usage is mandatory for this request.\n"
+    )
+    request = raw_args.strip()
+    if request:
+        return (
+            f"{prelude}\n"
+            "After reading the skill, complete the user's request below.\n\n"
+            f"User request:\n{request}"
+        ).strip()
+    return (
+        f"{prelude}\n"
+        "After reading the skill, briefly explain what it does and ask the user for the specific task."
+    ).strip()
+
+
+async def resolve_runtime_command(
+    *,
+    runtime: Any,
+    parsed: ParsedNativeCommand,
+    thread_id: str,
+    mcp_session_id: str | None = None,
+) -> RuntimeCommandResult:
+    command = runtime.resolve_chainlit_command(parsed.command_name)
+    if command is None:
+        return RuntimeCommandResult(
+            target="unknown",
+            command_name=parsed.command_name,
+        )
+
+    if command.target == "skill":
+        return RuntimeCommandResult(
+            target="prompt",
+            command_name=command.name,
+            description=command.description,
+            prompt=build_skill_command_prompt(
+                skill_name=command.name,
+                skill_path=command.value,
+                raw_args=parsed.raw_args,
+            ),
+        )
+
+    if command.target == "mcp_tool":
+        tool_raw_args = apply_native_template(command.template, parsed.raw_args)
+        result = await runtime.invoke_mcp_tool_command(
+            tool_name=command.value,
+            raw_args=tool_raw_args,
+            thread_id=thread_id,
+            mcp_session_id=mcp_session_id,
+            server_name=command.mcp_server,
+        )
+        return RuntimeCommandResult(
+            target="mcp_tool",
+            command_name=command.name,
+            description=command.description,
+            tool_result=result,
+        )
+
+    transformed = apply_native_template(command.template, parsed.raw_args)
+    if command.target == "prompt":
+        prompt = transformed or command.value
+    else:
+        prompt = (
+            f"Delegate this request to the configured `{command.value}` subagent.\n\n"
+            f"Command: `/{command.name}`\n"
+            f"Description: {command.description}\n\n"
+            f"User request:\n{transformed or parsed.raw_args or command.value}"
+        ).strip()
+
+    return RuntimeCommandResult(
+        target="prompt",
+        command_name=command.name,
+        description=command.description,
+        prompt=prompt,
+    )
+
+
+def dumps_tool_result(value: Any) -> str:
+    return json.dumps(value, indent=2, sort_keys=True, ensure_ascii=True, default=str)

--- a/chainagents_cli.py
+++ b/chainagents_cli.py
@@ -736,21 +736,25 @@ async def ingest_uploads(
     stdout: TextIO,
     stderr: TextIO,
     json_output: bool,
-) -> bool:
+) -> RagUploadResult | None:
     if not paths:
-        return True
+        return None
 
     uploads: list[UploadedRagFile] = []
     for raw_path in paths:
         path = Path(raw_path).expanduser().resolve()
         if not path.exists() or not path.is_file():
             print(f"upload-rag: file does not exist: {path}", file=stderr)
-            return False
+            return RagUploadResult(
+                thread_id=thread_id,
+                success=False,
+                reason=f"file does not exist: {path}",
+            )
         uploads.append(UploadedRagFile(path=path, name=path.name))
 
     result = await runtime.ingest_rag_uploads(thread_id=thread_id, uploads=uploads)
     print_upload_result(result, stdout=stdout, json_output=json_output)
-    return result.reason is None
+    return result
 
 
 async def run_agent_prompt(
@@ -760,7 +764,8 @@ async def run_agent_prompt(
     prompt: str,
     stdout: TextIO,
     stderr: TextIO,
-) -> int:
+    emit_json: bool = True,
+) -> int | dict[str, Any]:
     thread_id = str(args.thread_id or DEFAULT_CLI_THREAD_ID).strip() or DEFAULT_CLI_THREAD_ID
     reasoning_level: ReasoningLevel = normalize_reasoning_level(
         args.reasoning,
@@ -860,19 +865,16 @@ async def run_agent_prompt(
 
     response = renderer.finish()
     if args.json_output:
-        print(
-            json.dumps(
-                {
-                    "response": response,
-                    "thread_id": settings.thread_id,
-                    "model": settings.model_name,
-                    "reasoning": settings.reasoning_level,
-                },
-                indent=2,
-                sort_keys=True,
-            ),
-            file=stdout,
-        )
+        payload = {
+            "response": response,
+            "thread_id": settings.thread_id,
+            "model": settings.model_name,
+            "reasoning": settings.reasoning_level,
+        }
+        if emit_json:
+            print(json.dumps(payload, indent=2, sort_keys=True), file=stdout)
+            return 0
+        return {"prompt": payload}
     return 0
 
 
@@ -918,40 +920,74 @@ async def run_cli(
     prompt = prompt_from_args(args, stdin=stdin, parser=parser)
     has_prompt = bool(prompt and prompt.strip())
 
+    json_actions: dict[str, Any] = {}
+
     if args.status:
-        print_runtime_status(runtime, stdout=stdout, json_output=args.json_output)
+        if args.json_output:
+            json_actions["status"] = runtime_status_payload(runtime)
+        else:
+            print_runtime_status(runtime, stdout=stdout, json_output=False)
     if args.list_commands:
-        print_command_list(runtime, stdout=stdout, json_output=args.json_output)
+        if args.json_output:
+            json_actions["commands"] = [
+                {
+                    "name": command.name,
+                    "description": command.description,
+                    "target": command.target,
+                    "value": command.value,
+                    "source": command.source,
+                }
+                for command in runtime.chainlit_commands
+            ]
+            json_actions["notes"] = list(runtime.chainlit_command_notes)
+        else:
+            print_command_list(runtime, stdout=stdout, json_output=False)
     if args.rebuild_rag:
         status = await runtime.rebuild_rag_index()
-        print_rag_status(
-            status=status,
-            action="rebuild_rag",
-            stdout=stdout,
-            json_output=args.json_output,
-        )
+        if args.json_output:
+            json_actions["rebuild_rag"] = rag_status_payload(status)
+        else:
+            print_rag_status(
+                status=status,
+                action="rebuild_rag",
+                stdout=stdout,
+                json_output=False,
+            )
 
-    uploads_ok = await ingest_uploads(
+    upload_result = await ingest_uploads(
         runtime,
         paths=args.upload_rag,
         thread_id=args.thread_id,
         stdout=stdout,
         stderr=stderr,
-        json_output=args.json_output,
+        json_output=not args.json_output,
     )
-    if not uploads_ok:
+    if args.upload_rag and args.json_output and upload_result is not None:
+        json_actions["upload_rag"] = upload_result_payload(upload_result)
+
+    if upload_result is not None and upload_result.reason is not None:
         return 1
 
     if has_prompt:
-        return await run_agent_prompt(
+        prompt_result = await run_agent_prompt(
             runtime,
             args,
             prompt=prompt or "",
             stdout=stdout,
             stderr=stderr,
+            emit_json=not args.json_output,
         )
+        if args.json_output:
+            if isinstance(prompt_result, dict):
+                json_actions.update(prompt_result)
+                print(json.dumps(json_actions, indent=2, sort_keys=True), file=stdout)
+                return 0
+            return int(prompt_result)
+        return int(prompt_result)
 
     if args.status or args.list_commands or args.rebuild_rag or args.upload_rag:
+        if args.json_output:
+            print(json.dumps(json_actions, indent=2, sort_keys=True), file=stdout)
         return 0
 
     return await interactive_repl(

--- a/chainagents_cli.py
+++ b/chainagents_cli.py
@@ -1,0 +1,988 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+import traceback
+from contextlib import suppress
+from pathlib import Path
+from typing import Any, TextIO
+
+from rich import box
+from rich.console import Console
+from rich.panel import Panel
+from rich.text import Text
+
+from agent_commands import (
+    dumps_tool_result,
+    parse_native_command,
+    resolve_native_command,
+    resolve_runtime_command,
+)
+from deepagent_runtime import (
+    AgentRuntime,
+    AppSettings,
+    ReasoningLevel,
+    RuntimeConfig,
+    RuntimeConfigOverrides,
+    format_model_provider,
+    normalize_reasoning_level,
+)
+from rag_runtime import RagStatus, RagUploadResult, UploadedRagFile
+
+
+DEFAULT_CLI_THREAD_ID = "cli"
+TOOL_RESULT_PREVIEW_CHARS = 200
+LANGGRAPH_STREAM_MODES = {
+    "values",
+    "updates",
+    "custom",
+    "messages",
+    "checkpoints",
+    "tasks",
+    "debug",
+}
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="chainagents",
+        description="Run the ChainAgents DeepAgent runtime without the Chainlit UI.",
+    )
+    parser.add_argument("prompt_parts", nargs="*", metavar="PROMPT")
+    parser.add_argument("--prompt", help="Prompt to send to the agent.")
+    parser.add_argument(
+        "--stdin",
+        action="store_true",
+        help="Read the prompt from stdin.",
+    )
+
+    parser.add_argument("--config", help="Path to deepagent.toml.")
+    parser.add_argument("--database-url", help="Postgres URL for durable state.")
+    parser.add_argument(
+        "--no-database",
+        action="store_true",
+        help="Force in-memory state even when DATABASE_URL is set.",
+    )
+    parser.add_argument("--provider", help="Model provider: ollama or openai_compatible.")
+    parser.add_argument("--base-url", help="Model server base URL.")
+    parser.add_argument("--model", help="Model name to run.")
+    parser.add_argument("--api-key", help="API key for OpenAI-compatible model servers.")
+    parser.add_argument("--temperature", type=float, help="Model temperature.")
+    parser.add_argument(
+        "--reasoning",
+        choices=("low", "medium", "high"),
+        help="Reasoning effort for this run.",
+    )
+    parser.add_argument(
+        "--thread-id",
+        default=DEFAULT_CLI_THREAD_ID,
+        help=f"LangGraph thread ID. Defaults to {DEFAULT_CLI_THREAD_ID!r}.",
+    )
+    parser.add_argument("--recursion-limit", type=int, help="LangGraph recursion limit.")
+
+    parser.add_argument("--async-subagent-url", help="Override URL for async subagents.")
+    parser.add_argument("--mcp-session-id", help="Session scope for stateful MCP servers.")
+    parser.add_argument(
+        "--command",
+        help="Run a configured command using the prompt as command input.",
+    )
+
+    parser.add_argument(
+        "--rebuild-rag",
+        action="store_true",
+        help="Rebuild the configured workspace documentation RAG index.",
+    )
+    parser.add_argument(
+        "--upload-rag",
+        action="append",
+        default=[],
+        metavar="PATH",
+        help="Add a file to the current thread's uploaded RAG index.",
+    )
+    parser.add_argument(
+        "--no-rag",
+        action="store_true",
+        help="Disable RAG for this CLI process.",
+    )
+
+    parser.add_argument(
+        "--status",
+        action="store_true",
+        help="Print resolved runtime status.",
+    )
+    parser.add_argument(
+        "--list-commands",
+        action="store_true",
+        help="List configured commands and exit unless a prompt is also provided.",
+    )
+    parser.add_argument(
+        "--stream",
+        dest="stream",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Stream the final response as it is produced.",
+    )
+    parser.add_argument(
+        "--show-reasoning",
+        action="store_true",
+        help="Print streamed reasoning traces to stderr.",
+    )
+    parser.add_argument(
+        "--show-tools",
+        action="store_true",
+        help="Print tool call traces to stderr.",
+    )
+    parser.add_argument(
+        "--json",
+        dest="json_output",
+        action="store_true",
+        help="Print machine-readable JSON output.",
+    )
+    return parser
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    return build_parser().parse_args(argv)
+
+
+def runtime_overrides_from_args(args: argparse.Namespace) -> RuntimeConfigOverrides:
+    return RuntimeConfigOverrides(
+        config_path=args.config,
+        database_url=args.database_url,
+        disable_database=args.no_database,
+        model_provider=args.provider,
+        model_name=args.model,
+        model_base_url=args.base_url,
+        model_api_key=args.api_key,
+        model_temperature=args.temperature,
+        reasoning_level=args.reasoning,
+        recursion_limit=args.recursion_limit,
+        disable_rag=args.no_rag,
+    )
+
+
+def prompt_from_args(
+    args: argparse.Namespace,
+    *,
+    stdin: TextIO,
+    parser: argparse.ArgumentParser | None = None,
+) -> str | None:
+    prompt_sources = sum(
+        1
+        for enabled in (
+            bool(args.prompt),
+            bool(args.prompt_parts),
+            bool(args.stdin),
+        )
+        if enabled
+    )
+    if prompt_sources > 1:
+        message = "provide only one prompt source: positional PROMPT, --prompt, or --stdin"
+        if parser is not None:
+            parser.error(message)
+        raise ValueError(message)
+
+    if args.stdin:
+        return stdin.read()
+    if args.prompt is not None:
+        return args.prompt
+    if args.prompt_parts:
+        return " ".join(args.prompt_parts)
+    return None
+
+
+def langgraph_part_from_event_chunk(chunk: Any) -> dict[str, Any] | None:
+    if isinstance(chunk, dict):
+        mode = chunk.get("type")
+        if isinstance(mode, str) and mode in LANGGRAPH_STREAM_MODES and "data" in chunk:
+            return chunk
+        return None
+
+    if not isinstance(chunk, tuple):
+        return None
+
+    if len(chunk) == 3:
+        ns, mode, data = chunk
+    elif len(chunk) == 2:
+        first, data = chunk
+        if isinstance(first, tuple):
+            ns = first
+            mode = "values"
+        else:
+            ns = ()
+            mode = first
+    else:
+        return None
+
+    if not isinstance(mode, str) or mode not in LANGGRAPH_STREAM_MODES:
+        return None
+
+    if isinstance(ns, tuple):
+        namespace = ns
+    elif ns in (None, ""):
+        namespace = ()
+    else:
+        return None
+
+    return {"type": mode, "ns": namespace, "data": data}
+
+
+def stringify_content(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    if isinstance(value, list):
+        return "".join(stringify_content(item) for item in value)
+    if isinstance(value, dict):
+        for key in ("text", "reasoning", "content"):
+            nested = value.get(key)
+            if isinstance(nested, (str, list, dict)):
+                return stringify_content(nested)
+        return json.dumps(value, indent=2, sort_keys=True, ensure_ascii=True)
+    return str(value)
+
+
+def truncate_tool_result_content(value: Any) -> str:
+    content = stringify_content(value).strip()
+    if len(content) <= TOOL_RESULT_PREVIEW_CHARS:
+        return content
+    return content[:TOOL_RESULT_PREVIEW_CHARS]
+
+
+def reasoning_text_from_token(token: Any) -> str:
+    if hasattr(token, "additional_kwargs"):
+        text = stringify_content(token.additional_kwargs.get("reasoning_content"))
+        if text:
+            return text
+    if hasattr(token, "reasoning_content"):
+        return stringify_content(token.reasoning_content)
+    return ""
+
+
+def namespace_label(ns: tuple[str, ...], metadata: dict[str, Any]) -> str:
+    agent_name = metadata.get("lc_agent_name")
+    if agent_name:
+        return str(agent_name)
+    if not ns:
+        return "main-agent"
+
+    labels: list[str] = []
+    for segment in ns:
+        if segment.startswith("tools:"):
+            labels.append(f"subagent {segment.split(':', 1)[1]}")
+            continue
+        labels.append(segment.split(":", 1)[0])
+    return " / ".join(labels)
+
+
+def iter_messages(value: Any) -> list[Any]:
+    if value is None:
+        return []
+    if isinstance(value, (list, tuple)):
+        return list(value)
+    if isinstance(value, dict):
+        if "messages" in value:
+            return iter_messages(value["messages"])
+        if "value" in value:
+            return iter_messages(value["value"])
+        return [value]
+    if isinstance(value, (str, bytes)):
+        return []
+
+    for attr in ("value", "messages", "data"):
+        if hasattr(value, attr):
+            messages = iter_messages(getattr(value, attr))
+            if messages:
+                return messages
+
+    try:
+        return list(value)
+    except TypeError:
+        return [value]
+
+
+def messages_from_node_data(data: Any) -> list[Any]:
+    if data is None:
+        return []
+    if isinstance(data, dict):
+        return iter_messages(data.get("messages"))
+    return iter_messages(data)
+
+
+def is_assistant_message(message: Any) -> bool:
+    return getattr(message, "type", None) in {"ai", "AIMessageChunk"}
+
+
+def message_text(message: Any) -> str:
+    return stringify_content(getattr(message, "content", "")).strip()
+
+
+def assistant_messages_for_current_prompt(messages: list[Any], prompt: str) -> list[Any]:
+    prompt_text = prompt.strip()
+    current_prompt_index = -1
+    for index, message in enumerate(messages):
+        if getattr(message, "type", None) != "human":
+            continue
+        if message_text(message) == prompt_text:
+            current_prompt_index = index
+
+    if current_prompt_index < 0:
+        return []
+
+    return [
+        message
+        for message in messages[current_prompt_index + 1 :]
+        if is_assistant_message(message)
+    ]
+
+
+class CliEventRenderer:
+    def __init__(
+        self,
+        *,
+        prompt: str,
+        stdout: TextIO,
+        stderr: TextIO,
+        stream: bool,
+        json_output: bool,
+        show_reasoning: bool,
+        show_tools: bool,
+    ) -> None:
+        self.prompt = prompt
+        self.stdout = stdout
+        self.stderr = stderr
+        self.stream = stream
+        self.json_output = json_output
+        self.show_reasoning = show_reasoning
+        self.show_tools = show_tools
+        self.response_buffer = ""
+        self.response_streamed_from_messages = False
+        self.reasoning_buffers: dict[str, str] = {}
+        self.reasoning_line_source: str | None = None
+        self.tool_names: dict[str, str] = {}
+        self.completed_tool_results: set[tuple[str, str, str]] = set()
+        self.stdout_console = Console(
+            file=stdout,
+            highlight=False,
+            soft_wrap=True,
+        )
+        self.stderr_console = Console(
+            file=stderr,
+            highlight=False,
+            soft_wrap=True,
+        )
+
+    async def handle_event(self, event: dict[str, Any]) -> None:
+        if event.get("event") != "on_chain_stream":
+            return
+        if event.get("parent_ids"):
+            return
+
+        data = event.get("data")
+        if not isinstance(data, dict):
+            return
+
+        part = langgraph_part_from_event_chunk(data.get("chunk"))
+        if part is None:
+            return
+
+        kind = part["type"]
+        if kind == "messages":
+            self._handle_message_chunk(part)
+        elif kind == "updates":
+            self._handle_update_chunk(part)
+
+    def finish(self) -> str:
+        self._close_reasoning_line()
+        if self.json_output:
+            return self.response_buffer
+        if self.stream:
+            if self.response_buffer and not self.response_buffer.endswith("\n"):
+                self.stdout_console.print()
+            return self.response_buffer
+        if self.response_buffer:
+            self.stdout_console.print(Text(self.response_buffer, style="bright_white"))
+        return self.response_buffer
+
+    def _handle_message_chunk(self, part: dict[str, Any]) -> None:
+        token, metadata = part["data"]
+        metadata = metadata if isinstance(metadata, dict) else {}
+        ns = tuple(part.get("ns", ()))
+        source = namespace_label(ns, metadata)
+        is_main_source = not ns
+
+        reasoning_text = reasoning_text_from_token(token)
+        if reasoning_text:
+            self._stream_reasoning(source, reasoning_text)
+
+        tool_call_chunks = getattr(token, "tool_call_chunks", None) or []
+        if tool_call_chunks:
+            for chunk in tool_call_chunks:
+                self._stream_tool_call(source, chunk)
+
+        if getattr(token, "type", None) == "tool":
+            self._complete_tool(source, token)
+            return
+
+        content_text = stringify_content(getattr(token, "content", ""))
+        if is_main_source and content_text and not tool_call_chunks:
+            self.response_streamed_from_messages = True
+            self._stream_response(content_text)
+
+    def _handle_update_chunk(self, part: dict[str, Any]) -> None:
+        ns = tuple(part.get("ns", ()))
+        source = namespace_label(ns, {"lc_agent_name": None})
+
+        for node_name, data in part["data"].items():
+            if node_name != "tools":
+                if not ns and not self.response_streamed_from_messages:
+                    assistant_messages = assistant_messages_for_current_prompt(
+                        messages_from_node_data(data),
+                        self.prompt,
+                    )
+                    if assistant_messages:
+                        content_text = stringify_content(
+                            getattr(assistant_messages[-1], "content", "")
+                        )
+                        if content_text:
+                            self._stream_response(content_text)
+                continue
+
+            for message in messages_from_node_data(data):
+                if getattr(message, "type", None) == "tool":
+                    self._complete_tool(source, message)
+
+    def _stream_response(self, text: str) -> None:
+        delta = text[len(self.response_buffer) :] if text.startswith(self.response_buffer) else text
+        if not delta:
+            return
+        self.response_buffer += delta
+        if self.stream and not self.json_output:
+            self.stdout_console.print(Text(delta, style="bright_white"), end="")
+
+    def _stream_reasoning(self, source: str, text: str) -> None:
+        previous = self.reasoning_buffers.get(source, "")
+        delta = text[len(previous) :] if text.startswith(previous) else text
+        if not delta:
+            return
+        self.reasoning_buffers[source] = previous + delta
+        if self.show_reasoning:
+            if self.reasoning_line_source != source:
+                self._close_reasoning_line()
+                self.stderr_console.print(
+                    Text(f"[reasoning:{source}] ", style="bold magenta"),
+                    end="",
+                )
+                self.reasoning_line_source = source
+            self.stderr_console.print(Text(delta, style="magenta"), end="")
+
+    def _close_reasoning_line(self) -> None:
+        if self.reasoning_line_source is None:
+            return
+        self.stderr_console.print()
+        self.reasoning_line_source = None
+
+    def _stream_tool_call(self, source: str, chunk: dict[str, Any]) -> None:
+        call_id = str(chunk.get("id") or f"{source}:{chunk.get('index', '0')}")
+        tool_name = str(chunk.get("name") or self.tool_names.get(call_id) or "tool")
+        self.tool_names[call_id] = tool_name
+        if self.show_tools and chunk.get("name"):
+            self._close_reasoning_line()
+            self.stderr_console.print(
+                Panel(
+                    Text.assemble(
+                        ("status: ", "dim"),
+                        ("start", "bold yellow"),
+                        ("\nsource: ", "dim"),
+                        (source, "cyan"),
+                        ("\ntool: ", "dim"),
+                        (tool_name, "bold white"),
+                    ),
+                    title="Tool Call",
+                    title_align="left",
+                    border_style="yellow",
+                    box=box.ASCII,
+                )
+            )
+
+    def _complete_tool(self, source: str, tool_message: Any) -> None:
+        if not self.show_tools:
+            return
+        name = str(getattr(tool_message, "name", "") or "tool")
+        status = str(getattr(tool_message, "status", "") or "done")
+        content = truncate_tool_result_content(getattr(tool_message, "content", ""))
+        result_key = self._tool_result_key(
+            source=source,
+            name=name,
+            tool_message=tool_message,
+            content=content,
+        )
+        if result_key in self.completed_tool_results:
+            return
+        self.completed_tool_results.add(result_key)
+
+        self._close_reasoning_line()
+        status_style = "bold red" if status.lower() == "error" else "bold green"
+        body = Text.assemble(
+            ("status: ", "dim"),
+            (status, status_style),
+            ("\nsource: ", "dim"),
+            (source, "cyan"),
+            ("\ntool: ", "dim"),
+            (name, "bold white"),
+        )
+        if content:
+            body.append("\nresult: ", style="dim yellow")
+            body.append(content, style="yellow")
+        self.stderr_console.print(
+            Panel(
+                body,
+                title="Tool Result",
+                title_align="left",
+                border_style="red" if status.lower() == "error" else "green",
+                box=box.ASCII,
+            )
+        )
+
+    def _tool_result_key(
+        self,
+        *,
+        source: str,
+        name: str,
+        tool_message: Any,
+        content: str,
+    ) -> tuple[str, str, str]:
+        stable_id = str(
+            getattr(tool_message, "tool_call_id", None)
+            or getattr(tool_message, "id", None)
+            or ""
+        ).strip()
+        if stable_id:
+            return (source, "id", stable_id)
+        return (source, name, content)
+
+
+def rag_status_payload(status: RagStatus) -> dict[str, Any]:
+    return {
+        "enabled": status.enabled,
+        "ready": status.ready,
+        "file_count": status.file_count,
+        "chunk_count": status.chunk_count,
+        "reason": status.reason,
+        "persist_directory": str(status.persist_directory) if status.persist_directory else None,
+    }
+
+
+def upload_result_payload(result: RagUploadResult) -> dict[str, Any]:
+    return {
+        "thread_id": result.thread_id,
+        "success": result.success,
+        "added_files": list(result.added_files),
+        "indexed_files": result.indexed_files,
+        "chunk_count": result.chunk_count,
+        "rejected_files": list(result.rejected_files),
+        "reason": result.reason,
+    }
+
+
+def runtime_status_payload(runtime: AgentRuntime) -> dict[str, Any]:
+    extensions = runtime.config.extensions
+    return {
+        "model_provider": runtime.config.model_provider,
+        "model_provider_label": format_model_provider(runtime.config.model_provider),
+        "model": runtime.config.model_name,
+        "model_choices": list(runtime.config.model_choices),
+        "model_base_url": runtime.config.model_base_url,
+        "reasoning": runtime.config.default_reasoning,
+        "recursion_limit": runtime.config.recursion_limit,
+        "persistence": runtime.config.persistence_mode,
+        "rag": rag_status_payload(runtime.rag_status),
+        "extensions_config": str(extensions.config_path) if extensions.config_path else None,
+        "skill_sources": list(extensions.skills),
+        "mcp_servers": sorted((extensions.mcp_servers or {}).keys()),
+        "agent_mcp_servers": list(extensions.agent_mcp_servers),
+        "sync_subagents": [subagent.name for subagent in extensions.subagents],
+        "async_subagents": [subagent.name for subagent in extensions.async_subagents],
+        "commands": [command.name for command in runtime.chainlit_commands],
+    }
+
+
+def print_runtime_status(
+    runtime: AgentRuntime,
+    *,
+    stdout: TextIO,
+    json_output: bool,
+) -> None:
+    payload = runtime_status_payload(runtime)
+    if json_output:
+        print(json.dumps({"status": payload}, indent=2, sort_keys=True), file=stdout)
+        return
+
+    print("ChainAgents runtime", file=stdout)
+    print(f"- Model provider: {payload['model_provider_label']}", file=stdout)
+    print(f"- Model: {payload['model']}", file=stdout)
+    print(f"- Reasoning: {payload['reasoning']}", file=stdout)
+    print(f"- Recursion limit: {payload['recursion_limit']}", file=stdout)
+    print(f"- Persistence: {payload['persistence']}", file=stdout)
+    rag = payload["rag"]
+    if rag["enabled"] and rag["ready"]:
+        print(
+            f"- RAG: ready ({rag['file_count']} files, {rag['chunk_count']} chunks)",
+            file=stdout,
+        )
+    elif rag["enabled"]:
+        print(f"- RAG: unavailable ({rag['reason'] or 'unknown error'})", file=stdout)
+    else:
+        print("- RAG: disabled", file=stdout)
+    print(f"- Commands: {len(payload['commands'])}", file=stdout)
+
+
+def print_command_list(
+    runtime: AgentRuntime,
+    *,
+    stdout: TextIO,
+    json_output: bool,
+) -> None:
+    commands = [
+        {
+            "name": command.name,
+            "description": command.description,
+            "target": command.target,
+            "value": command.value,
+            "source": command.source,
+        }
+        for command in runtime.chainlit_commands
+    ]
+    if json_output:
+        print(
+            json.dumps(
+                {
+                    "commands": commands,
+                    "notes": list(runtime.chainlit_command_notes),
+                },
+                indent=2,
+                sort_keys=True,
+            ),
+            file=stdout,
+        )
+        return
+
+    if not commands:
+        print("No configured commands.", file=stdout)
+    else:
+        for command in commands:
+            print(
+                f"/{command['name']} ({command['target']}): {command['description']}",
+                file=stdout,
+            )
+    for note in runtime.chainlit_command_notes:
+        print(f"note: {note}", file=stdout)
+
+
+def print_rag_status(
+    *,
+    status: RagStatus,
+    action: str,
+    stdout: TextIO,
+    json_output: bool,
+) -> None:
+    payload = rag_status_payload(status)
+    if json_output:
+        print(json.dumps({action: payload}, indent=2, sort_keys=True), file=stdout)
+        return
+    if status.ready:
+        print(
+            f"{action}: ready ({status.file_count} files, {status.chunk_count} chunks)",
+            file=stdout,
+        )
+    elif status.enabled:
+        print(f"{action}: unavailable ({status.reason or 'unknown error'})", file=stdout)
+    else:
+        print(f"{action}: disabled", file=stdout)
+
+
+def print_upload_result(
+    result: RagUploadResult,
+    *,
+    stdout: TextIO,
+    json_output: bool,
+) -> None:
+    payload = upload_result_payload(result)
+    if json_output:
+        print(json.dumps({"upload_rag": payload}, indent=2, sort_keys=True), file=stdout)
+        return
+    if result.added_files:
+        print(
+            "upload-rag: added "
+            f"{', '.join(result.added_files)} "
+            f"({result.indexed_files} files, {result.chunk_count} chunks)",
+            file=stdout,
+        )
+    elif result.reason:
+        print(f"upload-rag: {result.reason}", file=stdout)
+    if result.rejected_files:
+        print(f"upload-rag: rejected {', '.join(result.rejected_files)}", file=stdout)
+
+
+async def ingest_uploads(
+    runtime: AgentRuntime,
+    *,
+    paths: list[str],
+    thread_id: str,
+    stdout: TextIO,
+    stderr: TextIO,
+    json_output: bool,
+) -> bool:
+    if not paths:
+        return True
+
+    uploads: list[UploadedRagFile] = []
+    for raw_path in paths:
+        path = Path(raw_path).expanduser().resolve()
+        if not path.exists() or not path.is_file():
+            print(f"upload-rag: file does not exist: {path}", file=stderr)
+            return False
+        uploads.append(UploadedRagFile(path=path, name=path.name))
+
+    result = await runtime.ingest_rag_uploads(thread_id=thread_id, uploads=uploads)
+    print_upload_result(result, stdout=stdout, json_output=json_output)
+    return result.reason is None
+
+
+async def run_agent_prompt(
+    runtime: AgentRuntime,
+    args: argparse.Namespace,
+    *,
+    prompt: str,
+    stdout: TextIO,
+    stderr: TextIO,
+) -> int:
+    thread_id = str(args.thread_id or DEFAULT_CLI_THREAD_ID).strip() or DEFAULT_CLI_THREAD_ID
+    reasoning_level: ReasoningLevel = normalize_reasoning_level(
+        args.reasoning,
+        default=runtime.config.default_reasoning,
+    )
+    settings = AppSettings(
+        model_name=args.model or runtime.config.model_name,
+        reasoning_level=reasoning_level,
+        thread_id=thread_id,
+    )
+
+    parsed_command = resolve_native_command(
+        raw_text=prompt,
+        selected_command=args.command,
+    )
+    slash_command_from_text = parse_native_command(prompt)
+    if parsed_command is not None:
+        try:
+            command_result = await resolve_runtime_command(
+                runtime=runtime,
+                parsed=parsed_command,
+                thread_id=settings.thread_id,
+                mcp_session_id=args.mcp_session_id,
+            )
+        except Exception as exc:
+            print(
+                f"Command /{parsed_command.command_name} failed: {exc}",
+                file=stderr,
+            )
+            return 1
+
+        if command_result.target == "unknown":
+            if slash_command_from_text is not None or args.command:
+                print(
+                    f"Unknown command /{parsed_command.command_name}.",
+                    file=stderr,
+                )
+                return 2
+        elif command_result.target == "mcp_tool":
+            print(dumps_tool_result(command_result.tool_result), file=stdout)
+            return 0
+        elif command_result.prompt is not None:
+            prompt = command_result.prompt
+            if not prompt.strip():
+                return 0
+
+    agent = await runtime.get_agent(
+        settings.reasoning_level,
+        model_name=settings.model_name,
+        thread_id=settings.thread_id,
+        async_subagent_url_override=args.async_subagent_url,
+        mcp_session_id=args.mcp_session_id,
+    )
+    payload = {"messages": [{"role": "user", "content": prompt}]}
+    config = {
+        "configurable": {"thread_id": settings.thread_id},
+        "recursion_limit": runtime.config.recursion_limit,
+    }
+    renderer = CliEventRenderer(
+        prompt=prompt,
+        stdout=stdout,
+        stderr=stderr,
+        stream=args.stream,
+        json_output=args.json_output,
+        show_reasoning=args.show_reasoning,
+        show_tools=args.show_tools,
+    )
+    stream = agent.astream_events(
+        payload,
+        config=config,
+        version="v2",
+        stream_mode=["messages", "updates"],
+        subgraphs=True,
+    )
+
+    try:
+        while True:
+            try:
+                event = await anext(stream)
+            except StopAsyncIteration:
+                break
+            await renderer.handle_event(event)
+    except asyncio.CancelledError:
+        with suppress(Exception):
+            await stream.aclose()
+        raise
+    except Exception as exc:
+        with suppress(Exception):
+            await stream.aclose()
+        print(f"{type(exc).__name__}: {exc}", file=stderr)
+        if args.show_tools or args.show_reasoning:
+            print(traceback.format_exc(limit=10), file=stderr)
+        return 1
+    finally:
+        with suppress(Exception):
+            await stream.aclose()
+
+    response = renderer.finish()
+    if args.json_output:
+        print(
+            json.dumps(
+                {
+                    "response": response,
+                    "thread_id": settings.thread_id,
+                    "model": settings.model_name,
+                    "reasoning": settings.reasoning_level,
+                },
+                indent=2,
+                sort_keys=True,
+            ),
+            file=stdout,
+        )
+    return 0
+
+
+async def interactive_repl(
+    runtime: AgentRuntime,
+    args: argparse.Namespace,
+    *,
+    stdout: TextIO,
+    stderr: TextIO,
+) -> int:
+    print("ChainAgents CLI. Press Ctrl-D to exit.", file=stderr)
+    while True:
+        try:
+            prompt = input("chainagents> ")
+        except EOFError:
+            print("", file=stderr)
+            return 0
+        except KeyboardInterrupt:
+            print("", file=stderr)
+            return 130
+        if not prompt.strip():
+            continue
+        code = await run_agent_prompt(
+            runtime,
+            args,
+            prompt=prompt,
+            stdout=stdout,
+            stderr=stderr,
+        )
+        if code not in (0,):
+            return code
+
+
+async def run_cli(
+    args: argparse.Namespace,
+    *,
+    runtime: AgentRuntime,
+    stdout: TextIO,
+    stderr: TextIO,
+    stdin: TextIO,
+    parser: argparse.ArgumentParser | None = None,
+) -> int:
+    prompt = prompt_from_args(args, stdin=stdin, parser=parser)
+    has_prompt = bool(prompt and prompt.strip())
+
+    if args.status:
+        print_runtime_status(runtime, stdout=stdout, json_output=args.json_output)
+    if args.list_commands:
+        print_command_list(runtime, stdout=stdout, json_output=args.json_output)
+    if args.rebuild_rag:
+        status = await runtime.rebuild_rag_index()
+        print_rag_status(
+            status=status,
+            action="rebuild_rag",
+            stdout=stdout,
+            json_output=args.json_output,
+        )
+
+    uploads_ok = await ingest_uploads(
+        runtime,
+        paths=args.upload_rag,
+        thread_id=args.thread_id,
+        stdout=stdout,
+        stderr=stderr,
+        json_output=args.json_output,
+    )
+    if not uploads_ok:
+        return 1
+
+    if has_prompt:
+        return await run_agent_prompt(
+            runtime,
+            args,
+            prompt=prompt or "",
+            stdout=stdout,
+            stderr=stderr,
+        )
+
+    if args.status or args.list_commands or args.rebuild_rag or args.upload_rag:
+        return 0
+
+    return await interactive_repl(
+        runtime,
+        args,
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+
+async def async_main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    config = RuntimeConfig.from_env(runtime_overrides_from_args(args))
+    runtime = await AgentRuntime.create(config)
+    try:
+        return await run_cli(
+            args,
+            runtime=runtime,
+            stdout=sys.stdout,
+            stderr=sys.stderr,
+            stdin=sys.stdin,
+            parser=parser,
+        )
+    finally:
+        await runtime.close()
+
+
+def main(argv: list[str] | None = None) -> int:
+    return asyncio.run(async_main(argv))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/chainagents_cli.py
+++ b/chainagents_cli.py
@@ -736,6 +736,7 @@ async def ingest_uploads(
     stdout: TextIO,
     stderr: TextIO,
     json_output: bool,
+    emit_output: bool = True,
 ) -> RagUploadResult | None:
     if not paths:
         return None
@@ -753,7 +754,8 @@ async def ingest_uploads(
         uploads.append(UploadedRagFile(path=path, name=path.name))
 
     result = await runtime.ingest_rag_uploads(thread_id=thread_id, uploads=uploads)
-    print_upload_result(result, stdout=stdout, json_output=json_output)
+    if emit_output:
+        print_upload_result(result, stdout=stdout, json_output=json_output)
     return result
 
 
@@ -960,7 +962,8 @@ async def run_cli(
         thread_id=args.thread_id,
         stdout=stdout,
         stderr=stderr,
-        json_output=not args.json_output,
+        json_output=False,
+        emit_output=not args.json_output,
     )
     if args.upload_rag and args.json_output and upload_result is not None:
         json_actions["upload_rag"] = upload_result_payload(upload_result)

--- a/deepagent_runtime.py
+++ b/deepagent_runtime.py
@@ -962,29 +962,51 @@ def compose_agent_system_prompt(base_prompt: str, custom_instruction: str | None
     )
 
 
-def load_file_config() -> FileConfig:
-    config_name = os.getenv("DEEPAGENT_CONFIG", DEFAULT_EXTENSIONS_CONFIG).strip()
-    config_path = resolve_local_path(config_name or DEFAULT_EXTENSIONS_CONFIG, PROJECT_ROOT)
-    if not config_path.exists():
+def load_file_config(config_path: str | Path | None = None) -> FileConfig:
+    config_name = (
+        str(config_path).strip()
+        if config_path is not None
+        else os.getenv("DEEPAGENT_CONFIG", DEFAULT_EXTENSIONS_CONFIG).strip()
+    )
+    resolved_config_path = resolve_local_path(
+        config_name or DEFAULT_EXTENSIONS_CONFIG,
+        PROJECT_ROOT,
+    )
+    if not resolved_config_path.exists():
         return FileConfig(
             model=ModelDefaults(),
             extensions=ExtensionsConfig(config_path=None),
             rag=RagConfig(),
         )
 
-    with config_path.open("rb") as fh:
+    with resolved_config_path.open("rb") as fh:
         raw_config = tomllib.load(fh)
 
     return FileConfig(
         model=parse_model_defaults(raw_config),
-        extensions=parse_extensions_config(raw_config, config_path),
-        rag=parse_rag_config(raw_config, config_path),
+        extensions=parse_extensions_config(raw_config, resolved_config_path),
+        rag=parse_rag_config(raw_config, resolved_config_path),
     )
 
 
-def load_extensions_config() -> ExtensionsConfig:
+def load_extensions_config(config_path: str | Path | None = None) -> ExtensionsConfig:
     # Keep the previous public helper for existing imports and tests.
-    return load_file_config().extensions
+    return load_file_config(config_path).extensions
+
+
+@dataclass(frozen=True)
+class RuntimeConfigOverrides:
+    config_path: str | Path | None = None
+    database_url: str | None = None
+    disable_database: bool = False
+    model_provider: str | None = None
+    model_name: str | None = None
+    model_base_url: str | None = None
+    model_api_key: str | None = None
+    model_temperature: float | None = None
+    reasoning_level: str | None = None
+    recursion_limit: int | None = None
+    disable_rag: bool = False
 
 
 @dataclass(frozen=True)
@@ -1005,20 +1027,42 @@ class RuntimeConfig:
     rag_error: str | None = None
 
     @classmethod
-    def from_env(cls) -> "RuntimeConfig":
-        file_config = load_file_config()
+    def from_env(
+        cls,
+        overrides: RuntimeConfigOverrides | None = None,
+    ) -> "RuntimeConfig":
+        overrides = overrides or RuntimeConfigOverrides()
+        file_config = load_file_config(overrides.config_path)
         model_defaults = file_config.model
-        database_url = os.getenv("DATABASE_URL", "").strip() or None
+        if overrides.disable_database:
+            database_url = None
+        elif overrides.database_url is not None:
+            database_url = normalize_optional_string(overrides.database_url)
+        else:
+            database_url = os.getenv("DATABASE_URL", "").strip() or None
         model_provider_override = normalize_optional_string(
-            os.getenv("DEEPAGENT_MODEL_PROVIDER")
+            overrides.model_provider
         )
+        if model_provider_override is None:
+            model_provider_override = normalize_optional_string(
+                os.getenv("DEEPAGENT_MODEL_PROVIDER")
+            )
         model_provider = normalize_model_provider(
             model_provider_override,
             default=model_defaults.provider,
         )
-        generic_model_name = os.getenv("DEEPAGENT_MODEL_NAME", "").strip()
-        generic_model_base_url = os.getenv("DEEPAGENT_MODEL_BASE_URL", "").strip()
-        generic_model_reasoning = os.getenv("DEEPAGENT_MODEL_REASONING", "").strip()
+        generic_model_name = (
+            normalize_optional_string(overrides.model_name)
+            or os.getenv("DEEPAGENT_MODEL_NAME", "").strip()
+        )
+        generic_model_base_url = (
+            normalize_optional_string(overrides.model_base_url)
+            or os.getenv("DEEPAGENT_MODEL_BASE_URL", "").strip()
+        )
+        generic_model_reasoning = (
+            normalize_optional_string(overrides.reasoning_level)
+            or os.getenv("DEEPAGENT_MODEL_REASONING", "").strip()
+        )
         model_name_alias = os.getenv("OLLAMA_MODEL", "").strip() if model_provider == "ollama" else ""
         model_base_url_alias = (
             os.getenv("OLLAMA_BASE_URL", "").strip() if model_provider == "ollama" else ""
@@ -1061,20 +1105,32 @@ class RuntimeConfig:
             generic_model_base_url or model_base_url_alias or model_defaults.base_url,
             required_message="The model base URL cannot be empty.",
         )
-        model_api_key = (
-            normalize_optional_string(os.getenv("DEEPAGENT_MODEL_API_KEY"))
-            or model_defaults.api_key
+        if overrides.model_api_key is not None:
+            model_api_key = normalize_optional_string(overrides.model_api_key)
+        else:
+            model_api_key = (
+                normalize_optional_string(os.getenv("DEEPAGENT_MODEL_API_KEY"))
+                or model_defaults.api_key
+            )
+        model_temperature = (
+            normalize_model_temperature(overrides.model_temperature)
+            if overrides.model_temperature is not None
+            else model_defaults.temperature
         )
         default_reasoning = normalize_reasoning_level(
             generic_model_reasoning or model_reasoning_alias,
             default=model_defaults.reasoning_effort,
         )
         recursion_limit = normalize_recursion_limit(
-            os.getenv("DEEPAGENT_RECURSION_LIMIT"),
+            (
+                overrides.recursion_limit
+                if overrides.recursion_limit is not None
+                else os.getenv("DEEPAGENT_RECURSION_LIMIT")
+            ),
             default=file_config.extensions.recursion_limit,
             field_name="DEEPAGENT_RECURSION_LIMIT",
         )
-        rag_requested = file_config.rag.enabled
+        rag_requested = file_config.rag.enabled and not overrides.disable_rag
         rag = None
         rag_error = None
         if rag_requested:
@@ -1094,7 +1150,7 @@ class RuntimeConfig:
             model_choices=model_choices,
             model_base_url=model_base_url,
             model_api_key=model_api_key,
-            model_temperature=model_defaults.temperature,
+            model_temperature=model_temperature,
             default_reasoning=default_reasoning,
             persistence_mode="postgres" if database_url else "memory",
             extensions=file_config.extensions,
@@ -1442,6 +1498,17 @@ class AgentRuntime:
                 await instance._initialize()
                 cls._instance = instance
             return cls._instance
+
+    @classmethod
+    async def create(
+        cls,
+        config: RuntimeConfig | None = None,
+        *,
+        project_root: Path | None = None,
+    ) -> "AgentRuntime":
+        instance = cls(config or RuntimeConfig.from_env(), project_root=project_root)
+        await instance._initialize()
+        return instance
 
     @classmethod
     def current(cls) -> "AgentRuntime | None":
@@ -1869,6 +1936,12 @@ class AgentRuntime:
 
         for stack in stacks:
             await stack.aclose()
+
+    async def close(self) -> None:
+        await self._exit_stack.aclose()
+        self._checkpointer = None
+        self._store = None
+        self._mcp_client = None
 
     def _build_backend(self, runtime):
         return build_deepagent_backend(project_root=self.project_root)

--- a/main.py
+++ b/main.py
@@ -1,18 +1,25 @@
 from __future__ import annotations
 
 import asyncio
-import json
 import os
 import secrets
 import traceback
 from contextlib import suppress
 from pathlib import Path
-from typing import Any, NamedTuple
+from typing import Any
 
 import chainlit as cl
 from chainlit.input_widget import Select, TextInput
 from chainlit.types import ThreadDict
 
+from agent_commands import (
+    ParsedNativeCommand,
+    build_skill_command_prompt,
+    dumps_tool_result,
+    parse_native_command,
+    resolve_native_command,
+    resolve_runtime_command,
+)
 from async_task_notifications import AsyncTaskNotifier, async_subagent_url_override
 from chainlit_bridge import ChainlitEventBridge, RunTaskList
 from deepagent_runtime import (
@@ -229,68 +236,6 @@ def upload_result_message(upload_result) -> str:
 
     return upload_result.reason or "No files were added to RAG."
 
-class ParsedNativeCommand(NamedTuple):
-    command_name: str
-    raw_args: str
-
-
-def parse_native_command(raw_text: str) -> ParsedNativeCommand | None:
-    text = raw_text.strip()
-    if not text.startswith("/"):
-        return None
-    tokens = text[1:].split(None, 1)
-    if not tokens:
-        return None
-    return ParsedNativeCommand(
-        command_name=tokens[0].strip().lower(),
-        raw_args=tokens[1].strip() if len(tokens) > 1 else "",
-    )
-
-
-def resolve_native_command(
-    *,
-    raw_text: str,
-    selected_command: str | None = None,
-) -> ParsedNativeCommand | None:
-    parsed = parse_native_command(raw_text)
-    if parsed is not None:
-        return parsed
-
-    command_name = str(selected_command or "").strip().lstrip("/").lower()
-    if not command_name:
-        return None
-
-    return ParsedNativeCommand(
-        command_name=command_name,
-        raw_args=raw_text.strip(),
-    )
-
-
-def apply_native_template(template: str | None, raw_args: str) -> str:
-    if template is None:
-        return raw_args.strip()
-    return template.replace("{input}", raw_args.strip()).strip()
-
-
-def build_skill_command_prompt(*, skill_name: str, skill_path: str, raw_args: str) -> str:
-    prelude = (
-        f"Use the configured `{skill_name}` skill for this request.\n"
-        f"Read `{skill_path}` before taking any other action and follow it for this entire turn.\n"
-        "Skill usage is mandatory for this request.\n"
-    )
-    request = raw_args.strip()
-    if request:
-        return (
-            f"{prelude}\n"
-            "After reading the skill, complete the user's request below.\n\n"
-            f"User request:\n{request}"
-        ).strip()
-    return (
-        f"{prelude}\n"
-        "After reading the skill, briefly explain what it does and ask the user for the specific task."
-    ).strip()
-
-
 async def handle_native_command(
     *,
     runtime: AgentRuntime,
@@ -298,47 +243,28 @@ async def handle_native_command(
     parsed: ParsedNativeCommand,
     mcp_session_id: str | None = None,
 ) -> str | None:
-    command = runtime.resolve_chainlit_command(parsed.command_name)
-    if command is None:
+    result = await resolve_runtime_command(
+        runtime=runtime,
+        parsed=parsed,
+        thread_id=settings.thread_id,
+        mcp_session_id=mcp_session_id,
+    )
+    if result.target == "unknown":
         return None
 
-    if command.target == "skill":
-        return build_skill_command_prompt(
-            skill_name=command.name,
-            skill_path=command.value,
-            raw_args=parsed.raw_args,
-        )
-
-    if command.target == "mcp_tool":
-        tool_raw_args = apply_native_template(command.template, parsed.raw_args)
-        result = await runtime.invoke_mcp_tool_command(
-            tool_name=command.value,
-            raw_args=tool_raw_args,
-            thread_id=settings.thread_id,
-            mcp_session_id=mcp_session_id,
-            server_name=command.mcp_server,
-        )
+    if result.target == "mcp_tool":
         await cl.Message(
             author="System",
             content=(
-                f"Ran `/{command.name}` ({command.description}).\n\n"
+                f"Ran `/{result.command_name}` ({result.description}).\n\n"
                 "Tool result:\n```json\n"
-                f"{json.dumps(result, indent=2, sort_keys=True, ensure_ascii=True, default=str)}\n"
+                f"{dumps_tool_result(result.tool_result)}\n"
                 "```"
             ),
         ).send()
         return ""
 
-    transformed = apply_native_template(command.template, parsed.raw_args)
-    if command.target == "prompt":
-        return transformed or command.value
-
-    return (
-        f"Delegate this request to the configured `{command.value}` subagent.\n\n"
-        f"Command: `/{command.name}`\n"
-        f"Description: {command.description}\n\n"
-        f"User request:\n{transformed or parsed.raw_args or command.value}"
-    ).strip()
+    return result.prompt
 
 
 async def ask_for_rag_upload() -> list[UploadedRagFile]:

--- a/mock_test.txt
+++ b/mock_test.txt
@@ -1,0 +1,1 @@
+This is a mock tool call test.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,27 @@ dependencies = [
     "langgraph-checkpoint-postgres>=1.0.0",
     "psycopg[binary,pool]>=3.2.0",
     "pytest>=8.3.0",
+    "rich>=15.0.0",
+]
+
+[project.scripts]
+chainagents = "chainagents_cli:main"
+
+[build-system]
+requires = ["setuptools>=69"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+py-modules = [
+    "agent_commands",
+    "async_task_notifications",
+    "chainagents_cli",
+    "chainlit_bridge",
+    "deepagent_runtime",
+    "langgraph_app",
+    "main",
+    "rag_runtime",
+    "response_exports",
 ]
 
 [tool.pytest.ini_options]

--- a/tests/test_agent_cli.py
+++ b/tests/test_agent_cli.py
@@ -261,7 +261,11 @@ async def test_cli_json_combines_multiple_actions(tmp_path: Path) -> None:
             async_subagents=[],
         ),
     )
-    runtime.rag_status = RagStatus.ready_status(1, 2, persist_directory=Path(".rag"))  # type: ignore[attr-defined]
+    runtime.rag_status = RagStatus.ready_status(  # type: ignore[attr-defined]
+        file_count=1,
+        chunk_count=2,
+        persist_directory=Path(".rag"),
+    )
     runtime.chainlit_commands = []  # type: ignore[attr-defined]
     runtime.chainlit_command_notes = []  # type: ignore[attr-defined]
     stdout = io.StringIO()

--- a/tests/test_agent_cli.py
+++ b/tests/test_agent_cli.py
@@ -1,0 +1,492 @@
+from __future__ import annotations
+
+import io
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import chainagents_cli
+from deepagent_runtime import RuntimeConfig
+from rag_runtime import RagStatus, RagUploadResult
+
+
+def test_cli_parses_prompt_and_runtime_flags() -> None:
+    args = chainagents_cli.parse_args(
+        [
+            "--prompt",
+            "hello",
+            "--model",
+            "gemma4:26b",
+            "--reasoning",
+            "high",
+            "--thread-id",
+            "thread-1",
+            "--no-stream",
+            "--json",
+        ]
+    )
+
+    assert chainagents_cli.prompt_from_args(args, stdin=io.StringIO("")) == "hello"
+    assert args.model == "gemma4:26b"
+    assert args.reasoning == "high"
+    assert args.thread_id == "thread-1"
+    assert args.stream is False
+    assert args.json_output is True
+
+
+def test_runtime_overrides_from_cli_args_take_precedence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path = tmp_path / "deepagent.toml"
+    config_path.write_text(
+        """
+[model]
+provider = "ollama"
+base_url = "http://config.example:11434"
+name = "config-model"
+temperature = 0.1
+reasoning_effort = "low"
+
+[agent]
+recursion_limit = 20
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DATABASE_URL", "postgresql://env/db")
+    monkeypatch.setenv("DEEPAGENT_MODEL_NAME", "env-model")
+    monkeypatch.setenv("DEEPAGENT_MODEL_REASONING", "medium")
+
+    args = chainagents_cli.parse_args(
+        [
+            "--config",
+            str(config_path),
+            "--database-url",
+            "postgresql://cli/db",
+            "--provider",
+            "openai_compatible",
+            "--base-url",
+            "http://cli.example/v1",
+            "--model",
+            "cli-model",
+            "--api-key",
+            "cli-key",
+            "--temperature",
+            "0.7",
+            "--reasoning",
+            "high",
+            "--recursion-limit",
+            "77",
+            "--no-rag",
+            "--status",
+        ]
+    )
+
+    config = RuntimeConfig.from_env(chainagents_cli.runtime_overrides_from_args(args))
+
+    assert config.database_url == "postgresql://cli/db"
+    assert config.model_provider == "openai_compatible"
+    assert config.model_base_url == "http://cli.example/v1"
+    assert config.model_name == "cli-model"
+    assert config.model_api_key == "cli-key"
+    assert config.model_temperature == 0.7
+    assert config.default_reasoning == "high"
+    assert config.recursion_limit == 77
+    assert config.rag_requested is False
+
+
+class _FakeMcpRuntime:
+    def __init__(self) -> None:
+        self.config = SimpleNamespace(
+            default_reasoning="medium",
+            model_name="fake-model",
+            recursion_limit=100,
+        )
+        self.invocation: dict[str, str | None] | None = None
+
+    def resolve_chainlit_command(self, name: str):
+        if name != "repo-readme":
+            return None
+        return SimpleNamespace(
+            name="repo-readme",
+            description="Read README",
+            target="mcp_tool",
+            value="repo_read_file",
+            template='{"path": "README.md"}',
+            mcp_server="repo",
+        )
+
+    async def invoke_mcp_tool_command(
+        self,
+        *,
+        tool_name: str,
+        raw_args: str,
+        thread_id: str,
+        mcp_session_id: str | None,
+        server_name: str | None,
+    ):
+        self.invocation = {
+            "tool_name": tool_name,
+            "raw_args": raw_args,
+            "thread_id": thread_id,
+            "mcp_session_id": mcp_session_id,
+            "server_name": server_name,
+        }
+        return {"ok": True}
+
+
+@pytest.mark.anyio
+async def test_cli_command_invokes_configured_mcp_tool() -> None:
+    args = chainagents_cli.parse_args(
+        [
+            "--prompt",
+            "ignored",
+            "--command",
+            "repo-readme",
+            "--thread-id",
+            "thread-1",
+            "--mcp-session-id",
+            "session-1",
+        ]
+    )
+    runtime = _FakeMcpRuntime()
+    stdout = io.StringIO()
+
+    code = await chainagents_cli.run_agent_prompt(
+        runtime,  # type: ignore[arg-type]
+        args,
+        prompt="ignored",
+        stdout=stdout,
+        stderr=io.StringIO(),
+    )
+
+    assert code == 0
+    assert '"ok": true' in stdout.getvalue()
+    assert runtime.invocation == {
+        "tool_name": "repo_read_file",
+        "raw_args": '{"path": "README.md"}',
+        "thread_id": "thread-1",
+        "mcp_session_id": "session-1",
+        "server_name": "repo",
+    }
+
+
+class _FakeRagRuntime:
+    def __init__(self) -> None:
+        self.rebuilt = False
+        self.uploaded: list[str] = []
+
+    async def rebuild_rag_index(self) -> RagStatus:
+        self.rebuilt = True
+        return RagStatus.ready_status(
+            file_count=1,
+            chunk_count=2,
+            persist_directory=Path(".rag"),
+        )
+
+    async def ingest_rag_uploads(self, *, thread_id: str, uploads):
+        self.uploaded = [upload.name for upload in uploads]
+        return RagUploadResult(
+            thread_id=thread_id,
+            added_files=tuple(self.uploaded),
+            indexed_files=1,
+            chunk_count=3,
+        )
+
+
+@pytest.mark.anyio
+async def test_cli_runs_rag_actions_without_prompt(tmp_path: Path) -> None:
+    upload = tmp_path / "notes.md"
+    upload.write_text("# Notes\n", encoding="utf-8")
+    args = chainagents_cli.parse_args(
+        [
+            "--rebuild-rag",
+            "--upload-rag",
+            str(upload),
+            "--thread-id",
+            "thread-1",
+        ]
+    )
+    runtime = _FakeRagRuntime()
+    stdout = io.StringIO()
+
+    code = await chainagents_cli.run_cli(
+        args,
+        runtime=runtime,  # type: ignore[arg-type]
+        stdout=stdout,
+        stderr=io.StringIO(),
+        stdin=io.StringIO(""),
+    )
+
+    assert code == 0
+    assert runtime.rebuilt is True
+    assert runtime.uploaded == ["notes.md"]
+    assert "rebuild_rag: ready" in stdout.getvalue()
+    assert "upload-rag: added notes.md" in stdout.getvalue()
+
+
+class _Token:
+    type = "AIMessageChunk"
+    additional_kwargs: dict[str, str] = {}
+    tool_call_chunks: list[dict[str, str]] = []
+
+    def __init__(self, content: str) -> None:
+        self.content = content
+
+
+class _ReasoningToken:
+    type = "AIMessageChunk"
+    content = ""
+    tool_call_chunks: list[dict[str, str]] = []
+
+    def __init__(self, reasoning: str = "thinking") -> None:
+        self.additional_kwargs = {"reasoning_content": reasoning}
+
+
+class _ToolCallToken:
+    type = "AIMessageChunk"
+    content = ""
+    additional_kwargs: dict[str, str] = {}
+    tool_call_chunks = [
+        {
+            "id": "call-1",
+            "name": "read_file",
+            "args": '{"path":"README.md"}',
+        }
+    ]
+
+
+class _ToolMessage:
+    type = "tool"
+    name = "read_file"
+    status = "success"
+    tool_call_id = "call-1"
+
+    def __init__(self, content: str) -> None:
+        self.content = content
+
+
+@pytest.mark.anyio
+async def test_cli_event_renderer_streams_final_response() -> None:
+    stdout = io.StringIO()
+    renderer = chainagents_cli.CliEventRenderer(
+        prompt="hello",
+        stdout=stdout,
+        stderr=io.StringIO(),
+        stream=True,
+        json_output=False,
+        show_reasoning=False,
+        show_tools=False,
+    )
+
+    await renderer.handle_event(
+        {
+            "event": "on_chain_stream",
+            "data": {
+                "chunk": (
+                    (),
+                    "messages",
+                    (_Token("Hello"), {}),
+                ),
+            },
+        }
+    )
+    await renderer.handle_event(
+        {
+            "event": "on_chain_stream",
+            "data": {
+                "chunk": (
+                    (),
+                    "messages",
+                    (_Token("Hello world"), {}),
+                ),
+            },
+        }
+    )
+
+    response = renderer.finish()
+
+    assert response == "Hello world"
+    assert stdout.getvalue() == "Hello world\n"
+
+
+@pytest.mark.anyio
+async def test_cli_event_renderer_formats_reasoning_trace() -> None:
+    stderr = io.StringIO()
+    renderer = chainagents_cli.CliEventRenderer(
+        prompt="hello",
+        stdout=io.StringIO(),
+        stderr=stderr,
+        stream=True,
+        json_output=False,
+        show_reasoning=True,
+        show_tools=False,
+    )
+
+    await renderer.handle_event(
+        {
+            "event": "on_chain_stream",
+            "data": {
+                "chunk": (
+                    (),
+                    "messages",
+                    (_ReasoningToken(), {}),
+                ),
+            },
+        }
+    )
+
+    assert "[reasoning:main-agent] thinking" in stderr.getvalue()
+
+
+@pytest.mark.anyio
+async def test_cli_event_renderer_appends_reasoning_chunks_inline() -> None:
+    stderr = io.StringIO()
+    renderer = chainagents_cli.CliEventRenderer(
+        prompt="hello",
+        stdout=io.StringIO(),
+        stderr=stderr,
+        stream=True,
+        json_output=False,
+        show_reasoning=True,
+        show_tools=False,
+    )
+
+    for reasoning in ("thinking", "thinking through", "thinking through details"):
+        await renderer.handle_event(
+            {
+                "event": "on_chain_stream",
+                "data": {
+                    "chunk": (
+                        (),
+                        "messages",
+                        (_ReasoningToken(reasoning), {}),
+                    ),
+                },
+            }
+        )
+    renderer.finish()
+
+    output = stderr.getvalue()
+    assert output.count("[reasoning:main-agent]") == 1
+    assert "[reasoning:main-agent] thinking through details\n" in output
+
+
+@pytest.mark.anyio
+async def test_cli_event_renderer_boxes_tool_call_start() -> None:
+    stderr = io.StringIO()
+    renderer = chainagents_cli.CliEventRenderer(
+        prompt="hello",
+        stdout=io.StringIO(),
+        stderr=stderr,
+        stream=True,
+        json_output=False,
+        show_reasoning=False,
+        show_tools=True,
+    )
+
+    await renderer.handle_event(
+        {
+            "event": "on_chain_stream",
+            "data": {
+                "chunk": (
+                    (),
+                    "messages",
+                    (_ToolCallToken(), {}),
+                ),
+            },
+        }
+    )
+
+    output = stderr.getvalue()
+    assert "Tool Call" in output
+    assert "status: start" in output
+    assert "source: main-agent" in output
+    assert "tool: read_file" in output
+    assert "+" in output
+    assert "|" in output
+
+
+@pytest.mark.anyio
+async def test_cli_event_renderer_truncates_tool_results_to_200_characters() -> None:
+    stderr = io.StringIO()
+    renderer = chainagents_cli.CliEventRenderer(
+        prompt="hello",
+        stdout=io.StringIO(),
+        stderr=stderr,
+        stream=True,
+        json_output=False,
+        show_reasoning=False,
+        show_tools=True,
+    )
+    long_result = ("abcdefghijklmnopqrstuvwxyz" * 8) + "TAIL"
+
+    assert chainagents_cli.truncate_tool_result_content(long_result) == long_result[:200]
+
+    await renderer.handle_event(
+        {
+            "event": "on_chain_stream",
+            "data": {
+                "chunk": (
+                    (),
+                    "messages",
+                    (_ToolMessage(long_result), {}),
+                ),
+            },
+        }
+    )
+
+    output = stderr.getvalue()
+    assert "Tool Result" in output
+    assert "status: success" in output
+    assert "source: main-agent" in output
+    assert "tool: read_file" in output
+    assert "result: " in output
+    assert "TAIL" not in output
+    assert "+" in output
+    assert "|" in output
+
+
+@pytest.mark.anyio
+async def test_cli_event_renderer_deduplicates_tool_results_from_stream_modes() -> None:
+    stderr = io.StringIO()
+    renderer = chainagents_cli.CliEventRenderer(
+        prompt="hello",
+        stdout=io.StringIO(),
+        stderr=stderr,
+        stream=True,
+        json_output=False,
+        show_reasoning=False,
+        show_tools=True,
+    )
+    tool_message = _ToolMessage("same result")
+
+    await renderer.handle_event(
+        {
+            "event": "on_chain_stream",
+            "data": {
+                "chunk": (
+                    (),
+                    "messages",
+                    (tool_message, {}),
+                ),
+            },
+        }
+    )
+    await renderer.handle_event(
+        {
+            "event": "on_chain_stream",
+            "data": {
+                "chunk": (
+                    (),
+                    "updates",
+                    {"tools": {"messages": [tool_message]}},
+                ),
+            },
+        }
+    )
+
+    output = stderr.getvalue()
+    assert output.count("Tool Result") == 1
+    assert output.count("same result") == 1

--- a/tests/test_agent_cli.py
+++ b/tests/test_agent_cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import io
+import json
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -224,6 +225,58 @@ async def test_cli_runs_rag_actions_without_prompt(tmp_path: Path) -> None:
     assert runtime.uploaded == ["notes.md"]
     assert "rebuild_rag: ready" in stdout.getvalue()
     assert "upload-rag: added notes.md" in stdout.getvalue()
+
+
+@pytest.mark.anyio
+async def test_cli_json_combines_multiple_actions(tmp_path: Path) -> None:
+    upload = tmp_path / "notes.md"
+    upload.write_text("# Notes\n", encoding="utf-8")
+    args = chainagents_cli.parse_args(
+        [
+            "--json",
+            "--status",
+            "--list-commands",
+            "--rebuild-rag",
+            "--upload-rag",
+            str(upload),
+            "--thread-id",
+            "thread-1",
+        ]
+    )
+    runtime = _FakeRagRuntime()
+    runtime.config = SimpleNamespace(  # type: ignore[attr-defined]
+        model_provider="ollama",
+        model_name="fake-model",
+        model_choices=["fake-model"],
+        model_base_url=None,
+        default_reasoning="medium",
+        recursion_limit=50,
+        persistence_mode="memory",
+        extensions=SimpleNamespace(
+            config_path=None,
+            skills=[],
+            mcp_servers={},
+            agent_mcp_servers=[],
+            subagents=[],
+            async_subagents=[],
+        ),
+    )
+    runtime.rag_status = RagStatus.ready_status(1, 2, persist_directory=Path(".rag"))  # type: ignore[attr-defined]
+    runtime.chainlit_commands = []  # type: ignore[attr-defined]
+    runtime.chainlit_command_notes = []  # type: ignore[attr-defined]
+    stdout = io.StringIO()
+
+    code = await chainagents_cli.run_cli(
+        args,
+        runtime=runtime,  # type: ignore[arg-type]
+        stdout=stdout,
+        stderr=io.StringIO(),
+        stdin=io.StringIO(""),
+    )
+
+    assert code == 0
+    payload = json.loads(stdout.getvalue())
+    assert set(payload.keys()) == {"status", "commands", "notes", "rebuild_rag", "upload_rag"}
 
 
 class _Token:

--- a/tests/test_main_native_commands.py
+++ b/tests/test_main_native_commands.py
@@ -2,36 +2,37 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+import agent_commands
 import main
 import pytest
 
 
 def test_resolve_native_command_prefers_explicit_slash_text() -> None:
-    parsed = main.resolve_native_command(
+    parsed = agent_commands.resolve_native_command(
         raw_text="/summarize hello world",
         selected_command="ask-researcher",
     )
 
-    assert parsed == main.ParsedNativeCommand(
+    assert parsed == agent_commands.ParsedNativeCommand(
         command_name="summarize",
         raw_args="hello world",
     )
 
 
 def test_resolve_native_command_uses_selected_command_input() -> None:
-    parsed = main.resolve_native_command(
+    parsed = agent_commands.resolve_native_command(
         raw_text="hello world",
         selected_command="summarize",
     )
 
-    assert parsed == main.ParsedNativeCommand(
+    assert parsed == agent_commands.ParsedNativeCommand(
         command_name="summarize",
         raw_args="hello world",
     )
 
 
 def test_resolve_native_command_returns_none_without_command() -> None:
-    parsed = main.resolve_native_command(
+    parsed = agent_commands.resolve_native_command(
         raw_text="hello world",
         selected_command=None,
     )
@@ -212,7 +213,7 @@ async def test_handle_native_command_applies_template_for_mcp_tool(monkeypatch) 
     result = await main.handle_native_command(
         runtime=runtime,
         settings=settings,
-        parsed=main.ParsedNativeCommand(command_name="repo-readme", raw_args=""),
+        parsed=agent_commands.ParsedNativeCommand(command_name="repo-readme", raw_args=""),
     )
 
     assert result == ""
@@ -222,7 +223,7 @@ async def test_handle_native_command_applies_template_for_mcp_tool(monkeypatch) 
 
 
 def test_build_skill_command_prompt_requires_skill_and_request() -> None:
-    prompt = main.build_skill_command_prompt(
+    prompt = agent_commands.build_skill_command_prompt(
         skill_name="reviewer",
         skill_path="/workspace/skills/reviewer/SKILL.md",
         raw_args="inspect this diff",
@@ -235,7 +236,7 @@ def test_build_skill_command_prompt_requires_skill_and_request() -> None:
 
 
 def test_build_skill_command_prompt_without_request_asks_for_task() -> None:
-    prompt = main.build_skill_command_prompt(
+    prompt = agent_commands.build_skill_command_prompt(
         skill_name="reviewer",
         skill_path="/workspace/skills/reviewer/SKILL.md",
         raw_args="",
@@ -261,7 +262,7 @@ async def test_handle_native_command_returns_forced_skill_prompt() -> None:
     result = await main.handle_native_command(
         runtime=runtime,
         settings=settings,
-        parsed=main.ParsedNativeCommand(
+        parsed=agent_commands.ParsedNativeCommand(
             command_name="reviewer",
             raw_args="inspect this diff",
         ),
@@ -289,7 +290,7 @@ async def test_handle_native_command_without_skill_args_requests_clarification()
     result = await main.handle_native_command(
         runtime=runtime,
         settings=settings,
-        parsed=main.ParsedNativeCommand(
+        parsed=agent_commands.ParsedNativeCommand(
             command_name="reviewer",
             raw_args="",
         ),
@@ -312,12 +313,12 @@ async def test_handle_native_command_uses_selected_skill_command_input() -> None
         )
     )
     settings = SimpleNamespace(thread_id="thread-1")
-    parsed = main.resolve_native_command(
+    parsed = agent_commands.resolve_native_command(
         raw_text="inspect this diff",
         selected_command="reviewer",
     )
 
-    assert parsed == main.ParsedNativeCommand(
+    assert parsed == agent_commands.ParsedNativeCommand(
         command_name="reviewer",
         raw_args="inspect this diff",
     )

--- a/uv.lock
+++ b/uv.lock
@@ -459,7 +459,7 @@ wheels = [
 [[package]]
 name = "chainagents"
 version = "1.1.0"
-source = { virtual = "." }
+source = { editable = "." }
 dependencies = [
     { name = "asyncpg" },
     { name = "chainlit" },
@@ -473,6 +473,7 @@ dependencies = [
     { name = "langgraph-checkpoint-postgres" },
     { name = "psycopg", extra = ["binary", "pool"] },
     { name = "pytest" },
+    { name = "rich" },
 ]
 
 [package.metadata]
@@ -489,6 +490,7 @@ requires-dist = [
     { name = "langgraph-checkpoint-postgres", specifier = ">=1.0.0" },
     { name = "psycopg", extras = ["binary", "pool"], specifier = ">=3.2.0" },
     { name = "pytest", specifier = ">=8.3.0" },
+    { name = "rich", specifier = ">=15.0.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add `chainagents`, a terminal CLI that runs the same DeepAgent runtime without the Chainlit UI.
- Share native command parsing between the UI and CLI so prompt rewrites, subagent delegation, and MCP tool calls behave consistently.
- Add runtime override hooks for config, model, persistence, RAG, recursion, and async subagent settings.
- Improve CLI output with Rich styling for reasoning and tool traces, plus tool-result de-duplication and truncation.
- Document the new CLI workflow in the README.

## Testing
- Added focused CLI coverage for argument parsing, runtime overrides, command handling, RAG actions, Rich output, and tool-result de-duplication.
- Updated the existing native command tests to use the shared command helpers.
- Full test suite passes locally.