### PR TITLE
Preserve vLLM reasoning deltas in OpenAI-compatible streaming

### DIFF
--- a/deepagent_runtime.py
+++ b/deepagent_runtime.py
@@ -23,7 +23,7 @@ from deepagents.backends import (
 )
 from deepagents.middleware.skills import _list_skills
 from langchain.agents.middleware.types import AgentMiddleware, ToolCallRequest
-from langchain_core.messages import ToolMessage
+from langchain_core.messages import AIMessageChunk, ToolMessage
 from langchain_ollama import ChatOllama
 from langchain_openai import ChatOpenAI
 from langchain_mcp_adapters.client import MultiServerMCPClient
@@ -63,6 +63,13 @@ DEFAULT_RECURSION_LIMIT = 100
 PROJECT_ROOT = Path(__file__).resolve().parent
 DEEPAGENT_ARTIFACTS_DIRECTORY = Path(".files/deepagent")
 logger = logging.getLogger(__name__)
+
+OPENAI_COMPATIBLE_REASONING_DELTA_KEYS = (
+    "reasoning_content",
+    "reasoning",
+    "reasoning_text",
+    "reasoning_details",
+)
 
 SYSTEM_PROMPT = f"""
 You are a local workspace deep agent running inside a Chainlit UI.
@@ -117,6 +124,61 @@ def format_model_provider(provider: ModelProvider) -> str:
     if provider == "openai_compatible":
         return "OpenAI-compatible"
     return "Ollama"
+
+
+def _first_openai_compatible_delta(chunk: dict[str, Any]) -> dict[str, Any]:
+    choices = chunk.get("choices", [])
+    if not choices:
+        nested_chunk = chunk.get("chunk")
+        if isinstance(nested_chunk, dict):
+            choices = nested_chunk.get("choices", [])
+
+    if not isinstance(choices, list) or not choices:
+        return {}
+
+    choice = choices[0]
+    if not isinstance(choice, dict):
+        return {}
+
+    delta = choice.get("delta")
+    if isinstance(delta, dict):
+        return delta
+    return {}
+
+
+def _openai_compatible_reasoning_delta(chunk: dict[str, Any]) -> Any:
+    delta = _first_openai_compatible_delta(chunk)
+    for key in OPENAI_COMPATIBLE_REASONING_DELTA_KEYS:
+        value = delta.get(key)
+        if value not in (None, ""):
+            return value
+    return None
+
+
+class OpenAICompatibleChatOpenAI(ChatOpenAI):
+    def _convert_chunk_to_generation_chunk(
+        self,
+        chunk: dict[str, Any],
+        default_chunk_class: type,
+        base_generation_info: dict | None,
+    ):
+        generation_chunk = super()._convert_chunk_to_generation_chunk(
+            chunk,
+            default_chunk_class,
+            base_generation_info,
+        )
+        if generation_chunk is None:
+            return None
+
+        reasoning_delta = _openai_compatible_reasoning_delta(chunk)
+        if reasoning_delta is None or not isinstance(
+            generation_chunk.message,
+            AIMessageChunk,
+        ):
+            return generation_chunk
+
+        generation_chunk.message.additional_kwargs["reasoning_content"] = reasoning_delta
+        return generation_chunk
 
 
 def normalize_model_endpoint(value: str | None) -> str:
@@ -1182,7 +1244,7 @@ def build_model(
         "api_key": config.model_api_key or "deepagent",
         "temperature": config.model_temperature,
     }
-    return ChatOpenAI(**kwargs)
+    return OpenAICompatibleChatOpenAI(**kwargs)
 
 
 def build_deepagent_backend(*, project_root: Path | None = None) -> CompositeBackend:

--- a/tests/test_deepagent_runtime_rag.py
+++ b/tests/test_deepagent_runtime_rag.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from types import SimpleNamespace
 
 from langchain.agents.middleware.types import ToolCallRequest
-from langchain_core.messages import ToolMessage
+from langchain_core.messages import AIMessageChunk, ToolMessage
 from langgraph.checkpoint.memory import MemorySaver
 from langgraph.store.memory import InMemoryStore
 import pytest
@@ -84,6 +84,47 @@ def make_extensions_config(
         mcp_stateful=mcp_stateful,
         mcp_servers={"repo": {"transport": "stdio", "command": "npx", "args": []}},
         agent_mcp_servers=agent_mcp_servers,
+    )
+
+
+def test_openai_compatible_model_preserves_vllm_reasoning_delta() -> None:
+    config = RuntimeConfig(
+        database_url=None,
+        model_provider="openai_compatible",
+        model_name="reasoning-model",
+        model_choices=("reasoning-model",),
+        model_base_url="http://127.0.0.1:8000/v1",
+        model_api_key=None,
+        model_temperature=0.0,
+        default_reasoning="medium",
+        persistence_mode="memory",
+        extensions=ExtensionsConfig(config_path=None),
+    )
+    model = deepagent_runtime.build_model(config, "medium")
+
+    chunk = {
+        "choices": [
+            {
+                "delta": {
+                    "role": "assistant",
+                    "content": None,
+                    "reasoning_content": "thinking through the answer",
+                },
+                "finish_reason": None,
+                "index": 0,
+            }
+        ]
+    }
+
+    generation_chunk = model._convert_chunk_to_generation_chunk(
+        chunk,
+        AIMessageChunk,
+        {},
+    )
+
+    assert generation_chunk is not None
+    assert generation_chunk.message.additional_kwargs["reasoning_content"] == (
+        "thinking through the answer"
     )
 
 


### PR DESCRIPTION
## Summary
- Added an OpenAI-compatible `ChatOpenAI` wrapper that copies streamed reasoning fields like `reasoning_content`, `reasoning`, `reasoning_text`, and `reasoning_details` into `additional_kwargs`.
- Switched the OpenAI-compatible runtime path to use that wrapper so Chainlit and CLI reasoning renderers can display vLLM reasoning text.
- Added a regression test covering a streamed OpenAI-compatible chunk with `delta.reasoning_content`.

## Testing
- `uv run pytest`