### PR TITLE
Show tool call arguments in CLI tool panels

### DIFF
--- a/chainagents_cli.py
+++ b/chainagents_cli.py
@@ -413,6 +413,8 @@ class CliEventRenderer:
         self.reasoning_buffers: dict[str, str] = {}
         self.reasoning_line_source: str | None = None
         self.tool_names: dict[str, str] = {}
+        self.tool_args_buffers: dict[str, str] = {}
+        self.tool_call_started: set[str] = set()
         self.completed_tool_results: set[tuple[str, str, str]] = set()
         self.stdout_console = Console(
             file=stdout,
@@ -539,29 +541,41 @@ class CliEventRenderer:
         call_id = str(chunk.get("id") or f"{source}:{chunk.get('index', '0')}")
         tool_name = str(chunk.get("name") or self.tool_names.get(call_id) or "tool")
         self.tool_names[call_id] = tool_name
-        if self.show_tools and chunk.get("name"):
-            self._close_reasoning_line()
-            body = Text.assemble(
-                ("status: ", "dim"),
-                ("start", "bold yellow"),
-                ("\nsource: ", "dim"),
-                (source, "cyan"),
-                ("\ntool: ", "dim"),
-                (tool_name, "bold white"),
+        args_delta = chunk.get("args")
+        if args_delta:
+            self.tool_args_buffers[call_id] = self.tool_args_buffers.get(call_id, "") + str(
+                args_delta
             )
-            args = pretty_tool_call_args(chunk.get("args"))
-            if args:
-                body.append("\nargs: ", style="dim yellow")
-                body.append(args, style="yellow")
-            self.stderr_console.print(
-                Panel(
-                    body,
-                    title="Tool Call",
-                    title_align="left",
-                    border_style="yellow",
-                    box=box.ASCII,
-                )
+
+        if not self.show_tools:
+            return
+        if not chunk.get("name") and call_id not in self.tool_call_started:
+            return
+
+        self._close_reasoning_line()
+        status = "start" if call_id not in self.tool_call_started else "update"
+        self.tool_call_started.add(call_id)
+        body = Text.assemble(
+            ("status: ", "dim"),
+            (status, "bold yellow"),
+            ("\nsource: ", "dim"),
+            (source, "cyan"),
+            ("\ntool: ", "dim"),
+            (tool_name, "bold white"),
+        )
+        args = pretty_tool_call_args(self.tool_args_buffers.get(call_id))
+        if args:
+            body.append("\nargs: ", style="dim yellow")
+            body.append(args, style="yellow")
+        self.stderr_console.print(
+            Panel(
+                body,
+                title="Tool Call",
+                title_align="left",
+                border_style="yellow",
+                box=box.ASCII,
             )
+        )
 
     def _complete_tool(self, source: str, tool_message: Any) -> None:
         if not self.show_tools:

--- a/chainagents_cli.py
+++ b/chainagents_cli.py
@@ -291,6 +291,17 @@ def truncate_tool_result_content(value: Any) -> str:
     return content[:TOOL_RESULT_PREVIEW_CHARS]
 
 
+def pretty_tool_call_args(value: Any) -> str:
+    content = stringify_content(value).strip()
+    if not content:
+        return ""
+    try:
+        parsed = json.loads(content)
+    except json.JSONDecodeError:
+        return content
+    return json.dumps(parsed, indent=2, sort_keys=True, ensure_ascii=True)
+
+
 def reasoning_text_from_token(token: Any) -> str:
     if hasattr(token, "additional_kwargs"):
         text = stringify_content(token.additional_kwargs.get("reasoning_content"))
@@ -530,16 +541,21 @@ class CliEventRenderer:
         self.tool_names[call_id] = tool_name
         if self.show_tools and chunk.get("name"):
             self._close_reasoning_line()
+            body = Text.assemble(
+                ("status: ", "dim"),
+                ("start", "bold yellow"),
+                ("\nsource: ", "dim"),
+                (source, "cyan"),
+                ("\ntool: ", "dim"),
+                (tool_name, "bold white"),
+            )
+            args = pretty_tool_call_args(chunk.get("args"))
+            if args:
+                body.append("\nargs: ", style="dim yellow")
+                body.append(args, style="yellow")
             self.stderr_console.print(
                 Panel(
-                    Text.assemble(
-                        ("status: ", "dim"),
-                        ("start", "bold yellow"),
-                        ("\nsource: ", "dim"),
-                        (source, "cyan"),
-                        ("\ntool: ", "dim"),
-                        (tool_name, "bold white"),
-                    ),
+                    body,
                     title="Tool Call",
                     title_align="left",
                     border_style="yellow",

--- a/tests/test_agent_cli.py
+++ b/tests/test_agent_cli.py
@@ -548,6 +548,8 @@ async def test_cli_event_renderer_boxes_tool_call_start() -> None:
     assert "status: start" in output
     assert "source: main-agent" in output
     assert "tool: read_file" in output
+    assert "args: " in output
+    assert '"path": "README.md"' in output
     assert "+" in output
     assert "|" in output
 

--- a/tests/test_agent_cli.py
+++ b/tests/test_agent_cli.py
@@ -401,6 +401,15 @@ class _ToolCallToken:
     ]
 
 
+class _ToolCallChunkToken:
+    type = "AIMessageChunk"
+    content = ""
+    additional_kwargs: dict[str, str] = {}
+
+    def __init__(self, chunk: dict[str, str]) -> None:
+        self.tool_call_chunks = [chunk]
+
+
 class _ToolMessage:
     type = "tool"
     name = "read_file"
@@ -552,6 +561,39 @@ async def test_cli_event_renderer_boxes_tool_call_start() -> None:
     assert '"path": "README.md"' in output
     assert "+" in output
     assert "|" in output
+
+
+@pytest.mark.anyio
+async def test_cli_event_renderer_accumulates_tool_args_across_chunks() -> None:
+    stderr = io.StringIO()
+    renderer = chainagents_cli.CliEventRenderer(
+        prompt="hello",
+        stdout=io.StringIO(),
+        stderr=stderr,
+        stream=True,
+        json_output=False,
+        show_reasoning=False,
+        show_tools=True,
+    )
+
+    await renderer.handle_event(
+        {
+            "event": "on_chain_stream",
+            "data": {"chunk": ((), "messages", (_ToolCallChunkToken({"id": "call-9", "name": "read_file", "args": '{"path":"REA'}), {}))},
+        }
+    )
+    await renderer.handle_event(
+        {
+            "event": "on_chain_stream",
+            "data": {"chunk": ((), "messages", (_ToolCallChunkToken({"id": "call-9", "args": 'DME.md"}'}), {}))},
+        }
+    )
+
+    output = stderr.getvalue()
+    assert "Tool Call" in output
+    assert "status: start" in output
+    assert "status: update" in output
+    assert '"path": "README.md"' in output
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary
- Add `pretty_tool_call_args` to format tool-call payloads for display in the CLI.
- Include an `args:` section in the `Tool Call` panel when arguments are present.
- Add a regression test that checks the rendered tool-call output includes the JSON payload.

## Testing
- `uv run pytest tests/test_agent_cli.py`
- `uv run pytest`
- Full suite passed