### PR TITLE
Add support for custom OpenAI endpoint URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Set these variables before starting the app if you want environment-based overri
 export DATABASE_URL="postgresql://USER:PASSWORD@HOST:5432/DBNAME?sslmode=disable"
 export DEEPAGENT_MODEL_PROVIDER="ollama"
 export DEEPAGENT_MODEL_BASE_URL="http://127.0.0.1:11434"
+# export DEEPAGENT_MODEL_ENDPOINT_URL="https://api.example.test/custom/chat/completions?api-version=2026-01-01"
 export DEEPAGENT_MODEL_NAME="gpt-oss:20b"
 export DEEPAGENT_MODEL_REASONING="medium"
 export DEEPAGENT_RECURSION_LIMIT="200"
@@ -163,9 +164,9 @@ uv run chainagents --photo scene.jpg --prompt "Describe this photo"
 ```
 
 Run `uv run chainagents --help` for all runtime flags, including model provider,
-base URL, API key, temperature, persistence, MCP session scope, async subagent
-URL, RAG controls, photo attachments, streaming, reasoning traces, tool traces,
-and JSON output.
+base URL, endpoint URL, API key, temperature, persistence, MCP session scope,
+async subagent URL, RAG controls, photo attachments, streaming, reasoning traces,
+tool traces, and JSON output.
 
 ## Model Config
 
@@ -193,15 +194,26 @@ reasoning_effort = "medium"
 # api_key = "optional"
 ```
 
+For OpenAI-compatible servers with a non-standard full chat-completions endpoint:
+
+```toml
+[model]
+provider = "openai_compatible"
+endpoint_url = "https://api.example.test/openai/deployments/local/chat/completions?api-version=2026-01-01"
+name = "your-loaded-model-id"
+# api_key = "optional"
+```
+
 Notes:
 
 - `provider` selects `ChatOllama` or `ChatOpenAI`.
 - Preferred shared fields are `base_url`, `name`, `temperature`, and `reasoning_effort`.
+- `endpoint_url` is an OpenAI-compatible override for full non-standard chat-completions URLs; query parameters are forwarded as OpenAI client default query parameters.
 - `models` is an optional list of model IDs surfaced in Chainlit settings and modes so users can switch models per session or per message.
 - `api_key` is optional and only used for `provider = "openai_compatible"`. When omitted, the runtime sends a placeholder token that local servers like LM Studio accept.
 - Legacy Ollama `endpoint` and `port` are still accepted when `provider = "ollama"` or omitted.
 - `reasoning_effort` sets the default Chainlit reasoning level for new chats. Ollama uses that level directly; OpenAI-compatible servers may ignore it.
-- `DEEPAGENT_MODEL_PROVIDER`, `DEEPAGENT_MODEL_BASE_URL`, `DEEPAGENT_MODEL_NAME`, `DEEPAGENT_MODEL_API_KEY`, and `DEEPAGENT_MODEL_REASONING` override the TOML defaults when set.
+- `DEEPAGENT_MODEL_PROVIDER`, `DEEPAGENT_MODEL_BASE_URL`, `DEEPAGENT_MODEL_ENDPOINT_URL`, `DEEPAGENT_MODEL_NAME`, `DEEPAGENT_MODEL_API_KEY`, and `DEEPAGENT_MODEL_REASONING` override the TOML defaults when set.
 - `OLLAMA_BASE_URL`, `OLLAMA_MODEL`, and `OLLAMA_REASONING` still work as Ollama-only compatibility aliases.
 
 ## Agent Runtime Config

--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ provider = "auto"
 Notes:
 
 - The default corpus is docs-only: `README.md`, `chainlit.md`, `prompts/**/*.md`, and `skills/**/*.md`.
+- `AGENTS.md` and `AGENT.md` stay out of RAG because `AGENTS.md` is loaded directly into the main agent prompt when present.
 - The persisted local index lives under [`.rag/`](.rag/) and is safe to delete and rebuild.
 - With `provider = "auto"`, the embedding backend follows the active chat-model provider.
 - For Ollama, the default embedding model is `nomic-embed-text`.
@@ -386,6 +387,7 @@ Supported subagent fields:
 Main `[agent]` additions:
 
 - `recursion_limit`: optional positive integer LangGraph step limit for a single agent run. Defaults to `100` unless overridden by `DEEPAGENT_RECURSION_LIMIT`.
+- `AGENTS.md`: optional repo-root file that is automatically appended to the **main/supervisor** agent system prompt when present. It is not applied to separately configured async graph prompts.
 - `custom_instruction`: optional string appended to the **main/supervisor** agent system prompt. This setting does **not** get applied to separately configured prompts such as the `async_researcher` graph prompt.
 - `summarization_middleware_enabled`: optional boolean (default `false`) to add LangChain's summarization middleware to the main agent and sync subagents.
 - `summarization_trigger_tokens`: optional positive integer token threshold that triggers summarization when reached.

--- a/chainagents_cli.py
+++ b/chainagents_cli.py
@@ -81,6 +81,13 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--provider", help="Model provider: ollama or openai_compatible.")
     parser.add_argument("--base-url", help="Model server base URL.")
+    parser.add_argument(
+        "--endpoint-url",
+        help=(
+            "OpenAI-compatible full endpoint URL. "
+            "Use this for non-standard /chat/completions paths."
+        ),
+    )
     parser.add_argument("--model", help="Model name to run.")
     parser.add_argument("--api-key", help="API key for OpenAI-compatible model servers.")
     parser.add_argument("--temperature", type=float, help="Model temperature.")
@@ -169,6 +176,7 @@ def runtime_overrides_from_args(args: argparse.Namespace) -> RuntimeConfigOverri
         model_provider=args.provider,
         model_name=args.model,
         model_base_url=args.base_url,
+        model_endpoint_url=args.endpoint_url,
         model_api_key=args.api_key,
         model_temperature=args.temperature,
         reasoning_level=args.reasoning,

--- a/chainlit.md
+++ b/chainlit.md
@@ -14,6 +14,7 @@ Local-first LangChain Deep Agent UI running on Ollama or any OpenAI-compatible s
 
 - Real repo files are available under `/workspace/`.
 - Memory is available under `/memories/`.
+- A repo-root `AGENTS.md` file is automatically included in the main agent system prompt when present.
 - Reuse the `LangGraph Thread ID` setting to continue a persisted thread.
 
 ## Model Defaults

--- a/chainlit.md
+++ b/chainlit.md
@@ -18,7 +18,7 @@ Local-first LangChain Deep Agent UI running on Ollama or any OpenAI-compatible s
 
 ## Model Defaults
 
-- `deepagent.toml` can define `[model]` with `provider`, `base_url`, `temperature`, `name`, optional `api_key`, and `reasoning_effort`
+- `deepagent.toml` can define `[model]` with `provider`, `base_url` or OpenAI-compatible `endpoint_url`, `temperature`, `name`, optional `api_key`, and `reasoning_effort`
 - if `deepagent.toml` is missing, the runtime defaults to `http://127.0.0.1:11434`, `gpt-oss:20b`, and `medium`
 - `DEEPAGENT_MODEL_*` env vars override the TOML defaults, and `OLLAMA_BASE_URL`, `OLLAMA_MODEL`, and `OLLAMA_REASONING` remain available as Ollama-only compatibility aliases
 

--- a/deepagent.toml.example
+++ b/deepagent.toml.example
@@ -8,6 +8,7 @@ reasoning_effort = "medium"
 # For LM Studio or another OpenAI-compatible server, switch to:
 # provider = "openai_compatible"
 # base_url = "http://127.0.0.1:1234/v1"
+# endpoint_url = "https://api.example.test/custom/chat/completions?api-version=2026-01-01"
 # name = "your-loaded-model-id"
 # api_key = ""
 

--- a/deepagent.toml.example
+++ b/deepagent.toml.example
@@ -27,6 +27,7 @@ transport = "http"
 url = "http://localhost:8000/mcp"
 
 [agent]
+# A repo-root AGENTS.md file is loaded automatically into the main agent prompt.
 # Relative skill source paths are resolved from this file and mapped to /workspace/...
 # This directory should contain one or more skill folders, each with its own SKILL.md.
 skills = ["skills"]

--- a/deepagent_runtime.py
+++ b/deepagent_runtime.py
@@ -62,6 +62,7 @@ DEFAULT_EXTENSIONS_CONFIG = "deepagent.toml"
 DEFAULT_RECURSION_LIMIT = 100
 PROJECT_ROOT = Path(__file__).resolve().parent
 DEEPAGENT_ARTIFACTS_DIRECTORY = Path(".files/deepagent")
+AGENTS_MD_FILENAME = "AGENTS.md"
 logger = logging.getLogger(__name__)
 OPENAI_CHAT_COMPLETIONS_PATH_SUFFIX = "/chat/completions"
 OPENAI_RESPONSES_PATH_SUFFIX = "/responses"
@@ -1112,15 +1113,40 @@ def parse_extensions_config(raw_config: dict[str, Any], config_path: Path) -> Ex
     )
 
 
-def compose_agent_system_prompt(base_prompt: str, custom_instruction: str | None) -> str:
+def load_agents_md_instruction(project_root: Path | None = None) -> str | None:
+    agents_md_path = (project_root or PROJECT_ROOT).resolve() / AGENTS_MD_FILENAME
+    try:
+        instruction = agents_md_path.read_text(encoding="utf-8").strip()
+    except FileNotFoundError:
+        return None
+    except OSError as exc:
+        logger.warning("Failed to read %s: %s", agents_md_path, exc)
+        return None
+    return instruction or None
+
+
+def compose_agent_system_prompt(
+    base_prompt: str,
+    custom_instruction: str | None,
+    *,
+    project_root: Path | None = None,
+) -> str:
+    sections = [base_prompt]
+    agents_md_instruction = load_agents_md_instruction(project_root)
+    if agents_md_instruction:
+        sections.append(
+            f"Repository instructions from {AGENTS_MD_FILENAME}:\n"
+            f"{agents_md_instruction}"
+        )
+
     instruction = (custom_instruction or "").strip()
     if not instruction:
-        return base_prompt
-    return (
-        f"{base_prompt}\n\n"
+        return "\n\n".join(sections)
+    sections.append(
         "Custom user instruction from [agent].custom_instruction in deepagent.toml:\n"
         f"{instruction}"
     )
+    return "\n\n".join(sections)
 
 
 def load_file_config(config_path: str | Path | None = None) -> FileConfig:
@@ -1246,16 +1272,24 @@ class RuntimeConfig:
             else ""
         )
 
+        endpoint_url_satisfies_provider_switch = (
+            model_provider == "openai_compatible" and bool(generic_model_endpoint_url)
+        )
         if (
             model_provider_override
             and model_provider != model_defaults.provider
             and not generic_model_base_url
-            and not generic_model_endpoint_url
+            and not endpoint_url_satisfies_provider_switch
         ):
+            required_url_env = "DEEPAGENT_MODEL_BASE_URL"
+            if model_provider == "openai_compatible":
+                required_url_env = (
+                    "DEEPAGENT_MODEL_BASE_URL or DEEPAGENT_MODEL_ENDPOINT_URL"
+                )
             raise ValueError(
                 "Switching model providers via DEEPAGENT_MODEL_PROVIDER also requires "
-                "DEEPAGENT_MODEL_BASE_URL or DEEPAGENT_MODEL_ENDPOINT_URL so the "
-                "new provider does not inherit an incompatible endpoint."
+                f"{required_url_env} so the new provider does not inherit an "
+                "incompatible endpoint."
             )
 
         if (
@@ -1634,6 +1668,7 @@ def create_configured_graph(
                     if apply_custom_instruction
                     else None
                 ),
+                project_root=PROJECT_ROOT,
             ),
             rag_enabled=config.rag is not None,
         ),
@@ -1853,6 +1888,7 @@ class AgentRuntime:
                         compose_agent_system_prompt(
                             SYSTEM_PROMPT,
                             self.config.extensions.custom_instruction,
+                            project_root=self.project_root,
                         ),
                         rag_enabled=rag_tool_enabled,
                     ),

--- a/deepagent_runtime.py
+++ b/deepagent_runtime.py
@@ -12,7 +12,7 @@ from contextlib import AsyncExitStack
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 from typing import Any, Literal
-from urllib.parse import urlsplit, urlunsplit
+from urllib.parse import parse_qsl, urlsplit, urlunsplit
 
 from deepagents import AsyncSubAgent, create_deep_agent
 from deepagents.backends import (
@@ -63,6 +63,8 @@ DEFAULT_RECURSION_LIMIT = 100
 PROJECT_ROOT = Path(__file__).resolve().parent
 DEEPAGENT_ARTIFACTS_DIRECTORY = Path(".files/deepagent")
 logger = logging.getLogger(__name__)
+OPENAI_CHAT_COMPLETIONS_PATH_SUFFIX = "/chat/completions"
+OPENAI_RESPONSES_PATH_SUFFIX = "/responses"
 
 OPENAI_COMPATIBLE_REASONING_DELTA_KEYS = (
     "reasoning_content",
@@ -251,6 +253,44 @@ def normalize_model_base_url(
     if "://" not in candidate:
         candidate = f"http://{candidate}"
     return candidate.rstrip("/")
+
+
+def normalize_openai_endpoint_url(
+    value: Any | None,
+    *,
+    required_message: str | None = None,
+) -> tuple[str, tuple[tuple[str, str], ...]]:
+    candidate = normalize_model_base_url(
+        value,
+        required_message=required_message,
+    )
+    parsed = urlsplit(candidate)
+    path = parsed.path.rstrip("/")
+    for suffix in (
+        OPENAI_CHAT_COMPLETIONS_PATH_SUFFIX,
+        OPENAI_RESPONSES_PATH_SUFFIX,
+    ):
+        if path.endswith(suffix):
+            path = path[: -len(suffix)].rstrip("/")
+            break
+
+    base_url = urlunsplit((parsed.scheme, parsed.netloc, path, "", "")).rstrip("/")
+    return base_url, tuple(parse_qsl(parsed.query, keep_blank_values=True))
+
+
+def model_endpoint_query_to_dict(
+    query: tuple[tuple[str, str], ...],
+) -> dict[str, object]:
+    values: dict[str, object] = {}
+    for key, value in query:
+        existing = values.get(key)
+        if existing is None:
+            values[key] = value
+        elif isinstance(existing, list):
+            existing.append(value)
+        else:
+            values[key] = [existing, value]
+    return values
 
 
 def normalize_optional_string(value: Any | None) -> str | None:
@@ -683,6 +723,7 @@ class ExtensionsConfig:
 class ModelDefaults:
     provider: ModelProvider = DEFAULT_MODEL_PROVIDER
     base_url: str = DEFAULT_OLLAMA_BASE_URL
+    endpoint_query: tuple[tuple[str, str], ...] = ()
     name: str = DEFAULT_MODEL
     api_key: str | None = None
     models: tuple[str, ...] = ()
@@ -720,6 +761,8 @@ def parse_model_defaults(raw_config: dict[str, Any]) -> ModelDefaults:
         )
 
     raw_base_url = str(raw_model.get("base_url", "")).strip()
+    raw_endpoint_url = raw_model.get("endpoint_url")
+    endpoint_query: tuple[tuple[str, str], ...] = ()
     if provider == "ollama":
         if raw_base_url:
             base_url = normalize_model_base_url(
@@ -732,16 +775,25 @@ def parse_model_defaults(raw_config: dict[str, Any]) -> ModelDefaults:
                 normalize_model_port(raw_model.get("port")),
             )
     else:
-        base_url = normalize_model_base_url(
-            raw_model.get("base_url"),
-            required_message=(
-                "OpenAI-compatible model config must define a non-empty 'base_url'."
-            ),
+        required_message = (
+            "OpenAI-compatible model config must define a non-empty "
+            "'base_url' or 'endpoint_url'."
         )
+        if normalize_optional_string(raw_endpoint_url):
+            base_url, endpoint_query = normalize_openai_endpoint_url(
+                raw_endpoint_url,
+                required_message=required_message,
+            )
+        else:
+            base_url = normalize_model_base_url(
+                raw_model.get("base_url"),
+                required_message=required_message,
+            )
 
     return ModelDefaults(
         provider=provider,
         base_url=base_url,
+        endpoint_query=endpoint_query,
         name=raw_name or (parsed_models[0] if parsed_models else DEFAULT_MODEL),
         api_key=normalize_optional_string(raw_model.get("api_key")),
         models=tuple(parsed_models),
@@ -1111,6 +1163,7 @@ class RuntimeConfigOverrides:
     model_provider: str | None = None
     model_name: str | None = None
     model_base_url: str | None = None
+    model_endpoint_url: str | None = None
     model_api_key: str | None = None
     model_temperature: float | None = None
     reasoning_level: str | None = None
@@ -1134,6 +1187,7 @@ class RuntimeConfig:
     rag_requested: bool = False
     rag: ResolvedRagConfig | None = None
     rag_error: str | None = None
+    model_endpoint_query: tuple[tuple[str, str], ...] = ()
 
     @classmethod
     def from_env(
@@ -1168,27 +1222,40 @@ class RuntimeConfig:
             normalize_optional_string(overrides.model_base_url)
             or os.getenv("DEEPAGENT_MODEL_BASE_URL", "").strip()
         )
+        generic_model_endpoint_url = (
+            normalize_optional_string(overrides.model_endpoint_url)
+            or os.getenv("DEEPAGENT_MODEL_ENDPOINT_URL", "").strip()
+        )
         generic_model_reasoning = (
             normalize_optional_string(overrides.reasoning_level)
             or os.getenv("DEEPAGENT_MODEL_REASONING", "").strip()
         )
-        model_name_alias = os.getenv("OLLAMA_MODEL", "").strip() if model_provider == "ollama" else ""
+        model_name_alias = (
+            os.getenv("OLLAMA_MODEL", "").strip()
+            if model_provider == "ollama"
+            else ""
+        )
         model_base_url_alias = (
-            os.getenv("OLLAMA_BASE_URL", "").strip() if model_provider == "ollama" else ""
+            os.getenv("OLLAMA_BASE_URL", "").strip()
+            if model_provider == "ollama"
+            else ""
         )
         model_reasoning_alias = (
-            os.getenv("OLLAMA_REASONING", "").strip() if model_provider == "ollama" else ""
+            os.getenv("OLLAMA_REASONING", "").strip()
+            if model_provider == "ollama"
+            else ""
         )
 
         if (
             model_provider_override
             and model_provider != model_defaults.provider
             and not generic_model_base_url
+            and not generic_model_endpoint_url
         ):
             raise ValueError(
                 "Switching model providers via DEEPAGENT_MODEL_PROVIDER also requires "
-                "DEEPAGENT_MODEL_BASE_URL so the new provider does not inherit an "
-                "incompatible endpoint."
+                "DEEPAGENT_MODEL_BASE_URL or DEEPAGENT_MODEL_ENDPOINT_URL so the "
+                "new provider does not inherit an incompatible endpoint."
             )
 
         if (
@@ -1210,10 +1277,21 @@ class RuntimeConfig:
                 ]
             )
         )
-        model_base_url = normalize_model_base_url(
-            generic_model_base_url or model_base_url_alias or model_defaults.base_url,
-            required_message="The model base URL cannot be empty.",
-        )
+        model_endpoint_query = model_defaults.endpoint_query
+        if model_provider == "openai_compatible" and generic_model_endpoint_url:
+            model_base_url, model_endpoint_query = normalize_openai_endpoint_url(
+                generic_model_endpoint_url,
+                required_message="The model endpoint URL cannot be empty.",
+            )
+        else:
+            model_base_url = normalize_model_base_url(
+                generic_model_base_url
+                or model_base_url_alias
+                or model_defaults.base_url,
+                required_message="The model base URL cannot be empty.",
+            )
+            if generic_model_base_url or model_base_url_alias:
+                model_endpoint_query = ()
         if overrides.model_api_key is not None:
             model_api_key = normalize_optional_string(overrides.model_api_key)
         else:
@@ -1267,6 +1345,7 @@ class RuntimeConfig:
             rag_requested=rag_requested,
             rag=rag,
             rag_error=rag_error,
+            model_endpoint_query=model_endpoint_query,
         )
 
 
@@ -1291,6 +1370,9 @@ def build_model(
         "api_key": config.model_api_key or "deepagent",
         "temperature": config.model_temperature,
     }
+    default_query = model_endpoint_query_to_dict(config.model_endpoint_query)
+    if default_query:
+        kwargs["default_query"] = default_query
     return OpenAICompatibleChatOpenAI(**kwargs)
 
 

--- a/tests/test_agent_cli.py
+++ b/tests/test_agent_cli.py
@@ -101,6 +101,40 @@ recursion_limit = 20
     assert config.rag_requested is False
 
 
+def test_cli_endpoint_url_override_supplies_openai_default_query(
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "deepagent.toml"
+    config_path.write_text(
+        """
+[model]
+provider = "ollama"
+base_url = "http://config.example:11434"
+name = "config-model"
+""".strip(),
+        encoding="utf-8",
+    )
+    args = chainagents_cli.parse_args(
+        [
+            "--config",
+            str(config_path),
+            "--provider",
+            "openai_compatible",
+            "--endpoint-url",
+            "https://api.example.test/proxy/chat/completions?api-version=2026-01-01",
+            "--model",
+            "cli-model",
+            "--status",
+        ]
+    )
+
+    config = RuntimeConfig.from_env(chainagents_cli.runtime_overrides_from_args(args))
+
+    assert config.model_provider == "openai_compatible"
+    assert config.model_base_url == "https://api.example.test/proxy"
+    assert config.model_endpoint_query == (("api-version", "2026-01-01"),)
+
+
 class _FakeMcpRuntime:
     def __init__(self) -> None:
         self.config = SimpleNamespace(

--- a/tests/test_deepagent_runtime_rag.py
+++ b/tests/test_deepagent_runtime_rag.py
@@ -249,6 +249,30 @@ models = ["gpt-oss:20b", "gemma4:27b"]
     assert config.model_choices == ("gpt-oss:20b", "gemma4:27b")
 
 
+def test_runtime_config_reads_openai_endpoint_url_from_toml(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    config_path = tmp_path / "deepagent.toml"
+    config_path.write_text(
+        """
+[model]
+provider = "openai_compatible"
+endpoint_url = "https://api.example.test/openai/deployments/local/chat/completions?api-version=2026-01-01"
+name = "local-model"
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DEEPAGENT_CONFIG", str(config_path))
+
+    config = deepagent_runtime.RuntimeConfig.from_env()
+    model = deepagent_runtime.build_model(config, "medium")
+
+    assert config.model_base_url == "https://api.example.test/openai/deployments/local"
+    assert config.model_endpoint_query == (("api-version", "2026-01-01"),)
+    assert model.default_query == {"api-version": "2026-01-01"}
+
+
 def test_runtime_config_reads_recursion_limit_from_toml(
     tmp_path: Path,
     monkeypatch,

--- a/tests/test_deepagent_runtime_rag.py
+++ b/tests/test_deepagent_runtime_rag.py
@@ -273,6 +273,33 @@ name = "local-model"
     assert model.default_query == {"api-version": "2026-01-01"}
 
 
+def test_runtime_config_rejects_ollama_provider_switch_with_only_endpoint_url(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    config_path = tmp_path / "deepagent.toml"
+    config_path.write_text(
+        """
+[model]
+provider = "openai_compatible"
+base_url = "https://api.example.test/openai/v1"
+name = "remote-model"
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DEEPAGENT_CONFIG", str(config_path))
+    monkeypatch.setenv("DEEPAGENT_MODEL_PROVIDER", "ollama")
+    monkeypatch.setenv(
+        "DEEPAGENT_MODEL_ENDPOINT_URL",
+        "http://127.0.0.1:11434/v1/chat/completions",
+    )
+    monkeypatch.delenv("DEEPAGENT_MODEL_BASE_URL", raising=False)
+    monkeypatch.delenv("OLLAMA_BASE_URL", raising=False)
+
+    with pytest.raises(ValueError, match="DEEPAGENT_MODEL_BASE_URL"):
+        deepagent_runtime.RuntimeConfig.from_env()
+
+
 def test_runtime_config_reads_recursion_limit_from_toml(
     tmp_path: Path,
     monkeypatch,
@@ -930,6 +957,39 @@ def test_build_chainlit_command_catalog_includes_main_and_subagent_skills(
     assert commands[0].value == str(tmp_path / "skills/reviewer/SKILL.md")
     assert commands[1].value == str(tmp_path / "subskills/repo-guide/SKILL.md")
     assert notes == ()
+
+
+def test_compose_agent_system_prompt_includes_agents_md(
+    tmp_path: Path,
+) -> None:
+    agents_md = tmp_path / "AGENTS.md"
+    agents_md.write_text(
+        "# Agent Notes\n\nPrefer focused changes.",
+        encoding="utf-8",
+    )
+
+    prompt = deepagent_runtime.compose_agent_system_prompt(
+        "Base prompt.",
+        "Use direct answers.",
+        project_root=tmp_path,
+    )
+
+    assert "Base prompt." in prompt
+    assert "Repository instructions from AGENTS.md:" in prompt
+    assert "Prefer focused changes." in prompt
+    assert prompt.index("Prefer focused changes.") < prompt.index("Use direct answers.")
+
+
+def test_compose_agent_system_prompt_ignores_missing_agents_md(
+    tmp_path: Path,
+) -> None:
+    prompt = deepagent_runtime.compose_agent_system_prompt(
+        "Base prompt.",
+        None,
+        project_root=tmp_path,
+    )
+
+    assert prompt == "Base prompt."
 
 
 def test_build_chainlit_command_catalog_uses_backend_workspace_root_when_project_root_missing(


### PR DESCRIPTION
## Summary
- Add `[model].endpoint_url` and `DEEPAGENT_MODEL_ENDPOINT_URL` for OpenAI-compatible servers
- Add `--endpoint-url` to the CLI and thread the value through runtime overrides
- Parse full non-standard chat-completions or responses URLs into `ChatOpenAI` base URL plus default query params
- Update README, Chainlit docs, and the example config to show the new setting
- Add regression tests for TOML and CLI configuration paths

## Testing
- Added unit tests covering endpoint URL parsing and runtime config resolution
- `uv run pytest -q`