### PR TITLE
Add configurable Ollama repeat_penalty in model config

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ You can keep the model defaults in `deepagent.toml`:
 provider = "ollama"
 base_url = "http://127.0.0.1:11434"
 temperature = 0
+repeat_penalty = 1.1
 name = "gpt-oss:20b"
 models = ["gpt-oss:20b", "gemma4:27b"]
 reasoning_effort = "medium"
@@ -208,6 +209,7 @@ Notes:
 
 - `provider` selects `ChatOllama` or `ChatOpenAI`.
 - Preferred shared fields are `base_url`, `name`, `temperature`, and `reasoning_effort`.
+- `repeat_penalty` is optional and currently applies to `provider = "ollama"`; when omitted, Ollama defaults are used.
 - `endpoint_url` is an OpenAI-compatible override for full non-standard chat-completions URLs; query parameters are forwarded as OpenAI client default query parameters.
 - `models` is an optional list of model IDs surfaced in Chainlit settings and modes so users can switch models per session or per message.
 - `api_key` is optional and only used for `provider = "openai_compatible"`. When omitted, the runtime sends a placeholder token that local servers like LM Studio accept.

--- a/deepagent.toml
+++ b/deepagent.toml
@@ -2,6 +2,7 @@
 provider = "ollama"
 base_url = "http://127.0.0.1:11434"
 temperature = 0.3
+repeat_penalty = 1.1
 
 name = "gemma4:26b"
 #models = ["gpt-oss:20b", "gemma4:26b", "qwen3.6:27b"]

--- a/deepagent_runtime.py
+++ b/deepagent_runtime.py
@@ -1306,10 +1306,10 @@ class RuntimeConfig:
     model_base_url: str
     model_api_key: str | None
     model_temperature: float
-    model_repeat_penalty: float | None
     default_reasoning: ReasoningLevel
     persistence_mode: PersistenceMode
     extensions: ExtensionsConfig
+    model_repeat_penalty: float | None = None
     recursion_limit: int = DEFAULT_RECURSION_LIMIT
     rag_requested: bool = False
     rag: ResolvedRagConfig | None = None

--- a/deepagent_runtime.py
+++ b/deepagent_runtime.py
@@ -241,6 +241,24 @@ def normalize_recursion_limit(
     return recursion_limit
 
 
+def normalize_repeat_penalty(value: Any | None) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        value = value.strip()
+        if not value:
+            return None
+    try:
+        repeat_penalty = float(str(value).strip())
+    except (TypeError, ValueError) as exc:
+        raise ValueError("Model repeat_penalty must be a finite number.") from exc
+    if not math.isfinite(repeat_penalty):
+        raise ValueError("Model repeat_penalty must be a finite number.")
+    if repeat_penalty < 0:
+        raise ValueError("Model repeat_penalty must be greater than or equal to 0.")
+    return repeat_penalty
+
+
 def normalize_model_base_url(
     value: Any | None,
     *,
@@ -811,6 +829,7 @@ class ModelDefaults:
     name_is_explicit: bool = False
     reasoning_effort: ReasoningLevel = DEFAULT_REASONING_LEVEL
     temperature: float = DEFAULT_TEMPERATURE
+    repeat_penalty: float | None = None
 
 
 @dataclass(frozen=True)
@@ -886,6 +905,7 @@ def parse_model_defaults(raw_config: dict[str, Any]) -> ModelDefaults:
         temperature=normalize_model_temperature(
             raw_model.get("temperature", raw_model.get("tempreature"))
         ),
+        repeat_penalty=normalize_repeat_penalty(raw_model.get("repeat_penalty")),
     )
 
 
@@ -1286,6 +1306,7 @@ class RuntimeConfig:
     model_base_url: str
     model_api_key: str | None
     model_temperature: float
+    model_repeat_penalty: float | None
     default_reasoning: ReasoningLevel
     persistence_mode: PersistenceMode
     extensions: ExtensionsConfig
@@ -1418,6 +1439,7 @@ class RuntimeConfig:
             if overrides.model_temperature is not None
             else model_defaults.temperature
         )
+        model_repeat_penalty = model_defaults.repeat_penalty
         default_reasoning = normalize_reasoning_level(
             generic_model_reasoning or model_reasoning_alias,
             default=model_defaults.reasoning_effort,
@@ -1452,6 +1474,7 @@ class RuntimeConfig:
             model_base_url=model_base_url,
             model_api_key=model_api_key,
             model_temperature=model_temperature,
+            model_repeat_penalty=model_repeat_penalty,
             default_reasoning=default_reasoning,
             persistence_mode="postgres" if database_url else "memory",
             extensions=file_config.extensions,
@@ -1471,12 +1494,15 @@ def build_model(
 ) -> Any:
     selected_model = str(model_name or config.model_name).strip() or config.model_name
     if config.model_provider == "ollama":
-        return ChatOllama(
-            model=selected_model,
-            base_url=config.model_base_url,
-            reasoning=reasoning_level,
-            temperature=config.model_temperature,
-        )
+        kwargs: dict[str, Any] = {
+            "model": selected_model,
+            "base_url": config.model_base_url,
+            "reasoning": reasoning_level,
+            "temperature": config.model_temperature,
+        }
+        if config.model_repeat_penalty is not None:
+            kwargs["repeat_penalty"] = config.model_repeat_penalty
+        return ChatOllama(**kwargs)
 
     kwargs: dict[str, Any] = {
         "model": selected_model,


### PR DESCRIPTION
### Motivation
- Make model repeat-penalty configurable so Ollama-backed models can be tuned from `deepagent.toml` instead of relying on hardcoded/default behavior.

### Description
- Add `normalize_repeat_penalty` to validate a finite non-negative float and treat empty values as unset when parsing config.
- Extend `ModelDefaults` with a `repeat_penalty` field and parse `[model].repeat_penalty` from `deepagent.toml` into `FileConfig`.
- Propagate the parsed value into `RuntimeConfig` as `model_repeat_penalty` and pass it to `ChatOllama` in `build_model` when configured.
- Document the new setting in `README.md` and add a sample `repeat_penalty` entry to `deepagent.toml`.

### Testing
- Ran `python -m py_compile deepagent_runtime.py main.py langgraph_app.py chainlit_bridge.py` which completed successfully.
- No other automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcb1b1f43c83248e763d6d950002d5)