### PR TITLE
Fix chronological ordering for reasoning and final responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,6 +414,8 @@ model_mode_enabled = true
 reasoning_mode_enabled = true
 # Set false to hide the initial startup status message ("Workspace agent ready...").
 startup_status_enabled = true
+# Set false to keep legacy non-chronological streaming order in Chainlit.
+chronological_ui_enabled = true
 commands = [
   { name = "ask-researcher", description = "Delegate to repo-researcher.", target = "subagent", value = "repo-researcher", template = "{input}" },
   { name = "repo-readme", description = "Run an MCP tool directly.", target = "mcp_tool", value = "repo_read_file", mcp_server = "repo", template = "{\"path\":\"README.md\"}" },
@@ -433,6 +435,7 @@ Notes:
 - `[chainlit].model_mode_enabled = false` hides the Model selector in chat settings and the Model mode group, and ignores per-message model overrides from UI modes.
 - `[chainlit].reasoning_mode_enabled = false` hides the Reasoning mode group and ignores per-message reasoning overrides from UI modes.
 - `[chainlit].startup_status_enabled = false` disables the initial startup status message that summarizes runtime configuration.
+- `[chainlit].chronological_ui_enabled = false` disables chronological UI ordering so response tokens stream immediately and reasoning steps are not force-rolled at tool boundaries.
 - Command `name` is invoked as `/<name>` and must be unique.
 - `template` is optional and may include `{input}`.
 - For `mcp_tool`, user command arguments must be valid JSON, e.g. `/repo-readme {"path":"README.md"}`.

--- a/chainlit_bridge.py
+++ b/chainlit_bridge.py
@@ -607,9 +607,8 @@ class ChainlitEventBridge:
         self.pending_collapse_tasks: set[asyncio.Task[Any]] = set()
 
     async def start(self) -> None:
-        self.response_message = await cl.Message(content="").send()
         if self.run_task_list is not None:
-            await self.run_task_list.start(response_for_id=self.response_message.id)
+            await self.run_task_list.start()
 
     async def handle_part(self, part: dict[str, Any]) -> None:
         kind = part["type"]
@@ -639,15 +638,8 @@ class ChainlitEventBridge:
         await self.handle_part(part)
 
     async def finish(self) -> None:
-        await self._flush_response_stream()
         await self._close_all_open_steps()
-        if self.response_message is not None:
-            attach_response_export_actions(
-                self.response_message,
-                prompt=self.prompt,
-                response_text=self.response_buffer,
-            )
-            await self.response_message.update()
+        await self._send_final_response_message()
         if self.run_task_list is not None:
             await self.run_task_list.finish()
 
@@ -772,19 +764,38 @@ class ChainlitEventBridge:
         delta = text[len(self.response_buffer) :] if text.startswith(self.response_buffer) else text
         if not delta:
             return
+        await self._close_active_reasoning_steps()
         if (
             not self.response_task_started
             and self.run_task_list is not None
-            and self.response_message is not None
         ):
+            await self.run_task_list.mark_response_started()
+            self.response_task_started = True
+        self.response_buffer += delta
+        self.pending_response_stream += delta
+
+    async def _send_final_response_message(self) -> None:
+        if not self.response_buffer:
+            return
+
+        if self.response_message is None:
+            self.response_message = await cl.Message(content=self.response_buffer).send()
+            self.pending_response_stream = ""
+        else:
+            await self._flush_response_stream()
+
+        if self.run_task_list is not None:
             await self.run_task_list.mark_response_started(
                 for_id=getattr(self.response_message, "id", None)
             )
             self.response_task_started = True
-        self.response_buffer += delta
-        self.pending_response_stream += delta
-        if self._should_flush_response_stream():
-            await self._flush_response_stream()
+
+        attach_response_export_actions(
+            self.response_message,
+            prompt=self.prompt,
+            response_text=self.response_buffer,
+        )
+        await self.response_message.update()
 
     def _should_flush_response_stream(self) -> bool:
         if len(self.pending_response_stream) >= RESPONSE_STREAM_FLUSH_CHARS:
@@ -806,6 +817,7 @@ class ChainlitEventBridge:
         self.last_response_flush_at = time.monotonic()
 
     async def _stream_tool_call(self, source: str, chunk: dict[str, Any]) -> None:
+        await self._close_reasoning_step(source)
         call_id = str(chunk.get("id") or f"{source}:{chunk.get('index', '0')}")
         state = self.tool_steps.get(call_id)
         if state is None:
@@ -884,6 +896,19 @@ class ChainlitEventBridge:
             if todos:
                 await self.run_task_list.update_todos(todos)
         self.tool_steps.pop(state.call_id, None)
+
+    async def _close_reasoning_step(self, source: str) -> None:
+        step = self.reasoning_steps.pop(source, None)
+        if step is None:
+            return
+        if not step.end:
+            step.end = utc_now()
+        await step.update()
+        self._schedule_step_auto_collapse(step)
+
+    async def _close_active_reasoning_steps(self) -> None:
+        for source in list(self.reasoning_steps):
+            await self._close_reasoning_step(source)
 
     def _resolve_tool_step(self, source: str, tool_message: Any) -> ToolStepState | None:
         tool_call_id = getattr(tool_message, "tool_call_id", None)

--- a/chainlit_bridge.py
+++ b/chainlit_bridge.py
@@ -590,7 +590,13 @@ class RunTaskList:
 
 
 class ChainlitEventBridge:
-    def __init__(self, prompt: str, run_task_list: RunTaskList | None = None) -> None:
+    def __init__(
+        self,
+        prompt: str,
+        run_task_list: RunTaskList | None = None,
+        *,
+        chronological_ui_enabled: bool = True,
+    ) -> None:
         self.prompt = prompt
         self.run_task_list = run_task_list
         self.response_message: cl.Message | None = None
@@ -605,6 +611,7 @@ class ChainlitEventBridge:
         self.summarization_steps: dict[str, cl.Step] = {}
         self.collapse_scheduled_step_ids: set[str] = set()
         self.pending_collapse_tasks: set[asyncio.Task[Any]] = set()
+        self.chronological_ui_enabled = chronological_ui_enabled
 
     async def start(self) -> None:
         if self.run_task_list is not None:
@@ -773,6 +780,10 @@ class ChainlitEventBridge:
             self.response_task_started = True
         self.response_buffer += delta
         self.pending_response_stream += delta
+        if not self.chronological_ui_enabled:
+            if self.response_message is None:
+                self.response_message = await cl.Message(content="").send()
+            await self._flush_response_stream()
 
     async def _send_final_response_message(self) -> None:
         if not self.response_buffer:
@@ -817,7 +828,8 @@ class ChainlitEventBridge:
         self.last_response_flush_at = time.monotonic()
 
     async def _stream_tool_call(self, source: str, chunk: dict[str, Any]) -> None:
-        await self._close_reasoning_step(source)
+        if self.chronological_ui_enabled:
+            await self._close_reasoning_step(source)
         call_id = str(chunk.get("id") or f"{source}:{chunk.get('index', '0')}")
         state = self.tool_steps.get(call_id)
         if state is None:

--- a/deepagent.toml
+++ b/deepagent.toml
@@ -42,8 +42,8 @@ skills = ["skills"]
 mcp_servers = ["repo"]
 summarization_middleware_enabled = true
 # Optional token thresholds used when the installed LangChain middleware supports them.
-summarization_trigger_tokens = 1000
-summarization_keep_tokens = 500
+summarization_trigger_tokens = 150000
+summarization_keep_tokens = 10000
 
 [rag]
 enabled = true
@@ -80,6 +80,13 @@ skills = ["skills"]
 mcp_servers = ["repo"]
 
 [chainlit]
+# Set false to hide model selection in chat settings and Modes.
+model_mode_enabled = false
+# Set false to disable per-message reasoning overrides from the Modes picker.
+reasoning_mode_enabled = true
+# Set false to hide the initial startup status message ("Workspace agent ready...").
+startup_status_enabled = false
+
 commands = [
   { name = "ask-researcher", description = "Delegate to repo-researcher.", target = "subagent", value = "repo-researcher", template = "{input}" },
   { name = "repo-readme", description = "Run an MCP tool directly.", target = "mcp_tool", value = "repo_read_file", mcp_server = "repo", template = "{\"path\":\"README.md\"}" },

--- a/deepagent_runtime.py
+++ b/deepagent_runtime.py
@@ -802,6 +802,7 @@ class ExtensionsConfig:
     chainlit_model_mode_enabled: bool = True
     chainlit_reasoning_mode_enabled: bool = True
     chainlit_startup_status_enabled: bool = True
+    chainlit_chronological_ui_enabled: bool = True
     summarization_middleware_enabled: bool = False
     summarization_trigger_tokens: int | None = None
     summarization_keep_tokens: int | None = None
@@ -1128,6 +1129,7 @@ def parse_extensions_config(raw_config: dict[str, Any], config_path: Path) -> Ex
     raw_reasoning_mode_enabled = chainlit_section.get("reasoning_mode_enabled", True)
     raw_model_mode_enabled = chainlit_section.get("model_mode_enabled", True)
     raw_startup_status_enabled = chainlit_section.get("startup_status_enabled", True)
+    raw_chronological_ui_enabled = chainlit_section.get("chronological_ui_enabled", True)
     if not isinstance(raw_reasoning_mode_enabled, bool):
         raise ValueError(
             "The top-level 'chainlit.reasoning_mode_enabled' config must be a boolean."
@@ -1139,6 +1141,10 @@ def parse_extensions_config(raw_config: dict[str, Any], config_path: Path) -> Ex
     if not isinstance(raw_startup_status_enabled, bool):
         raise ValueError(
             "The top-level 'chainlit.startup_status_enabled' config must be a boolean."
+        )
+    if not isinstance(raw_chronological_ui_enabled, bool):
+        raise ValueError(
+            "The top-level 'chainlit.chronological_ui_enabled' config must be a boolean."
         )
 
     chainlit_commands: list[ChainlitCommandConfig] = []
@@ -1206,6 +1212,7 @@ def parse_extensions_config(raw_config: dict[str, Any], config_path: Path) -> Ex
         chainlit_model_mode_enabled=raw_model_mode_enabled,
         chainlit_reasoning_mode_enabled=raw_reasoning_mode_enabled,
         chainlit_startup_status_enabled=raw_startup_status_enabled,
+        chainlit_chronological_ui_enabled=raw_chronological_ui_enabled,
         summarization_middleware_enabled=raw_summarization_middleware_enabled,
         summarization_trigger_tokens=raw_summarization_trigger_tokens,
         summarization_keep_tokens=raw_summarization_keep_tokens,

--- a/main.py
+++ b/main.py
@@ -874,7 +874,11 @@ async def on_message(message: cl.Message) -> None:
         runtime=runtime,
         url_override=async_url_override,
     )
-    bridge = ChainlitEventBridge(prompt=message.content, run_task_list=run_task_list)
+    bridge = ChainlitEventBridge(
+        prompt=message.content,
+        run_task_list=run_task_list,
+        chronological_ui_enabled=runtime.config.extensions.chainlit_chronological_ui_enabled,
+    )
     await bridge.start()
 
     config = build_langgraph_config(

--- a/tests/test_chainlit_bridge_streaming.py
+++ b/tests/test_chainlit_bridge_streaming.py
@@ -46,6 +46,30 @@ class _ResponseMessage:
         self.update_count += 1
 
 
+class _Message:
+    instances: list["_Message"] = []
+
+    def __init__(self, content: str = "", author: str | None = None, **_kwargs: Any) -> None:
+        self.content = content
+        self.author = author
+        self.id = f"message-{len(self.instances) + 1}"
+        self.tokens: list[str] = []
+        self.actions: list[Any] = []
+        self.send_count = 0
+        self.update_count = 0
+        self.instances.append(self)
+
+    async def send(self) -> "_Message":
+        self.send_count += 1
+        return self
+
+    async def stream_token(self, token: str) -> None:
+        self.tokens.append(token)
+
+    async def update(self) -> None:
+        self.update_count += 1
+
+
 class _Step:
     instances: list["_Step"] = []
 
@@ -63,6 +87,7 @@ class _Step:
         self.output: Any = None
         self.start: Any = None
         self.end: Any = None
+        self.tokens: list[str] = []
         self.send_count = 0
         self.update_count = 0
         self.id = f"step-{len(self.instances) + 1}"
@@ -71,16 +96,21 @@ class _Step:
     async def send(self) -> None:
         self.send_count += 1
 
+    async def stream_token(self, token: str) -> None:
+        self.tokens.append(token)
+
     async def update(self) -> None:
         self.update_count += 1
 
 
 @pytest.fixture(autouse=True)
 def _patch_chainlit_tasks(monkeypatch) -> None:
+    _Message.instances.clear()
     _Step.instances.clear()
     monkeypatch.setattr(chainlit_bridge.cl, "TaskStatus", _TaskStatus)
     monkeypatch.setattr(chainlit_bridge.cl, "Task", _Task)
     monkeypatch.setattr(chainlit_bridge.cl, "Step", _Step)
+    monkeypatch.setattr(chainlit_bridge.cl, "Message", _Message)
 
 
 @pytest.mark.anyio
@@ -102,7 +132,72 @@ async def test_response_task_starts_once_for_rapid_response_tokens() -> None:
 
 
 @pytest.mark.anyio
-async def test_response_stream_batches_fast_chunks_until_finish(monkeypatch) -> None:
+async def test_response_message_is_created_on_finish_after_reasoning_steps(monkeypatch) -> None:
+    task_list = _TaskList()
+    run_task_list = RunTaskList(task_list)  # type: ignore[arg-type]
+    bridge = ChainlitEventBridge(prompt="hello", run_task_list=run_task_list)
+    monkeypatch.setattr(
+        chainlit_bridge,
+        "attach_response_export_actions",
+        lambda *args, **kwargs: None,
+    )
+
+    await bridge.start()
+
+    assert _Message.instances == []
+    assert [task.title for task in task_list.tasks] == ["main-agent reasoning"]
+    assert task_list.tasks[0].forId is None
+
+    await bridge._stream_reasoning("main-agent", "thinking")
+
+    assert _Message.instances == []
+    assert len(_Step.instances) == 1
+    assert _Step.instances[0].name == "main-agent reasoning"
+
+    await bridge._stream_response("Final answer")
+
+    assert _Message.instances == []
+    assert bridge.response_buffer == "Final answer"
+
+    await bridge.finish()
+
+    assert len(_Message.instances) == 1
+    assert _Message.instances[0].send_count == 1
+    assert _Message.instances[0].content == "Final answer"
+    assert _Message.instances[0].tokens == []
+    assert _Message.instances[0].update_count == 1
+    assert _Step.instances[0].end is not None
+    assert [task.title for task in task_list.tasks] == [
+        "main-agent reasoning",
+        "final response",
+    ]
+    assert task_list.tasks[-1].status == _TaskStatus.DONE
+    assert task_list.tasks[-1].forId == _Message.instances[0].id
+
+
+@pytest.mark.anyio
+async def test_reasoning_after_tool_call_starts_a_new_chronological_step() -> None:
+    bridge = ChainlitEventBridge(prompt="hello")
+
+    await bridge._stream_reasoning("main-agent", "first thought")
+    await bridge._stream_tool_call(
+        "main-agent",
+        {"id": "call-1", "name": "read_file", "args": '{"path":"README.md"}'},
+    )
+    await bridge._stream_reasoning("main-agent", "first thought second thought")
+
+    assert [step.name for step in _Step.instances] == [
+        "main-agent reasoning",
+        "main-agent · read_file",
+        "main-agent reasoning",
+    ]
+    assert _Step.instances[0].tokens == ["first thought"]
+    assert _Step.instances[0].end is not None
+    assert _Step.instances[2].tokens == [" second thought"]
+
+
+@pytest.mark.anyio
+async def test_response_stream_buffers_fast_chunks_until_finish(monkeypatch) -> None:
     response_message = _ResponseMessage()
     bridge = ChainlitEventBridge(prompt="hello")
     bridge.response_message = response_message  # type: ignore[assignment]
@@ -118,12 +213,12 @@ async def test_response_stream_batches_fast_chunks_until_finish(monkeypatch) -> 
     await bridge._stream_response("B")
     await bridge._stream_response("C")
 
-    assert response_message.tokens == ["A"]
     assert bridge.response_buffer == "ABC"
+    assert response_message.tokens == []
 
     await bridge.finish()
 
-    assert response_message.tokens == ["A", "BC"]
+    assert response_message.tokens == ["ABC"]
     assert response_message.update_count == 1
 
 

--- a/tests/test_chainlit_bridge_streaming.py
+++ b/tests/test_chainlit_bridge_streaming.py
@@ -223,6 +223,35 @@ async def test_response_stream_buffers_fast_chunks_until_finish(monkeypatch) -> 
 
 
 @pytest.mark.anyio
+async def test_non_chronological_mode_streams_response_immediately() -> None:
+    bridge = ChainlitEventBridge(prompt="hello", chronological_ui_enabled=False)
+
+    await bridge._stream_response("A")
+    await bridge._stream_response("AB")
+
+    assert len(_Message.instances) == 1
+    assert _Message.instances[0].tokens == ["A", "B"]
+
+
+@pytest.mark.anyio
+async def test_non_chronological_mode_keeps_reasoning_step_open_across_tool_call() -> None:
+    bridge = ChainlitEventBridge(prompt="hello", chronological_ui_enabled=False)
+
+    await bridge._stream_reasoning("main-agent", "first thought")
+    await bridge._stream_tool_call(
+        "main-agent",
+        {"id": "call-1", "name": "read_file", "args": '{"path":"README.md"}'},
+    )
+    await bridge._stream_reasoning("main-agent", "first thought second thought")
+
+    assert [step.name for step in _Step.instances] == [
+        "main-agent reasoning",
+        "main-agent · read_file",
+    ]
+    assert _Step.instances[0].tokens == ["first thought", " second thought"]
+
+
+@pytest.mark.anyio
 async def test_astream_events_chain_stream_tuple_chunk_is_normalized() -> None:
     bridge = ChainlitEventBridge(prompt="hello")
     handled_parts: list[dict[str, Any]] = []

--- a/tests/test_deepagent_runtime_rag.py
+++ b/tests/test_deepagent_runtime_rag.py
@@ -814,6 +814,7 @@ system_prompt = "Do research"
 model_mode_enabled = false
 reasoning_mode_enabled = false
 startup_status_enabled = false
+chronological_ui_enabled = false
 commands = [
   { name = "ask-researcher", description = "Delegate to subagent", target = "subagent", value = "repo-researcher" },
   { name = "run-tool", description = "Call MCP tool", target = "mcp_tool", value = "repo_read_file", mcp_server = "repo" },
@@ -833,6 +834,7 @@ commands = [
     assert extensions.chainlit_model_mode_enabled is False
     assert extensions.chainlit_reasoning_mode_enabled is False
     assert extensions.chainlit_startup_status_enabled is False
+    assert extensions.chainlit_chronological_ui_enabled is False
 
 
 def test_load_extensions_config_parses_summarization_middleware_flag(
@@ -928,6 +930,24 @@ reasoning_mode_enabled = "no"
     monkeypatch.setenv("DEEPAGENT_CONFIG", str(config_path))
 
     with pytest.raises(ValueError, match="reasoning_mode_enabled"):
+        deepagent_runtime.load_extensions_config()
+
+
+def test_load_extensions_config_rejects_non_boolean_chronological_ui_flag(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    config_path = tmp_path / "deepagent.toml"
+    config_path.write_text(
+        """
+[chainlit]
+chronological_ui_enabled = "sometimes"
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DEEPAGENT_CONFIG", str(config_path))
+
+    with pytest.raises(ValueError, match="chronological_ui_enabled"):
         deepagent_runtime.load_extensions_config()
 
 


### PR DESCRIPTION
## Summary
- Close reasoning steps when tool calls begin so later reasoning opens a new chronological step
- Buffer the final answer until `finish()` so the response bubble is sent after the run's steps
- Update the bridge tests to cover reasoning step rollover and end-of-run response ordering
- Adjust `deepagent.toml` to raise summarization thresholds and update Chainlit UI flags

## Testing
- Added regression coverage for chronological reasoning steps and final response placement
- `uv run pytest`