### PR TITLE
✨ feat(cli): add photo attachments to terminal prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,11 +159,13 @@ uv run chainagents --command ask-researcher --prompt "Find the config entrypoint
 uv run chainagents --stdin --model gemma4:26b --reasoning high < prompt.txt
 uv run chainagents --rebuild-rag
 uv run chainagents --upload-rag notes.md --prompt "Use my uploaded notes"
+uv run chainagents --photo scene.jpg --prompt "Describe this photo"
 ```
 
 Run `uv run chainagents --help` for all runtime flags, including model provider,
 base URL, API key, temperature, persistence, MCP session scope, async subagent
-URL, RAG controls, streaming, reasoning traces, tool traces, and JSON output.
+URL, RAG controls, photo attachments, streaming, reasoning traces, tool traces,
+and JSON output.
 
 ## Model Config
 

--- a/chainagents_cli.py
+++ b/chainagents_cli.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import base64
 import json
+import mimetypes
 import sys
 import traceback
 from contextlib import suppress
@@ -57,6 +59,13 @@ def build_parser() -> argparse.ArgumentParser:
         "--stdin",
         action="store_true",
         help="Read the prompt from stdin.",
+    )
+    parser.add_argument(
+        "--photo",
+        action="append",
+        default=[],
+        metavar="PATH",
+        help="Attach an image file to the prompt for vision-capable models. May be repeated.",
     )
 
     parser.add_argument("--config", help="Path to deepagent.toml.")
@@ -192,6 +201,35 @@ def prompt_from_args(
     if args.prompt_parts:
         return " ".join(args.prompt_parts)
     return None
+
+
+def photo_content_parts(paths: list[str], *, stderr: TextIO) -> list[dict[str, Any]] | None:
+    parts: list[dict[str, Any]] = []
+    for raw_path in paths:
+        path = Path(raw_path).expanduser().resolve()
+        if not path.exists() or not path.is_file():
+            print(f"photo: file does not exist: {path}", file=stderr)
+            return None
+
+        mime_type, _ = mimetypes.guess_type(path.name)
+        if not mime_type or not mime_type.startswith("image/"):
+            print(f"photo: unsupported image type: {path}", file=stderr)
+            return None
+
+        encoded = base64.b64encode(path.read_bytes()).decode("ascii")
+        parts.append(
+            {
+                "type": "image_url",
+                "image_url": {"url": f"data:{mime_type};base64,{encoded}"},
+            }
+        )
+    return parts
+
+
+def user_message_content(prompt: str, photos: list[dict[str, Any]]) -> str | list[dict[str, Any]]:
+    if not photos:
+        return prompt
+    return [{"type": "text", "text": prompt}, *photos]
 
 
 def langgraph_part_from_event_chunk(chunk: Any) -> dict[str, Any] | None:
@@ -814,6 +852,10 @@ async def run_agent_prompt(
             if not prompt.strip():
                 return 0
 
+    photos = photo_content_parts(args.photo, stderr=stderr)
+    if photos is None:
+        return 1
+
     agent = await runtime.get_agent(
         settings.reasoning_level,
         model_name=settings.model_name,
@@ -821,7 +863,9 @@ async def run_agent_prompt(
         async_subagent_url_override=args.async_subagent_url,
         mcp_session_id=args.mcp_session_id,
     )
-    payload = {"messages": [{"role": "user", "content": prompt}]}
+    payload = {
+        "messages": [{"role": "user", "content": user_message_content(prompt, photos)}]
+    }
     config = {
         "configurable": {"thread_id": settings.thread_id},
         "recursion_limit": runtime.config.recursion_limit,
@@ -923,6 +967,10 @@ async def run_cli(
     has_prompt = bool(prompt and prompt.strip())
 
     json_actions: dict[str, Any] = {}
+
+    if args.photo and not has_prompt:
+        print("photo: provide a prompt with --photo.", file=stderr)
+        return 2
 
     if args.status:
         if args.json_output:

--- a/tests/test_agent_cli.py
+++ b/tests/test_agent_cli.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import base64
 import io
 import json
 from pathlib import Path
@@ -17,6 +18,8 @@ def test_cli_parses_prompt_and_runtime_flags() -> None:
         [
             "--prompt",
             "hello",
+            "--photo",
+            "image.png",
             "--model",
             "gemma4:26b",
             "--reasoning",
@@ -29,6 +32,7 @@ def test_cli_parses_prompt_and_runtime_flags() -> None:
     )
 
     assert chainagents_cli.prompt_from_args(args, stdin=io.StringIO("")) == "hello"
+    assert args.photo == ["image.png"]
     assert args.model == "gemma4:26b"
     assert args.reasoning == "high"
     assert args.thread_id == "thread-1"
@@ -196,6 +200,35 @@ class _FakeRagRuntime:
         )
 
 
+class _CaptureAgent:
+    def __init__(self) -> None:
+        self.payload = None
+        self.config = None
+
+    def astream_events(self, payload, *, config, version, stream_mode, subgraphs):
+        self.payload = payload
+        self.config = config
+
+        async def events():
+            if False:
+                yield None
+
+        return events()
+
+
+class _FakePromptRuntime:
+    def __init__(self) -> None:
+        self.config = SimpleNamespace(
+            default_reasoning="medium",
+            model_name="fake-model",
+            recursion_limit=100,
+        )
+        self.agent = _CaptureAgent()
+
+    async def get_agent(self, *args, **kwargs):
+        return self.agent
+
+
 @pytest.mark.anyio
 async def test_cli_runs_rag_actions_without_prompt(tmp_path: Path) -> None:
     upload = tmp_path / "notes.md"
@@ -225,6 +258,60 @@ async def test_cli_runs_rag_actions_without_prompt(tmp_path: Path) -> None:
     assert runtime.uploaded == ["notes.md"]
     assert "rebuild_rag: ready" in stdout.getvalue()
     assert "upload-rag: added notes.md" in stdout.getvalue()
+
+
+@pytest.mark.anyio
+async def test_cli_photo_attaches_image_content_to_agent_payload(tmp_path: Path) -> None:
+    photo = tmp_path / "scene.png"
+    photo.write_bytes(b"\x89PNG\r\n")
+    args = chainagents_cli.parse_args(
+        [
+            "--prompt",
+            "Describe this scene",
+            "--photo",
+            str(photo),
+            "--no-stream",
+        ]
+    )
+    runtime = _FakePromptRuntime()
+
+    code = await chainagents_cli.run_agent_prompt(
+        runtime,  # type: ignore[arg-type]
+        args,
+        prompt="Describe this scene",
+        stdout=io.StringIO(),
+        stderr=io.StringIO(),
+    )
+
+    assert code == 0
+    content = runtime.agent.payload["messages"][0]["content"]
+    expected_image_url = (
+        "data:image/png;base64,"
+        + base64.b64encode(photo.read_bytes()).decode("ascii")
+    )
+    assert content == [
+        {"type": "text", "text": "Describe this scene"},
+        {"type": "image_url", "image_url": {"url": expected_image_url}},
+    ]
+
+
+@pytest.mark.anyio
+async def test_cli_photo_requires_prompt(tmp_path: Path) -> None:
+    photo = tmp_path / "scene.png"
+    photo.write_bytes(b"\x89PNG\r\n")
+    args = chainagents_cli.parse_args(["--photo", str(photo)])
+    stderr = io.StringIO()
+
+    code = await chainagents_cli.run_cli(
+        args,
+        runtime=_FakePromptRuntime(),  # type: ignore[arg-type]
+        stdout=io.StringIO(),
+        stderr=stderr,
+        stdin=io.StringIO(""),
+    )
+
+    assert code == 2
+    assert "provide a prompt with --photo" in stderr.getvalue()
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary
- Add `--photo PATH` to the CLI so prompts can include one or more image attachments.
- Encode attached files as `image_url` data URLs and send them with the user message content.
- Require a prompt when `--photo` is used and document the new flag in the README.
- Add tests for argument parsing, multimodal payload construction, and the prompt requirement.

## Testing
- `pytest -q` passed.
- `chainagents_cli.py --help` shows the new `--photo` option.