### PR TITLE
Show summarization status in CLI and Chainlit

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,6 +392,7 @@ Main `[agent]` additions:
 - `summarization_middleware_enabled`: optional boolean (default `false`) to add LangChain's summarization middleware to the main agent and sync subagents.
 - `summarization_trigger_tokens`: optional positive integer token threshold that triggers summarization when reached.
 - `summarization_keep_tokens`: optional positive integer token budget to keep in conversation history after summarization.
+- When summarization runs, the CLI prints a summarization status panel and Chainlit shows a summarization step in the UI.
 
 ## Chainlit Native Commands
 

--- a/chainagents_cli.py
+++ b/chainagents_cli.py
@@ -38,6 +38,7 @@ from rag_runtime import RagStatus, RagUploadResult, UploadedRagFile
 
 DEFAULT_CLI_THREAD_ID = "cli"
 TOOL_RESULT_PREVIEW_CHARS = 200
+SUMMARIZATION_STATUS_KIND = "summarization_status"
 LANGGRAPH_STREAM_MODES = {
     "values",
     "updates",
@@ -476,6 +477,8 @@ class CliEventRenderer:
             self._handle_message_chunk(part)
         elif kind == "updates":
             self._handle_update_chunk(part)
+        elif kind == "custom":
+            self._handle_custom_chunk(part)
 
     def finish(self) -> str:
         self._close_reasoning_line()
@@ -536,6 +539,36 @@ class CliEventRenderer:
             for message in messages_from_node_data(data):
                 if getattr(message, "type", None) == "tool":
                     self._complete_tool(source, message)
+
+    def _handle_custom_chunk(self, part: dict[str, Any]) -> None:
+        data = part.get("data")
+        if not isinstance(data, dict):
+            return
+        if data.get("kind") != SUMMARIZATION_STATUS_KIND:
+            return
+        if self.json_output:
+            return
+
+        status = str(data.get("status") or "triggered").strip() or "triggered"
+        source = str(data.get("source") or "main-agent").strip() or "main-agent"
+        message = str(data.get("message") or "Conversation summarization triggered.").strip()
+        self._close_reasoning_line()
+        body = Text.assemble(
+            ("status: ", "dim"),
+            (status, "bold cyan"),
+            ("\nsource: ", "dim"),
+            (source, "cyan"),
+        )
+        if message:
+            body.append("\nmessage: ", style="dim")
+            body.append(message, style="white")
+        self.stderr_console.print(
+            cli_panel(
+                body,
+                title="Summarization",
+                border_style="cyan",
+            )
+        )
 
     def _stream_response(self, text: str) -> None:
         delta = text[len(self.response_buffer) :] if text.startswith(self.response_buffer) else text
@@ -1013,7 +1046,7 @@ async def run_agent_prompt(
         payload,
         config=config,
         version="v2",
-        stream_mode=["messages", "updates"],
+        stream_mode=["messages", "updates", "custom"],
         subgraphs=True,
     )
 

--- a/chainlit.md
+++ b/chainlit.md
@@ -22,6 +22,7 @@ Local-first LangChain Deep Agent UI running on Ollama or any OpenAI-compatible s
 - `deepagent.toml` can define `[model]` with `provider`, `base_url` or OpenAI-compatible `endpoint_url`, `temperature`, `name`, optional `api_key`, and `reasoning_effort`
 - if `deepagent.toml` is missing, the runtime defaults to `http://127.0.0.1:11434`, `gpt-oss:20b`, and `medium`
 - `DEEPAGENT_MODEL_*` env vars override the TOML defaults, and `OLLAMA_BASE_URL`, `OLLAMA_MODEL`, and `OLLAMA_REASONING` remain available as Ollama-only compatibility aliases
+- When summarization middleware compacts conversation history, Chainlit shows a summarization status step.
 
 ## Optional Persistence
 

--- a/chainlit_bridge.py
+++ b/chainlit_bridge.py
@@ -18,6 +18,7 @@ DEFAULT_AUTO_COLLAPSE_DELAY_SECONDS = 3.0
 RESPONSE_STREAM_FLUSH_INTERVAL_SECONDS = 0.05
 RESPONSE_STREAM_FLUSH_CHARS = 1024
 CHAINLIT_APP_CONFIG_PATH = Path(__file__).resolve().parent / "chainlit.toml"
+SUMMARIZATION_STATUS_KIND = "summarization_status"
 LANGGRAPH_STREAM_MODES = {
     "values",
     "updates",
@@ -601,6 +602,7 @@ class ChainlitEventBridge:
         self.reasoning_steps: dict[str, cl.Step] = {}
         self.reasoning_buffers: dict[str, str] = {}
         self.tool_steps: dict[str, ToolStepState] = {}
+        self.summarization_steps: dict[str, cl.Step] = {}
         self.collapse_scheduled_step_ids: set[str] = set()
         self.pending_collapse_tasks: set[asyncio.Task[Any]] = set()
 
@@ -616,6 +618,9 @@ class ChainlitEventBridge:
             return
         if kind == "updates":
             await self._handle_update_chunk(part)
+            return
+        if kind == "custom":
+            await self._handle_custom_chunk(part)
 
     async def handle_event(self, event: dict[str, Any]) -> None:
         if event.get("event") != "on_chain_stream":
@@ -708,6 +713,34 @@ class ChainlitEventBridge:
             for message in messages_from_node_data(data):
                 if getattr(message, "type", None) == "tool":
                     await self._complete_tool_step(source, message)
+
+    async def _handle_custom_chunk(self, part: dict[str, Any]) -> None:
+        data = part.get("data")
+        if not isinstance(data, dict):
+            return
+        if data.get("kind") != SUMMARIZATION_STATUS_KIND:
+            return
+
+        source = str(data.get("source") or "main-agent").strip() or "main-agent"
+        status = str(data.get("status") or "triggered").strip().lower() or "triggered"
+        message = str(data.get("message") or "Conversation summarization triggered.").strip()
+        step = self.summarization_steps.get(source)
+        if step is None:
+            step = cl.Step(
+                name=f"{source} summarization",
+                type="llm",
+                default_open=True,
+            )
+            step.input = self.prompt if source == "main-agent" else ""
+            step.start = utc_now()
+            await step.send()
+            self.summarization_steps[source] = step
+
+        step.output = message
+        if status in {"completed", "skipped", "failed"}:
+            step.end = utc_now()
+            self._schedule_step_auto_collapse(step)
+        await step.update()
 
     async def _stream_reasoning(self, source: str, text: str) -> None:
         previous = self.reasoning_buffers.get(source, "")
@@ -900,6 +933,13 @@ class ChainlitEventBridge:
             await step.update()
             self._schedule_step_auto_collapse(step)
         self.reasoning_steps.clear()
+
+        for step in self.summarization_steps.values():
+            if not step.end:
+                step.end = utc_now()
+            await step.update()
+            self._schedule_step_auto_collapse(step)
+        self.summarization_steps.clear()
 
     def _schedule_step_auto_collapse(self, step: cl.Step) -> None:
         if step.id in self.collapse_scheduled_step_ids:

--- a/deepagent.toml
+++ b/deepagent.toml
@@ -39,6 +39,10 @@ cwd = "."
 recursion_limit = 200
 skills = ["skills"]
 mcp_servers = ["repo"]
+summarization_middleware_enabled = true
+# Optional token thresholds used when the installed LangChain middleware supports them.
+summarization_trigger_tokens = 1000
+summarization_keep_tokens = 500
 
 [rag]
 enabled = true

--- a/deepagent_runtime.py
+++ b/deepagent_runtime.py
@@ -73,6 +73,7 @@ OPENAI_COMPATIBLE_REASONING_DELTA_KEYS = (
     "reasoning_text",
     "reasoning_details",
 )
+SUMMARIZATION_STATUS_EVENT_KIND = "summarization_status"
 
 SYSTEM_PROMPT = f"""
 You are a local workspace deep agent running inside a Chainlit UI.
@@ -439,11 +440,88 @@ class ToolExecutionResilienceMiddleware(AgentMiddleware[Any, Any, Any]):
             return self._error_tool_message(request, exc)
 
 
+class SummarizationStatusMiddleware(AgentMiddleware[Any, Any, Any]):
+    def __init__(self, inner: AgentMiddleware[Any, Any, Any], *, source: str = "main-agent") -> None:
+        super().__init__()
+        self.inner = inner
+        self.source = source
+
+    @property
+    def name(self) -> str:
+        return str(getattr(self.inner, "name", "SummarizationMiddleware"))
+
+    def before_model(self, state: Any, runtime: Any) -> dict[str, Any] | None:
+        will_summarize = self._will_summarize(state)
+        if will_summarize:
+            self._emit(runtime, "started", "Conversation summarization triggered.")
+        try:
+            result = self.inner.before_model(state, runtime)
+        except Exception:
+            if will_summarize:
+                self._emit(runtime, "failed", "Conversation summarization failed.")
+            raise
+        if result is not None:
+            if not will_summarize:
+                self._emit(runtime, "started", "Conversation summarization triggered.")
+            self._emit(runtime, "completed", "Conversation summarization completed.")
+        return result
+
+    async def abefore_model(self, state: Any, runtime: Any) -> dict[str, Any] | None:
+        will_summarize = self._will_summarize(state)
+        if will_summarize:
+            self._emit(runtime, "started", "Conversation summarization triggered.")
+        try:
+            result = await self.inner.abefore_model(state, runtime)
+        except Exception:
+            if will_summarize:
+                self._emit(runtime, "failed", "Conversation summarization failed.")
+            raise
+        if result is not None:
+            if not will_summarize:
+                self._emit(runtime, "started", "Conversation summarization triggered.")
+            self._emit(runtime, "completed", "Conversation summarization completed.")
+        return result
+
+    def _will_summarize(self, state: Any) -> bool:
+        try:
+            messages = state["messages"]
+            ensure_ids = getattr(self.inner, "_ensure_message_ids", None)
+            if callable(ensure_ids):
+                ensure_ids(messages)
+            token_counter = getattr(self.inner, "token_counter")
+            should_summarize = getattr(self.inner, "_should_summarize")
+            determine_cutoff = getattr(self.inner, "_determine_cutoff_index")
+            total_tokens = token_counter(messages)
+            return bool(
+                should_summarize(messages, total_tokens)
+                and determine_cutoff(messages) > 0
+            )
+        except Exception:
+            return False
+
+    def _emit(self, runtime: Any, status: str, message: str) -> None:
+        stream_writer = getattr(runtime, "stream_writer", None)
+        if not callable(stream_writer):
+            return
+        try:
+            stream_writer(
+                {
+                    "kind": SUMMARIZATION_STATUS_EVENT_KIND,
+                    "status": status,
+                    "source": self.source,
+                    "message": message,
+                }
+            )
+        except Exception as exc:
+            logger.debug("Failed to emit summarization status event: %s", exc)
+
+
 def _build_summarization_middleware(
     *,
     config: RuntimeConfig,
     reasoning_level: ReasoningLevel,
     model_name: str | None = None,
+    source: str = "main-agent",
 ) -> AgentMiddleware[Any, Any, Any] | None:
     try:
         from langchain.agents.middleware import SummarizationMiddleware
@@ -479,7 +557,7 @@ def _build_summarization_middleware(
             exc,
         )
         return None
-    return middleware
+    return SummarizationStatusMiddleware(middleware, source=source)
 
 
 def build_agent_middleware(
@@ -487,6 +565,7 @@ def build_agent_middleware(
     config: RuntimeConfig | None = None,
     reasoning_level: ReasoningLevel | None = None,
     model_name: str | None = None,
+    source: str = "main-agent",
     project_root: Path | None = None,
 ) -> list[AgentMiddleware[Any, Any, Any]]:
     middleware: list[AgentMiddleware[Any, Any, Any]] = [
@@ -501,6 +580,7 @@ def build_agent_middleware(
             config=config,
             reasoning_level=reasoning_level,
             model_name=model_name,
+            source=source,
         )
         if summarization_middleware is not None:
             middleware.append(summarization_middleware)
@@ -1624,6 +1704,7 @@ def build_graph_subagent_specs(
                 config=config,
                 reasoning_level=config.default_reasoning,
                 model_name=subagent.model,
+                source=subagent.name,
             )
         )
         for subagent in config.extensions.subagents
@@ -1675,6 +1756,7 @@ def create_configured_graph(
         middleware=build_agent_middleware(
             config=config,
             reasoning_level=config.default_reasoning,
+            source="main-agent",
             project_root=PROJECT_ROOT,
         ),
         backend=build_deepagent_backend(),
@@ -1854,6 +1936,7 @@ class AgentRuntime:
                     config=self.config,
                     reasoning_level=reasoning_level,
                     model_name=selected_model,
+                    source="main-agent",
                     project_root=self.project_root,
                 )
                 subagent_specs: list[Any] = [
@@ -1870,6 +1953,7 @@ class AgentRuntime:
                             config=self.config,
                             reasoning_level=reasoning_level,
                             model_name=subagent.model or selected_model,
+                            source=subagent.name,
                             project_root=self.project_root,
                         ),
                     )

--- a/main.py
+++ b/main.py
@@ -893,7 +893,7 @@ async def on_message(message: cl.Message) -> None:
         payload,
         config=config,
         version="v2",
-        stream_mode=["messages", "updates"],
+        stream_mode=["messages", "updates", "custom"],
         subgraphs=True,
     )
 

--- a/tests/test_agent_cli.py
+++ b/tests/test_agent_cli.py
@@ -600,6 +600,43 @@ async def test_cli_event_renderer_uses_block_panel_for_tool_call_start() -> None
 
 
 @pytest.mark.anyio
+async def test_cli_event_renderer_shows_summarization_status() -> None:
+    stderr = io.StringIO()
+    renderer = chainagents_cli.CliEventRenderer(
+        prompt="hello",
+        stdout=io.StringIO(),
+        stderr=stderr,
+        stream=True,
+        json_output=False,
+        show_reasoning=False,
+        show_tools=False,
+    )
+
+    await renderer.handle_event(
+        {
+            "event": "on_chain_stream",
+            "data": {
+                "chunk": (
+                    "custom",
+                    {
+                        "kind": "summarization_status",
+                        "status": "started",
+                        "source": "main-agent",
+                        "message": "Conversation summarization triggered.",
+                    },
+                ),
+            },
+        }
+    )
+
+    output = stderr.getvalue()
+    assert "Summarization" in output
+    assert "status: started" in output
+    assert "source: main-agent" in output
+    assert "Conversation summarization triggered." in output
+
+
+@pytest.mark.anyio
 async def test_cli_event_renderer_accumulates_tool_args_across_chunks() -> None:
     stderr = io.StringIO()
     renderer = chainagents_cli.CliEventRenderer(

--- a/tests/test_chainlit_bridge_streaming.py
+++ b/tests/test_chainlit_bridge_streaming.py
@@ -46,10 +46,41 @@ class _ResponseMessage:
         self.update_count += 1
 
 
+class _Step:
+    instances: list["_Step"] = []
+
+    def __init__(
+        self,
+        name: str,
+        type: str,
+        default_open: bool = False,
+        **_kwargs: Any,
+    ) -> None:
+        self.name = name
+        self.type = type
+        self.default_open = default_open
+        self.input: Any = None
+        self.output: Any = None
+        self.start: Any = None
+        self.end: Any = None
+        self.send_count = 0
+        self.update_count = 0
+        self.id = f"step-{len(self.instances) + 1}"
+        self.instances.append(self)
+
+    async def send(self) -> None:
+        self.send_count += 1
+
+    async def update(self) -> None:
+        self.update_count += 1
+
+
 @pytest.fixture(autouse=True)
 def _patch_chainlit_tasks(monkeypatch) -> None:
+    _Step.instances.clear()
     monkeypatch.setattr(chainlit_bridge.cl, "TaskStatus", _TaskStatus)
     monkeypatch.setattr(chainlit_bridge.cl, "Task", _Task)
+    monkeypatch.setattr(chainlit_bridge.cl, "Step", _Step)
 
 
 @pytest.mark.anyio
@@ -165,3 +196,34 @@ async def test_astream_events_ignores_non_langgraph_stream_chunks() -> None:
     )
 
     assert handled_parts == []
+
+
+@pytest.mark.anyio
+async def test_chainlit_bridge_shows_summarization_status() -> None:
+    bridge = ChainlitEventBridge(prompt="hello")
+
+    await bridge.handle_event(
+        {
+            "event": "on_chain_stream",
+            "data": {
+                "chunk": (
+                    "custom",
+                    {
+                        "kind": "summarization_status",
+                        "status": "started",
+                        "source": "main-agent",
+                        "message": "Conversation summarization triggered.",
+                    },
+                ),
+            },
+        }
+    )
+
+    assert len(_Step.instances) == 1
+    step = _Step.instances[0]
+    assert step.name == "main-agent summarization"
+    assert step.type == "llm"
+    assert step.default_open is True
+    assert step.output == "Conversation summarization triggered."
+    assert step.send_count == 1
+    assert step.update_count == 1

--- a/tests/test_deepagent_runtime_rag.py
+++ b/tests/test_deepagent_runtime_rag.py
@@ -562,21 +562,72 @@ def test_get_agent_includes_summarization_middleware_when_enabled(
     middleware = captured["kwargs"]["middleware"]
     assert any(isinstance(item, ToolExecutionResilienceMiddleware) for item in middleware)
     summarizers = [
-        item for item in middleware if isinstance(item, FakeSummarizationMiddleware)
+        item.inner
+        for item in middleware
+        if isinstance(item, deepagent_runtime.SummarizationStatusMiddleware)
     ]
     assert len(summarizers) == 1
+    assert isinstance(summarizers[0], FakeSummarizationMiddleware)
     assert summarizers[0].model == "model::gpt-oss:20b"
     assert summarizers[0].trigger == ("tokens", 5000)
     assert summarizers[0].keep == ("tokens", 2000)
     subagent_specs = captured["kwargs"]["subagents"]
     subagent_middleware = subagent_specs[0]["middleware"]
     subagent_summarizers = [
-        item
+        item.inner
         for item in subagent_middleware
-        if isinstance(item, FakeSummarizationMiddleware)
+        if isinstance(item, deepagent_runtime.SummarizationStatusMiddleware)
     ]
     assert len(subagent_summarizers) == 1
+    assert isinstance(subagent_summarizers[0], FakeSummarizationMiddleware)
     assert subagent_summarizers[0].model == "model::gpt-oss:120b"
+
+
+def test_summarization_status_middleware_emits_stream_events() -> None:
+    events: list[dict[str, str]] = []
+
+    class FakeRuntime:
+        def stream_writer(self, event: dict[str, str]) -> None:
+            events.append(event)
+
+    class FakeSummarizationMiddleware:
+        def token_counter(self, messages) -> int:
+            return 12
+
+        def _should_summarize(self, messages, total_tokens: int) -> bool:
+            return total_tokens >= 10
+
+        def _determine_cutoff_index(self, messages) -> int:
+            return 1
+
+        def before_model(self, state, runtime):
+            return {"messages": ["summary"]}
+
+    middleware = deepagent_runtime.SummarizationStatusMiddleware(
+        FakeSummarizationMiddleware(),
+        source="main-agent",
+    )
+
+    result = middleware.before_model(
+        {"messages": ["one", "two"]},
+        FakeRuntime(),
+    )
+
+    assert result == {"messages": ["summary"]}
+    assert events == [
+        {
+            "kind": "summarization_status",
+            "status": "started",
+            "source": "main-agent",
+            "message": "Conversation summarization triggered.",
+        },
+        {
+            "kind": "summarization_status",
+            "status": "completed",
+            "source": "main-agent",
+            "message": "Conversation summarization completed.",
+        },
+    ]
 
 
 def test_get_agent_omits_rag_tool_when_service_is_missing(


### PR DESCRIPTION
## Summary
- Add a custom summarization status event to the LangGraph stream when summarization middleware runs.
- Render that event as a status panel in the CLI and as a step in the Chainlit UI.
- Extend the shared stream subscriptions to include `custom` events.
- Add tests covering the runtime event emitter and both renderers.

## Testing
- `uv run pytest -q`
- Result: `85 passed`