### PR TITLE
Harden skill loading and tool output handling

### DIFF
--- a/chainlit_bridge.py
+++ b/chainlit_bridge.py
@@ -17,6 +17,7 @@ from response_exports import attach_response_export_actions
 DEFAULT_AUTO_COLLAPSE_DELAY_SECONDS = 3.0
 RESPONSE_STREAM_FLUSH_INTERVAL_SECONDS = 0.05
 RESPONSE_STREAM_FLUSH_CHARS = 1024
+MAX_TOOL_OUTPUT_CHARS = 20_000
 CHAINLIT_APP_CONFIG_PATH = Path(__file__).resolve().parent / "chainlit.toml"
 LANGGRAPH_STREAM_MODES = {
     "values",
@@ -835,7 +836,9 @@ class ChainlitEventBridge:
 
         if not state.step.input:
             state.step.input = state.rendered_input
-        state.step.output = pretty_data(getattr(tool_message, "content", ""))
+        state.step.output = truncate_tool_output(
+            pretty_data(getattr(tool_message, "content", ""))
+        )
         state.step.end = utc_now()
         await state.step.update()
         self._schedule_step_auto_collapse(state.step)
@@ -918,3 +921,12 @@ class ChainlitEventBridge:
         task = asyncio.create_task(collapse_later())
         self.pending_collapse_tasks.add(task)
         task.add_done_callback(self.pending_collapse_tasks.discard)
+
+def truncate_tool_output(text: str, *, limit: int = MAX_TOOL_OUTPUT_CHARS) -> str:
+    if len(text) <= limit:
+        return text
+    omitted = len(text) - limit
+    return (
+        f"{text[:limit]}\n\n[output truncated: omitted {omitted} characters to keep Chainlit step updates stable]"
+    )
+

--- a/deepagent_runtime.py
+++ b/deepagent_runtime.py
@@ -7,6 +7,7 @@ import logging
 import math
 import os
 import tomllib
+import time
 from collections.abc import Awaitable, Callable
 from contextlib import AsyncExitStack
 from dataclasses import dataclass
@@ -1271,6 +1272,35 @@ def normalize_chainlit_command_name(value: str) -> str:
     return value.strip().lstrip("/").lower()
 
 
+
+def _list_skills_with_retry(
+    backend: CompositeBackend,
+    source_path: str,
+    *,
+    retries: int = 2,
+    delay_seconds: float = 0.15,
+) -> list[dict[str, Any]]:
+    last_exc: Exception | None = None
+    for attempt in range(retries + 1):
+        try:
+            return _list_skills(backend, source_path)
+        except PermissionError as exc:
+            last_exc = exc
+            if attempt < retries:
+                time.sleep(delay_seconds * (attempt + 1))
+                continue
+            raise
+        except OSError as exc:
+            if exc.errno in {13, 2}:
+                last_exc = exc
+                if attempt < retries:
+                    time.sleep(delay_seconds * (attempt + 1))
+                    continue
+            raise
+    if last_exc is not None:
+        raise last_exc
+    return []
+
 def _load_skill_command_bucket(
     *,
     backend: CompositeBackend,
@@ -1282,10 +1312,10 @@ def _load_skill_command_bucket(
     commands_by_name: dict[str, SkillCommandMetadata] = {}
     for source_path in source_paths:
         try:
-            source_skills = _list_skills(backend, source_path)
+            source_skills = _list_skills_with_retry(backend, source_path)
         except Exception as exc:
             logger.warning(
-                "Failed to load skills from '%s' for Chainlit command generation: %s",
+                "Failed to load skills from '%s' (check path mapping/read permissions) for Chainlit command generation: %s",
                 source_path,
                 exc,
             )


### PR DESCRIPTION
### Motivation
- Intermittent "permission"-like failures occurred when discovering skills (agent sometimes cannot find skills on first try) due to transient file access/path timing issues.
- Very large tool outputs could destabilize Chainlit step updates and surface as misleading runtime or access errors.

### Description
- Add a retry wrapper `_list_skills_with_retry` in `deepagent_runtime.py` that retries `_list_skills` on transient `PermissionError` and `OSError` (errno 13/2) with a small backoff. 
- Switch Chainlit command skill discovery to use `_list_skills_with_retry` and improve the warning message to mention path mapping/read-permission hints. 
- Add `MAX_TOOL_OUTPUT_CHARS` and a `truncate_tool_output` helper in `chainlit_bridge.py`, and apply it before assigning `step.output` to truncate oversized tool results. 
- Changes touch `deepagent_runtime.py` and `chainlit_bridge.py` to make skill loading and tool-output handling more resilient.

### Testing
- Ran `python -m py_compile deepagent_runtime.py chainlit_bridge.py` which completed successfully for both modified files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8c978e3748324855f77e1d099ec1f)