### PR TITLE
Add a Textual TUI for ChainAgents

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,9 +158,12 @@ uv run chainagents --tui
 ```
 
 The TUI defaults to thread ID `tui`, keeps the prompt box at the bottom, shows
-the conversation in the main pane, and splits reasoning and tool activity in the
-right sidebar. Type `/` in the TUI prompt to show configured slash commands, and
-press Tab to complete the first matching command.
+the conversation in the main pane with Markdown-formatted assistant responses,
+and splits reasoning and tool activity in the right sidebar. Type `/` in the TUI
+prompt to show configured slash commands, and press Tab to complete the first
+matching command. Stdio MCP server diagnostics are written to
+`.files/tui-stderr.log` in TUI mode so they do not corrupt the full-screen
+interface.
 
 Useful CLI examples:
 

--- a/README.md
+++ b/README.md
@@ -151,10 +151,22 @@ Run the same underlying agent from a terminal without the Chainlit UI:
 uv run chainagents --prompt "Summarize this repository" --thread-id cli
 ```
 
+Start the full-screen terminal UI:
+
+```bash
+uv run chainagents --tui
+```
+
+The TUI defaults to thread ID `tui`, keeps the prompt box at the bottom, shows
+the conversation in the main pane, and splits reasoning and tool activity in the
+right sidebar. Type `/` in the TUI prompt to show configured slash commands, and
+press Tab to complete the first matching command.
+
 Useful CLI examples:
 
 ```bash
 uv run chainagents --status --no-rag
+uv run chainagents --tui --reasoning high
 uv run chainagents --list-commands
 uv run chainagents --command ask-researcher --prompt "Find the config entrypoints"
 uv run chainagents --stdin --model gemma4:26b --reasoning high < prompt.txt

--- a/agent_stream_events.py
+++ b/agent_stream_events.py
@@ -1,0 +1,399 @@
+"""Normalize LangGraph stream chunks for CLI, Chainlit, and TUI renderers."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any, Literal
+
+
+StreamEventKind = Literal[
+    "response_delta",
+    "reasoning_delta",
+    "tool_call",
+    "tool_result",
+    "summarization_status",
+]
+
+LANGGRAPH_STREAM_MODES = {
+    "values",
+    "updates",
+    "custom",
+    "messages",
+    "checkpoints",
+    "tasks",
+    "debug",
+}
+SUMMARIZATION_STATUS_KIND = "summarization_status"
+
+
+@dataclass(frozen=True)
+class AgentStreamEvent:
+    """A renderer-neutral event produced from LangGraph stream chunks."""
+
+    kind: StreamEventKind
+    source: str
+    text: str = ""
+    tool_call_id: str = ""
+    tool_name: str = ""
+    tool_args: str = ""
+    tool_args_delta: str = ""
+    tool_result: str = ""
+    status: str = ""
+
+
+def stringify_content(value: Any) -> str:
+    """Convert LangChain message content into displayable text."""
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    if isinstance(value, list):
+        return "".join(stringify_content(item) for item in value)
+    if isinstance(value, dict):
+        for key in ("text", "reasoning", "content"):
+            nested = value.get(key)
+            if isinstance(nested, (str, list, dict)):
+                return stringify_content(nested)
+        return json.dumps(value, indent=2, sort_keys=True, ensure_ascii=True)
+    return str(value)
+
+
+def langgraph_part_from_event_chunk(chunk: Any) -> dict[str, Any] | None:
+    """Normalize LangGraph stream event chunks into part metadata."""
+    if isinstance(chunk, dict):
+        mode = chunk.get("type")
+        if isinstance(mode, str) and mode in LANGGRAPH_STREAM_MODES and "data" in chunk:
+            return chunk
+        return None
+
+    if not isinstance(chunk, tuple):
+        return None
+
+    if len(chunk) == 3:
+        ns, mode, data = chunk
+    elif len(chunk) == 2:
+        first, data = chunk
+        if isinstance(first, tuple):
+            ns = first
+            mode = "values"
+        else:
+            ns = ()
+            mode = first
+    else:
+        return None
+
+    if not isinstance(mode, str) or mode not in LANGGRAPH_STREAM_MODES:
+        return None
+
+    if isinstance(ns, tuple):
+        namespace = ns
+    elif ns in (None, ""):
+        namespace = ()
+    else:
+        return None
+
+    return {"type": mode, "ns": namespace, "data": data}
+
+
+def reasoning_text_from_token(token: Any) -> str:
+    """Extract reasoning text from a streamed model token."""
+    if hasattr(token, "additional_kwargs"):
+        text = stringify_content(token.additional_kwargs.get("reasoning_content"))
+        if text:
+            return text
+    if hasattr(token, "reasoning_content"):
+        return stringify_content(token.reasoning_content)
+    return ""
+
+
+def namespace_label(ns: tuple[str, ...], metadata: dict[str, Any]) -> str:
+    """Return a display label for a streamed namespace."""
+    agent_name = metadata.get("lc_agent_name")
+    if agent_name:
+        return str(agent_name)
+    if not ns:
+        return "main-agent"
+
+    labels: list[str] = []
+    for segment in ns:
+        if segment.startswith("tools:"):
+            labels.append(f"subagent {segment.split(':', 1)[1]}")
+            continue
+        labels.append(segment.split(":", 1)[0])
+    return " / ".join(labels)
+
+
+def iter_messages(value: Any) -> list[Any]:
+    """Return message-like objects from nested LangGraph update payloads."""
+    if value is None:
+        return []
+    if isinstance(value, (list, tuple)):
+        return list(value)
+    if isinstance(value, dict):
+        if "messages" in value:
+            return iter_messages(value["messages"])
+        if "value" in value:
+            return iter_messages(value["value"])
+        return [value]
+    if isinstance(value, (str, bytes)):
+        return []
+
+    for attr in ("value", "messages", "data"):
+        if hasattr(value, attr):
+            messages = iter_messages(getattr(value, attr))
+            if messages:
+                return messages
+
+    try:
+        return list(value)
+    except TypeError:
+        return [value]
+
+
+def messages_from_node_data(data: Any) -> list[Any]:
+    """Extract message objects from LangGraph node update payloads."""
+    if data is None:
+        return []
+    if isinstance(data, dict):
+        return iter_messages(data.get("messages"))
+    return iter_messages(data)
+
+
+def is_assistant_message(message: Any) -> bool:
+    """Return whether a message is assistant-authored."""
+    return getattr(message, "type", None) in {"ai", "AIMessageChunk"}
+
+
+def message_text(message: Any) -> str:
+    """Return normalized text from a LangChain-style message."""
+    return stringify_content(getattr(message, "content", "")).strip()
+
+
+def assistant_messages_for_current_prompt(messages: list[Any], prompt: str) -> list[Any]:
+    """Return assistant messages produced after the current prompt began."""
+    prompt_text = prompt.strip()
+    current_prompt_index = -1
+    for index, message in enumerate(messages):
+        if getattr(message, "type", None) != "human":
+            continue
+        if message_text(message) == prompt_text:
+            current_prompt_index = index
+
+    if current_prompt_index < 0:
+        return []
+
+    return [
+        message
+        for message in messages[current_prompt_index + 1 :]
+        if is_assistant_message(message)
+    ]
+
+
+class AgentStreamEventAdapter:
+    """Convert raw LangGraph events into renderer-neutral stream events."""
+
+    def __init__(self, *, prompt: str) -> None:
+        self.prompt = prompt
+        self.response_buffer = ""
+        self.response_streamed_from_messages = False
+        self.reasoning_buffers: dict[str, str] = {}
+        self.tool_names: dict[str, str] = {}
+        self.tool_args_buffers: dict[str, str] = {}
+        self.tool_call_started: set[str] = set()
+        self.completed_tool_results: set[tuple[str, str, str]] = set()
+
+    def events_from_raw_event(self, event: dict[str, Any]) -> list[AgentStreamEvent]:
+        """Return normalized events from one raw LangGraph stream event."""
+        if event.get("event") != "on_chain_stream":
+            return []
+        if event.get("parent_ids"):
+            return []
+
+        data = event.get("data")
+        if not isinstance(data, dict):
+            return []
+
+        part = langgraph_part_from_event_chunk(data.get("chunk"))
+        if part is None:
+            return []
+        return self.events_from_part(part)
+
+    def events_from_part(self, part: dict[str, Any]) -> list[AgentStreamEvent]:
+        """Return normalized events from one LangGraph stream part."""
+        kind = part.get("type")
+        if kind == "messages":
+            return self._events_from_message_chunk(part)
+        if kind == "updates":
+            return self._events_from_update_chunk(part)
+        if kind == "custom":
+            return self._events_from_custom_chunk(part)
+        return []
+
+    def _events_from_message_chunk(self, part: dict[str, Any]) -> list[AgentStreamEvent]:
+        token, metadata = part["data"]
+        metadata = metadata if isinstance(metadata, dict) else {}
+        ns = tuple(part.get("ns", ()))
+        source = namespace_label(ns, metadata)
+        is_main_source = not ns
+        events: list[AgentStreamEvent] = []
+
+        reasoning_text = reasoning_text_from_token(token)
+        if reasoning_text:
+            event = self._reasoning_event(source, reasoning_text)
+            if event is not None:
+                events.append(event)
+
+        tool_call_chunks = getattr(token, "tool_call_chunks", None) or []
+        for chunk in tool_call_chunks:
+            events.append(self._tool_call_event(source, chunk))
+
+        if getattr(token, "type", None) == "tool":
+            event = self._tool_result_event(source, token)
+            return events + ([event] if event is not None else [])
+
+        content_text = stringify_content(getattr(token, "content", ""))
+        if is_main_source and content_text and not tool_call_chunks:
+            self.response_streamed_from_messages = True
+            event = self._response_event(source, content_text)
+            if event is not None:
+                events.append(event)
+        return events
+
+    def _events_from_update_chunk(self, part: dict[str, Any]) -> list[AgentStreamEvent]:
+        ns = tuple(part.get("ns", ()))
+        source = namespace_label(ns, {"lc_agent_name": None})
+        data_by_node = part.get("data")
+        if not isinstance(data_by_node, dict):
+            return []
+
+        events: list[AgentStreamEvent] = []
+        for node_name, data in data_by_node.items():
+            if node_name != "tools":
+                if not ns and not self.response_streamed_from_messages:
+                    assistant_messages = assistant_messages_for_current_prompt(
+                        messages_from_node_data(data),
+                        self.prompt,
+                    )
+                    if assistant_messages:
+                        content_text = stringify_content(
+                            getattr(assistant_messages[-1], "content", "")
+                        )
+                        if content_text:
+                            event = self._response_event(source, content_text)
+                            if event is not None:
+                                events.append(event)
+                continue
+
+            for message in messages_from_node_data(data):
+                if getattr(message, "type", None) == "tool":
+                    event = self._tool_result_event(source, message)
+                    if event is not None:
+                        events.append(event)
+        return events
+
+    def _events_from_custom_chunk(self, part: dict[str, Any]) -> list[AgentStreamEvent]:
+        data = part.get("data")
+        if not isinstance(data, dict):
+            return []
+        if data.get("kind") != SUMMARIZATION_STATUS_KIND:
+            return []
+
+        return [
+            AgentStreamEvent(
+                kind="summarization_status",
+                source=str(data.get("source") or "main-agent").strip() or "main-agent",
+                status=str(data.get("status") or "triggered").strip() or "triggered",
+                text=str(
+                    data.get("message") or "Conversation summarization triggered."
+                ).strip(),
+            )
+        ]
+
+    def _response_event(self, source: str, text: str) -> AgentStreamEvent | None:
+        delta = text[len(self.response_buffer) :] if text.startswith(self.response_buffer) else text
+        if not delta:
+            return None
+        self.response_buffer += delta
+        return AgentStreamEvent(kind="response_delta", source=source, text=delta)
+
+    def _reasoning_event(self, source: str, text: str) -> AgentStreamEvent | None:
+        previous = self.reasoning_buffers.get(source, "")
+        delta = text[len(previous) :] if text.startswith(previous) else text
+        if not delta:
+            return None
+        self.reasoning_buffers[source] = previous + delta
+        return AgentStreamEvent(kind="reasoning_delta", source=source, text=delta)
+
+    def _tool_call_event(self, source: str, chunk: dict[str, Any]) -> AgentStreamEvent:
+        call_id = str(chunk.get("id") or f"{source}:{chunk.get('index', '0')}")
+        tool_name = str(chunk.get("name") or self.tool_names.get(call_id) or "tool")
+        self.tool_names[call_id] = tool_name
+
+        args_delta = chunk.get("args")
+        args_delta_text = ""
+        if args_delta:
+            args_delta_text = str(args_delta)
+            self.tool_args_buffers[call_id] = (
+                self.tool_args_buffers.get(call_id, "") + args_delta_text
+            )
+
+        status = "update" if call_id in self.tool_call_started else "start"
+        self.tool_call_started.add(call_id)
+        return AgentStreamEvent(
+            kind="tool_call",
+            source=source,
+            tool_call_id=call_id,
+            tool_name=tool_name,
+            tool_args=self.tool_args_buffers.get(call_id, ""),
+            tool_args_delta=args_delta_text,
+            status=status,
+        )
+
+    def _tool_result_event(
+        self,
+        source: str,
+        tool_message: Any,
+    ) -> AgentStreamEvent | None:
+        name = str(getattr(tool_message, "name", "") or "tool")
+        status = str(getattr(tool_message, "status", "") or "done")
+        content = stringify_content(getattr(tool_message, "content", ""))
+        result_key = self._tool_result_key(
+            source=source,
+            name=name,
+            tool_message=tool_message,
+            content=content,
+        )
+        if result_key in self.completed_tool_results:
+            return None
+        self.completed_tool_results.add(result_key)
+
+        return AgentStreamEvent(
+            kind="tool_result",
+            source=source,
+            tool_call_id=str(
+                getattr(tool_message, "tool_call_id", None)
+                or getattr(tool_message, "id", None)
+                or ""
+            ),
+            tool_name=name,
+            tool_result=content,
+            status=status,
+        )
+
+    @staticmethod
+    def _tool_result_key(
+        *,
+        source: str,
+        name: str,
+        tool_message: Any,
+        content: str,
+    ) -> tuple[str, str, str]:
+        stable_id = str(
+            getattr(tool_message, "tool_call_id", None)
+            or getattr(tool_message, "id", None)
+            or ""
+        ).strip()
+        if stable_id:
+            return (source, "id", stable_id)
+        return (source, name, content)

--- a/chainagents_cli.py
+++ b/chainagents_cli.py
@@ -20,6 +20,7 @@ from rich.panel import Panel
 from rich.table import Table
 from rich.text import Text
 
+from agent_stream_events import AgentStreamEvent, AgentStreamEventAdapter
 from agent_commands import (
     dumps_tool_result,
     parse_native_command,
@@ -106,8 +107,11 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--thread-id",
-        default=DEFAULT_CLI_THREAD_ID,
-        help=f"LangGraph thread ID. Defaults to {DEFAULT_CLI_THREAD_ID!r}.",
+        default=None,
+        help=(
+            f"LangGraph thread ID. Defaults to {DEFAULT_CLI_THREAD_ID!r}, "
+            "or 'tui' in --tui mode."
+        ),
     )
     parser.add_argument("--recursion-limit", type=int, help="LangGraph recursion limit.")
 
@@ -168,6 +172,11 @@ def build_parser() -> argparse.ArgumentParser:
         dest="json_output",
         action="store_true",
         help="Print machine-readable JSON output.",
+    )
+    parser.add_argument(
+        "--tui",
+        action="store_true",
+        help="Run the full-screen terminal UI.",
     )
     return parser
 
@@ -628,13 +637,8 @@ class CliEventRenderer:
         self.show_reasoning = show_reasoning
         self.show_tools = show_tools
         self.response_buffer = ""
-        self.response_streamed_from_messages = False
-        self.reasoning_buffers: dict[str, str] = {}
+        self.stream_adapter = AgentStreamEventAdapter(prompt=prompt)
         self.reasoning_line_source: str | None = None
-        self.tool_names: dict[str, str] = {}
-        self.tool_args_buffers: dict[str, str] = {}
-        self.tool_call_started: set[str] = set()
-        self.completed_tool_results: set[tuple[str, str, str]] = set()
         self.stdout_console = cli_console(stdout)
         self.stderr_console = cli_console(stderr)
 
@@ -644,26 +648,21 @@ class CliEventRenderer:
         Args:
             event: LangGraph stream event to process.
         """
-        if event.get("event") != "on_chain_stream":
-            return
-        if event.get("parent_ids"):
-            return
+        for stream_event in self.stream_adapter.events_from_raw_event(event):
+            self._handle_stream_event(stream_event)
 
-        data = event.get("data")
-        if not isinstance(data, dict):
-            return
-
-        part = langgraph_part_from_event_chunk(data.get("chunk"))
-        if part is None:
-            return
-
-        kind = part["type"]
-        if kind == "messages":
-            self._handle_message_chunk(part)
-        elif kind == "updates":
-            self._handle_update_chunk(part)
-        elif kind == "custom":
-            self._handle_custom_chunk(part)
+    def _handle_stream_event(self, event: AgentStreamEvent) -> None:
+        """Render one normalized agent stream event."""
+        if event.kind == "response_delta":
+            self._stream_response_delta(event.text)
+        elif event.kind == "reasoning_delta":
+            self._stream_reasoning_delta(event.source, event.text)
+        elif event.kind == "tool_call":
+            self._stream_tool_call_event(event)
+        elif event.kind == "tool_result":
+            self._complete_tool_event(event)
+        elif event.kind == "summarization_status":
+            self._stream_summarization_status(event)
 
     def finish(self) -> str:
         """Finish the CLI event renderer.
@@ -682,91 +681,21 @@ class CliEventRenderer:
             self.stdout_console.print(Text(self.response_buffer, style="bright_white"))
         return self.response_buffer
 
-    def _handle_message_chunk(self, part: dict[str, Any]) -> None:
-        """Handle message chunk.
-
-        Args:
-            part: The part value.
-        """
-        token, metadata = part["data"]
-        metadata = metadata if isinstance(metadata, dict) else {}
-        ns = tuple(part.get("ns", ()))
-        source = namespace_label(ns, metadata)
-        is_main_source = not ns
-
-        reasoning_text = reasoning_text_from_token(token)
-        if reasoning_text:
-            self._stream_reasoning(source, reasoning_text)
-
-        tool_call_chunks = getattr(token, "tool_call_chunks", None) or []
-        if tool_call_chunks:
-            for chunk in tool_call_chunks:
-                self._stream_tool_call(source, chunk)
-
-        if getattr(token, "type", None) == "tool":
-            self._complete_tool(source, token)
-            return
-
-        content_text = stringify_content(getattr(token, "content", ""))
-        if is_main_source and content_text and not tool_call_chunks:
-            self.response_streamed_from_messages = True
-            self._stream_response(content_text)
-
-    def _handle_update_chunk(self, part: dict[str, Any]) -> None:
-        """Handle update chunk.
-
-        Args:
-            part: The part value.
-        """
-        ns = tuple(part.get("ns", ()))
-        source = namespace_label(ns, {"lc_agent_name": None})
-
-        for node_name, data in part["data"].items():
-            if node_name != "tools":
-                if not ns and not self.response_streamed_from_messages:
-                    assistant_messages = assistant_messages_for_current_prompt(
-                        messages_from_node_data(data),
-                        self.prompt,
-                    )
-                    if assistant_messages:
-                        content_text = stringify_content(
-                            getattr(assistant_messages[-1], "content", "")
-                        )
-                        if content_text:
-                            self._stream_response(content_text)
-                continue
-
-            for message in messages_from_node_data(data):
-                if getattr(message, "type", None) == "tool":
-                    self._complete_tool(source, message)
-
-    def _handle_custom_chunk(self, part: dict[str, Any]) -> None:
-        """Handle custom chunk.
-
-        Args:
-            part: The part value.
-        """
-        data = part.get("data")
-        if not isinstance(data, dict):
-            return
-        if data.get("kind") != SUMMARIZATION_STATUS_KIND:
-            return
+    def _stream_summarization_status(self, event: AgentStreamEvent) -> None:
+        """Render a summarization status update."""
         if self.json_output:
             return
 
-        status = str(data.get("status") or "triggered").strip() or "triggered"
-        source = str(data.get("source") or "main-agent").strip() or "main-agent"
-        message = str(data.get("message") or "Conversation summarization triggered.").strip()
         self._close_reasoning_line()
         body = Text.assemble(
             ("status: ", "dim"),
-            (status, "bold cyan"),
+            (event.status, "bold cyan"),
             ("\nsource: ", "dim"),
-            (source, "cyan"),
+            (event.source, "cyan"),
         )
-        if message:
+        if event.text:
             body.append("\nmessage: ", style="dim")
-            body.append(message, style="white")
+            body.append(event.text, style="white")
         self.stderr_console.print(
             cli_panel(
                 body,
@@ -775,31 +704,27 @@ class CliEventRenderer:
             )
         )
 
-    def _stream_response(self, text: str) -> None:
+    def _stream_response_delta(self, text: str) -> None:
         """Stream final response text into the active output target.
 
         Args:
             text: Text content to process.
         """
-        delta = text[len(self.response_buffer) :] if text.startswith(self.response_buffer) else text
-        if not delta:
+        if not text:
             return
-        self.response_buffer += delta
+        self.response_buffer += text
         if self.stream and not self.json_output:
-            self.stdout_console.print(Text(delta, style="bright_white"), end="")
+            self.stdout_console.print(Text(text, style="bright_white"), end="")
 
-    def _stream_reasoning(self, source: str, text: str) -> None:
+    def _stream_reasoning_delta(self, source: str, text: str) -> None:
         """Stream reasoning text into the active output target.
 
         Args:
             source: The source value.
             text: Text content to process.
         """
-        previous = self.reasoning_buffers.get(source, "")
-        delta = text[len(previous) :] if text.startswith(previous) else text
-        if not delta:
+        if not text:
             return
-        self.reasoning_buffers[source] = previous + delta
         if self.show_reasoning:
             if self.reasoning_line_source != source:
                 self._close_reasoning_line()
@@ -808,7 +733,7 @@ class CliEventRenderer:
                     end="",
                 )
                 self.reasoning_line_source = source
-            self.stderr_console.print(Text(delta, style="magenta"), end="")
+            self.stderr_console.print(Text(text, style="magenta"), end="")
 
     def _close_reasoning_line(self) -> None:
         """Close the active reasoning line before rendering other output."""
@@ -817,39 +742,21 @@ class CliEventRenderer:
         self.stderr_console.print()
         self.reasoning_line_source = None
 
-    def _stream_tool_call(self, source: str, chunk: dict[str, Any]) -> None:
-        """Render a streamed tool call and its accumulated arguments.
-
-        Args:
-            source: The source value.
-            chunk: Streamed event chunk to normalize.
-        """
-        call_id = str(chunk.get("id") or f"{source}:{chunk.get('index', '0')}")
-        tool_name = str(chunk.get("name") or self.tool_names.get(call_id) or "tool")
-        self.tool_names[call_id] = tool_name
-        args_delta = chunk.get("args")
-        if args_delta:
-            self.tool_args_buffers[call_id] = self.tool_args_buffers.get(call_id, "") + str(
-                args_delta
-            )
-
+    def _stream_tool_call_event(self, event: AgentStreamEvent) -> None:
+        """Render a streamed tool call and its accumulated arguments."""
         if not self.show_tools:
-            return
-        if not chunk.get("name") and call_id not in self.tool_call_started:
             return
 
         self._close_reasoning_line()
-        status = "start" if call_id not in self.tool_call_started else "update"
-        self.tool_call_started.add(call_id)
         body = Text.assemble(
             ("status: ", "dim"),
-            (status, "bold yellow"),
+            (event.status, "bold yellow"),
             ("\nsource: ", "dim"),
-            (source, "cyan"),
+            (event.source, "cyan"),
             ("\ntool: ", "dim"),
-            (tool_name, "bold white"),
+            (event.tool_name, "bold white"),
         )
-        args = pretty_tool_call_args(self.tool_args_buffers.get(call_id))
+        args = pretty_tool_call_args(event.tool_args)
         if args:
             body.append("\nargs: ", style="dim yellow")
             body.append(args, style="yellow")
@@ -861,37 +768,20 @@ class CliEventRenderer:
             )
         )
 
-    def _complete_tool(self, source: str, tool_message: Any) -> None:
-        """Render the final status and output for a completed tool call.
-
-        Args:
-            source: The source value.
-            tool_message: The tool message value.
-        """
+    def _complete_tool_event(self, event: AgentStreamEvent) -> None:
+        """Render the final status and output for a completed tool call."""
         if not self.show_tools:
             return
-        name = str(getattr(tool_message, "name", "") or "tool")
-        status = str(getattr(tool_message, "status", "") or "done")
-        content = truncate_tool_result_content(getattr(tool_message, "content", ""))
-        result_key = self._tool_result_key(
-            source=source,
-            name=name,
-            tool_message=tool_message,
-            content=content,
-        )
-        if result_key in self.completed_tool_results:
-            return
-        self.completed_tool_results.add(result_key)
-
+        content = truncate_tool_result_content(event.tool_result)
         self._close_reasoning_line()
-        status_style = "bold red" if status.lower() == "error" else "bold green"
+        status_style = "bold red" if event.status.lower() == "error" else "bold green"
         body = Text.assemble(
             ("status: ", "dim"),
-            (status, status_style),
+            (event.status, status_style),
             ("\nsource: ", "dim"),
-            (source, "cyan"),
+            (event.source, "cyan"),
             ("\ntool: ", "dim"),
-            (name, "bold white"),
+            (event.tool_name, "bold white"),
         )
         if content:
             body.append("\nresult: ", style="dim yellow")
@@ -900,7 +790,7 @@ class CliEventRenderer:
             cli_panel(
                 body,
                 title="Tool Result",
-                border_style="red" if status.lower() == "error" else "green",
+                border_style="red" if event.status.lower() == "error" else "green",
             )
         )
 
@@ -1478,6 +1368,36 @@ async def run_cli(
     Returns:
         The command result.
     """
+    if args.tui:
+        if args.prompt or args.prompt_parts or args.stdin:
+            print("tui: start the TUI without a one-shot prompt.", file=stderr)
+            return 2
+        unsupported_tui_flags = []
+        if args.photo:
+            unsupported_tui_flags.append("--photo")
+        if args.command:
+            unsupported_tui_flags.append("--command")
+        if args.rebuild_rag:
+            unsupported_tui_flags.append("--rebuild-rag")
+        if args.upload_rag:
+            unsupported_tui_flags.append("--upload-rag")
+        if args.status:
+            unsupported_tui_flags.append("--status")
+        if args.list_commands:
+            unsupported_tui_flags.append("--list-commands")
+        if args.json_output:
+            unsupported_tui_flags.append("--json")
+        if unsupported_tui_flags:
+            print(
+                "tui: unsupported flags in TUI mode: "
+                + ", ".join(unsupported_tui_flags),
+                file=stderr,
+            )
+            return 2
+        from chainagents_tui import run_tui
+
+        return await run_tui(runtime, args)
+
     prompt = prompt_from_args(args, stdin=stdin, parser=parser)
     has_prompt = bool(prompt and prompt.strip())
 
@@ -1519,10 +1439,11 @@ async def run_cli(
                 json_output=False,
             )
 
+    thread_id = str(args.thread_id or DEFAULT_CLI_THREAD_ID).strip() or DEFAULT_CLI_THREAD_ID
     upload_result = await ingest_uploads(
         runtime,
         paths=args.upload_rag,
-        thread_id=args.thread_id,
+        thread_id=thread_id,
         stdout=stdout,
         stderr=stderr,
         json_output=False,

--- a/chainagents_tui.py
+++ b/chainagents_tui.py
@@ -1,0 +1,439 @@
+"""Textual terminal UI for ChainAgents."""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import suppress
+from typing import Any
+
+from rich.panel import Panel
+from rich.text import Text
+from textual import events, on
+from textual.app import App, ComposeResult
+from textual.containers import Horizontal, Vertical
+from textual.widgets import Footer, Header, Input, RichLog, Static
+
+from agent_commands import (
+    dumps_tool_result,
+    parse_native_command,
+    resolve_native_command,
+    resolve_runtime_command,
+)
+from agent_stream_events import AgentStreamEvent, AgentStreamEventAdapter
+from deepagent_runtime import AgentRuntime, ReasoningLevel, normalize_reasoning_level
+
+
+DEFAULT_TUI_THREAD_ID = "tui"
+
+
+class ChainAgentsTuiApp(App[int]):
+    """Interactive Textual app for the configured ChainAgents runtime."""
+
+    CSS = """
+    Screen {
+        layout: vertical;
+    }
+
+    #status {
+        height: 1;
+        padding: 0 1;
+        background: $boost;
+        color: $text;
+    }
+
+    #main {
+        height: 1fr;
+    }
+
+    #conversation {
+        width: 2fr;
+        height: 100%;
+        border: solid $primary;
+    }
+
+    #side {
+        width: 42;
+        height: 100%;
+    }
+
+    #reasoning {
+        height: 1fr;
+        border: solid $secondary;
+    }
+
+    #tools {
+        height: 1fr;
+        border: solid $accent;
+    }
+
+    #prompt {
+        height: 3;
+    }
+
+    #commands {
+        height: auto;
+        max-height: 6;
+        padding: 0 1;
+        border: solid $warning;
+        display: none;
+    }
+    """
+
+    BINDINGS = [
+        ("ctrl+c", "cancel_or_quit", "Cancel/Quit"),
+        ("ctrl+l", "clear_conversation", "Clear"),
+        ("tab", "complete_slash_command", "Complete command"),
+    ]
+
+    def __init__(self, *, runtime: AgentRuntime, args: Any) -> None:
+        super().__init__()
+        self.runtime = runtime
+        self.args = args
+        self.thread_id = str(getattr(args, "thread_id", "") or DEFAULT_TUI_THREAD_ID)
+        self.reasoning_level: ReasoningLevel = normalize_reasoning_level(
+            getattr(args, "reasoning", None),
+            default=runtime.config.default_reasoning,
+        )
+        self.model_name = getattr(args, "model", None) or runtime.config.model_name
+        self.async_subagent_url = getattr(args, "async_subagent_url", None)
+        self.mcp_session_id = getattr(args, "mcp_session_id", None)
+        self.active_task: asyncio.Task[None] | None = None
+        self.status_message = "Ready."
+        self.conversation_entries: list[tuple[str, str]] = []
+        self.reasoning_entries: list[tuple[str, str]] = []
+        self.reasoning_entry_indexes: dict[str, int] = {}
+        self.tool_entries: list[str] = []
+        self.command_help_text = ""
+        self.command_help_visible = False
+        self.visible_command_names: list[str] = []
+
+    def compose(self) -> ComposeResult:
+        """Compose the TUI layout."""
+        yield Header(show_clock=True)
+        yield Static(self.status_message, id="status")
+        with Horizontal(id="main"):
+            yield RichLog(id="conversation", wrap=True, markup=True, highlight=False)
+            with Vertical(id="side"):
+                yield RichLog(id="reasoning", wrap=True, markup=True, highlight=False)
+                yield RichLog(id="tools", wrap=True, markup=True, highlight=False)
+        yield Static("", id="commands")
+        yield Input(placeholder="Prompt ChainAgents...", id="prompt")
+        yield Footer()
+
+    def on_mount(self) -> None:
+        """Focus the prompt when the TUI starts."""
+        self.query_one("#prompt", Input).focus()
+        self._set_status(
+            f"Ready. thread={self.thread_id} model={self.model_name} "
+            f"reasoning={self.reasoning_level}"
+        )
+
+    def on_key(self, event: events.Key) -> None:
+        """Handle prompt-level slash command completion keys."""
+        if event.key == "tab" and self.command_help_visible:
+            event.prevent_default()
+            event.stop()
+            self.action_complete_slash_command()
+
+    @on(Input.Submitted, "#prompt")
+    async def on_prompt_submitted(self, event: Input.Submitted) -> None:
+        """Send a submitted prompt to the agent."""
+        event.stop()
+        prompt = event.value.strip()
+        if not prompt or self.active_task is not None:
+            return
+
+        event.input.value = ""
+        self.hide_command_help()
+        self.active_task = asyncio.create_task(self._run_prompt(prompt))
+
+    @on(Input.Changed, "#prompt")
+    def on_prompt_changed(self, event: Input.Changed) -> None:
+        """Refresh slash command help as the user types."""
+        self.refresh_command_help(event.value)
+
+    async def action_cancel_or_quit(self) -> None:
+        """Cancel an active run, or exit when idle."""
+        if self.active_task is not None and not self.active_task.done():
+            self.active_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await self.active_task
+            return
+        self.exit(0)
+
+    def action_clear_conversation(self) -> None:
+        """Clear the visible conversation panes."""
+        if self.active_task is not None and not self.active_task.done():
+            return
+        self.conversation_entries.clear()
+        self.reasoning_entries.clear()
+        self.reasoning_entry_indexes.clear()
+        self.tool_entries.clear()
+        self.query_one("#conversation", RichLog).clear()
+        self.query_one("#reasoning", RichLog).clear()
+        self.query_one("#tools", RichLog).clear()
+        self._set_status("Cleared.")
+
+    def action_complete_slash_command(self) -> None:
+        """Complete the first visible slash command into the prompt."""
+        if not self.command_help_visible or not self.visible_command_names:
+            return
+        prompt = self.query_one("#prompt", Input)
+        command_name = self.visible_command_names[0]
+        prompt.value = f"/{command_name} "
+        prompt.cursor_position = len(prompt.value)
+        self.hide_command_help()
+
+    async def _run_prompt(self, raw_prompt: str) -> None:
+        prompt_input = self.query_one("#prompt", Input)
+        prompt_input.disabled = True
+        self._set_status("Running...")
+        self._append_conversation("You", raw_prompt)
+        self.reasoning_entry_indexes.clear()
+
+        try:
+            resolved_prompt = await self._resolve_prompt(raw_prompt)
+            if resolved_prompt is None:
+                return
+            await self._stream_agent_prompt(resolved_prompt)
+            self._set_status("Ready.")
+        except asyncio.CancelledError:
+            self._set_status("Cancelled.")
+            raise
+        except Exception as exc:
+            self._append_tool_entry(f"runtime error {type(exc).__name__}: {exc}")
+            self._set_status(f"{type(exc).__name__}: {exc}")
+        finally:
+            prompt_input.disabled = False
+            prompt_input.focus()
+            self.active_task = None
+
+    def refresh_command_help(self, prompt_value: str) -> None:
+        """Show matching slash commands when the prompt starts with slash."""
+        text = prompt_value.lstrip()
+        if not text.startswith("/") or " " in text:
+            self.hide_command_help()
+            return
+
+        query = text[1:].lower()
+        commands = [
+            command
+            for command in getattr(self.runtime, "chainlit_commands", ())
+            if str(getattr(command, "name", "")).lower().startswith(query)
+        ]
+        commands = sorted(commands, key=lambda command: str(getattr(command, "name", "")))
+        self.visible_command_names = [
+            str(getattr(command, "name", ""))
+            for command in commands
+            if str(getattr(command, "name", ""))
+        ]
+
+        if not commands:
+            self.command_help_text = "No matching slash commands."
+        else:
+            self.command_help_text = "\n".join(
+                self._format_command_help_line(command) for command in commands
+            )
+
+        panel = self.query_one("#commands", Static)
+        panel.update(self.command_help_text)
+        panel.display = True
+        self.command_help_visible = True
+
+    def hide_command_help(self) -> None:
+        """Hide the slash command help panel."""
+        self.command_help_text = ""
+        self.command_help_visible = False
+        self.visible_command_names = []
+        panel = self.query_one("#commands", Static)
+        panel.update("")
+        panel.display = False
+
+    @staticmethod
+    def _format_command_help_line(command: Any) -> str:
+        name = str(getattr(command, "name", "")).strip()
+        description = str(getattr(command, "description", "")).strip()
+        if description:
+            return f"/{name} - {description}"
+        return f"/{name}"
+
+    async def _resolve_prompt(self, raw_prompt: str) -> str | None:
+        parsed_command = resolve_native_command(raw_text=raw_prompt, selected_command=None)
+        slash_command_from_text = parse_native_command(raw_prompt)
+        if parsed_command is None:
+            return raw_prompt
+
+        try:
+            command_result = await resolve_runtime_command(
+                runtime=self.runtime,
+                parsed=parsed_command,
+                thread_id=self.thread_id,
+                mcp_session_id=self.mcp_session_id,
+            )
+        except Exception as exc:
+            self._append_tool_entry(
+                f"command /{parsed_command.command_name} failed: {exc}"
+            )
+            self._set_status(f"Command /{parsed_command.command_name} failed.")
+            return None
+
+        if command_result.target == "unknown":
+            if slash_command_from_text is not None:
+                self._append_tool_entry(f"unknown command /{parsed_command.command_name}")
+                self._set_status(f"Unknown command /{parsed_command.command_name}.")
+                return None
+            return raw_prompt
+
+        if command_result.target == "mcp_tool":
+            self._append_tool_entry(dumps_tool_result(command_result.tool_result))
+            self._set_status(f"Command /{parsed_command.command_name} finished.")
+            return None
+
+        prompt = command_result.prompt or ""
+        return prompt if prompt.strip() else None
+
+    async def _stream_agent_prompt(self, prompt: str) -> None:
+        agent = await self.runtime.get_agent(
+            self.reasoning_level,
+            model_name=self.model_name,
+            thread_id=self.thread_id,
+            async_subagent_url_override=self.async_subagent_url,
+            mcp_session_id=self.mcp_session_id,
+        )
+        payload = {"messages": [{"role": "user", "content": prompt}]}
+        config = {
+            "configurable": {"thread_id": self.thread_id},
+            "recursion_limit": self.runtime.config.recursion_limit,
+        }
+        adapter = AgentStreamEventAdapter(prompt=prompt)
+        stream = agent.astream_events(
+            payload,
+            config=config,
+            version="v2",
+            stream_mode=["messages", "updates", "custom"],
+            subgraphs=True,
+        )
+
+        try:
+            while True:
+                try:
+                    event = await anext(stream)
+                except StopAsyncIteration:
+                    break
+                for stream_event in adapter.events_from_raw_event(event):
+                    self._handle_stream_event(stream_event)
+        finally:
+            with suppress(Exception):
+                await stream.aclose()
+
+    def _handle_stream_event(self, event: AgentStreamEvent) -> None:
+        if event.kind == "response_delta":
+            self._append_response_delta(event.text)
+        elif event.kind == "reasoning_delta":
+            self._append_reasoning(event.source, event.text)
+        elif event.kind == "tool_call":
+            self._append_tool_entry(
+                " ".join(
+                    part
+                    for part in (
+                        event.source,
+                        event.tool_name,
+                        event.status,
+                        event.tool_args,
+                    )
+                    if part
+                )
+            )
+        elif event.kind == "tool_result":
+            self._append_tool_entry(
+                " ".join(
+                    part
+                    for part in (
+                        event.source,
+                        event.tool_name,
+                        event.status,
+                        self._preview(event.tool_result),
+                    )
+                    if part
+                )
+            )
+        elif event.kind == "summarization_status":
+            self._append_tool_entry(
+                f"{event.source} summarization {event.status}: {event.text}"
+            )
+
+    def _append_conversation(self, role: str, text: str) -> None:
+        self.conversation_entries.append((role, text))
+        self._render_conversation()
+
+    def _append_response_delta(self, text: str) -> None:
+        if not text:
+            return
+        if self.conversation_entries and self.conversation_entries[-1][0] == "Assistant":
+            role, current = self.conversation_entries[-1]
+            self.conversation_entries[-1] = (role, current + text)
+        else:
+            self.conversation_entries.append(("Assistant", text))
+        self._render_conversation()
+
+    def _render_conversation(self) -> None:
+        log = self.query_one("#conversation", RichLog)
+        log.clear()
+        for role, text in self.conversation_entries:
+            style = "cyan" if role == "You" else "green"
+            log.write(
+                Panel(
+                    Text(text, style="white"),
+                    title=role,
+                    title_align="left",
+                    border_style=style,
+                )
+            )
+
+    def _append_reasoning(self, source: str, text: str) -> None:
+        if not text:
+            return
+        existing_index = self.reasoning_entry_indexes.get(source)
+        if existing_index is not None:
+            current_source, current_text = self.reasoning_entries[existing_index]
+            self.reasoning_entries[existing_index] = (current_source, current_text + text)
+        else:
+            self.reasoning_entries.append((source, text))
+            self.reasoning_entry_indexes[source] = len(self.reasoning_entries) - 1
+        self._render_reasoning()
+
+    def _render_reasoning(self) -> None:
+        log = self.query_one("#reasoning", RichLog)
+        log.clear()
+        for source, text in self.reasoning_entries:
+            log.write(
+                Panel(
+                    Text(text, style="magenta"),
+                    title=f"{source} reasoning",
+                    title_align="left",
+                    border_style="magenta",
+                )
+            )
+
+    def _append_tool_entry(self, text: str) -> None:
+        self.tool_entries.append(text)
+        self.query_one("#tools", RichLog).write(Text(text, style="yellow"))
+
+    def _set_status(self, message: str) -> None:
+        self.status_message = message
+        status = self.query_one("#status", Static)
+        status.update(message)
+
+    @staticmethod
+    def _preview(text: str, limit: int = 200) -> str:
+        compact = text.strip()
+        if len(compact) <= limit:
+            return compact
+        return compact[:limit]
+
+
+async def run_tui(runtime: AgentRuntime, args: Any) -> int:
+    """Run the Textual TUI and return a process-style exit code."""
+    app = ChainAgentsTuiApp(runtime=runtime, args=args)
+    result = await app.run_async()
+    return int(result or 0)

--- a/chainagents_tui.py
+++ b/chainagents_tui.py
@@ -3,15 +3,17 @@
 from __future__ import annotations
 
 import asyncio
-from contextlib import suppress
+from contextlib import contextmanager, suppress
+from pathlib import Path
 from typing import Any
 
+from langchain_mcp_adapters import sessions as mcp_sessions
 from rich.panel import Panel
 from rich.text import Text
 from textual import events, on
 from textual.app import App, ComposeResult
-from textual.containers import Horizontal, Vertical
-from textual.widgets import Footer, Header, Input, RichLog, Static
+from textual.containers import Horizontal, Vertical, VerticalScroll
+from textual.widgets import Footer, Header, Input, Markdown, RichLog, Static
 
 from agent_commands import (
     dumps_tool_result,
@@ -24,10 +26,37 @@ from deepagent_runtime import AgentRuntime, ReasoningLevel, normalize_reasoning_
 
 
 DEFAULT_TUI_THREAD_ID = "tui"
+TUI_SIDE_PANEL_WIDTH = 56
+TUI_STDERR_LOG = Path(".files/tui-stderr.log")
+
+
+def tui_stderr_log_path(runtime: AgentRuntime) -> Path:
+    """Return the log path used for stderr emitted during TUI mode."""
+    project_root = Path(getattr(runtime, "project_root", Path(__file__).resolve().parent))
+    return project_root / TUI_STDERR_LOG
+
+
+@contextmanager
+def capture_mcp_stdio_stderr(log_path: Path):
+    """Route stdio MCP server stderr to a log file during TUI mode."""
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    original_stdio_client = mcp_sessions.stdio_client
+    try:
+        with log_path.open("a", encoding="utf-8", buffering=1) as log_file:
+
+            def stdio_client_with_log(server, errlog=None):
+                return original_stdio_client(server, errlog=log_file)
+
+            mcp_sessions.stdio_client = stdio_client_with_log
+            yield
+    finally:
+        mcp_sessions.stdio_client = original_stdio_client
 
 
 class ChainAgentsTuiApp(App[int]):
     """Interactive Textual app for the configured ChainAgents runtime."""
+
+    TITLE = "ChainAgents"
 
     CSS = """
     Screen {
@@ -49,10 +78,27 @@ class ChainAgentsTuiApp(App[int]):
         width: 2fr;
         height: 100%;
         border: solid $primary;
+        padding: 0 1;
+    }
+
+    .conversation-label {
+        height: 1;
+        margin: 1 0 0 0;
+        color: $text-muted;
+    }
+
+    .conversation-user {
+        margin: 0 0 1 0;
+    }
+
+    .conversation-assistant {
+        margin: 0 0 1 0;
+        padding: 0 1;
+        border: solid $success;
     }
 
     #side {
-        width: 42;
+        width: __SIDE_PANEL_WIDTH__;
         height: 100%;
     }
 
@@ -77,7 +123,7 @@ class ChainAgentsTuiApp(App[int]):
         border: solid $warning;
         display: none;
     }
-    """
+    """.replace("__SIDE_PANEL_WIDTH__", str(TUI_SIDE_PANEL_WIDTH))
 
     BINDINGS = [
         ("ctrl+c", "cancel_or_quit", "Cancel/Quit"),
@@ -100,6 +146,7 @@ class ChainAgentsTuiApp(App[int]):
         self.active_task: asyncio.Task[None] | None = None
         self.status_message = "Ready."
         self.conversation_entries: list[tuple[str, str]] = []
+        self.assistant_markdown_widgets: dict[int, Markdown] = {}
         self.reasoning_entries: list[tuple[str, str]] = []
         self.reasoning_entry_indexes: dict[str, int] = {}
         self.tool_entries: list[str] = []
@@ -112,7 +159,7 @@ class ChainAgentsTuiApp(App[int]):
         yield Header(show_clock=True)
         yield Static(self.status_message, id="status")
         with Horizontal(id="main"):
-            yield RichLog(id="conversation", wrap=True, markup=True, highlight=False)
+            yield VerticalScroll(id="conversation")
             with Vertical(id="side"):
                 yield RichLog(id="reasoning", wrap=True, markup=True, highlight=False)
                 yield RichLog(id="tools", wrap=True, markup=True, highlight=False)
@@ -166,10 +213,11 @@ class ChainAgentsTuiApp(App[int]):
         if self.active_task is not None and not self.active_task.done():
             return
         self.conversation_entries.clear()
+        self.assistant_markdown_widgets.clear()
         self.reasoning_entries.clear()
         self.reasoning_entry_indexes.clear()
         self.tool_entries.clear()
-        self.query_one("#conversation", RichLog).clear()
+        self.query_one("#conversation", VerticalScroll).remove_children()
         self.query_one("#reasoning", RichLog).clear()
         self.query_one("#tools", RichLog).clear()
         self._set_status("Cleared.")
@@ -188,7 +236,7 @@ class ChainAgentsTuiApp(App[int]):
         prompt_input = self.query_one("#prompt", Input)
         prompt_input.disabled = True
         self._set_status("Running...")
-        self._append_conversation("You", raw_prompt)
+        await self._append_conversation("You", raw_prompt)
         self.reasoning_entry_indexes.clear()
 
         try:
@@ -321,14 +369,14 @@ class ChainAgentsTuiApp(App[int]):
                 except StopAsyncIteration:
                     break
                 for stream_event in adapter.events_from_raw_event(event):
-                    self._handle_stream_event(stream_event)
+                    await self._handle_stream_event(stream_event)
         finally:
             with suppress(Exception):
                 await stream.aclose()
 
-    def _handle_stream_event(self, event: AgentStreamEvent) -> None:
+    async def _handle_stream_event(self, event: AgentStreamEvent) -> None:
         if event.kind == "response_delta":
-            self._append_response_delta(event.text)
+            await self._append_response_delta(event.text)
         elif event.kind == "reasoning_delta":
             self._append_reasoning(event.source, event.text)
         elif event.kind == "tool_call":
@@ -362,33 +410,71 @@ class ChainAgentsTuiApp(App[int]):
                 f"{event.source} summarization {event.status}: {event.text}"
             )
 
-    def _append_conversation(self, role: str, text: str) -> None:
+    async def _append_conversation(self, role: str, text: str) -> None:
         self.conversation_entries.append((role, text))
-        self._render_conversation()
+        widget = await self._mount_conversation_entry(
+            len(self.conversation_entries) - 1,
+            role,
+            text,
+        )
+        if role == "Assistant" and text and widget is not None:
+            await widget.append(text)
+            self.query_one("#conversation", VerticalScroll).scroll_end(animate=False)
 
-    def _append_response_delta(self, text: str) -> None:
+    async def _append_response_delta(self, text: str) -> None:
         if not text:
             return
         if self.conversation_entries and self.conversation_entries[-1][0] == "Assistant":
             role, current = self.conversation_entries[-1]
-            self.conversation_entries[-1] = (role, current + text)
+            updated_text = current + text
+            entry_index = len(self.conversation_entries) - 1
+            self.conversation_entries[-1] = (role, updated_text)
+            widget = self.assistant_markdown_widgets.get(entry_index)
+            if widget is not None:
+                await widget.append(text)
         else:
             self.conversation_entries.append(("Assistant", text))
-        self._render_conversation()
+            widget = await self._mount_conversation_entry(
+                len(self.conversation_entries) - 1,
+                "Assistant",
+            )
+            if widget is not None:
+                await widget.append(text)
+        self.query_one("#conversation", VerticalScroll).scroll_end(animate=False)
 
-    def _render_conversation(self) -> None:
-        log = self.query_one("#conversation", RichLog)
-        log.clear()
-        for role, text in self.conversation_entries:
-            style = "cyan" if role == "You" else "green"
-            log.write(
-                Panel(
-                    Text(text, style="white"),
-                    title=role,
-                    title_align="left",
-                    border_style=style,
+    async def _mount_conversation_entry(
+        self,
+        index: int,
+        role: str,
+        text: str = "",
+    ) -> Markdown | None:
+        conversation = self.query_one("#conversation", VerticalScroll)
+        if role == "Assistant":
+            markdown = Markdown("", classes="conversation-assistant")
+            markdown.code_indent_guides = False
+            self.assistant_markdown_widgets[index] = markdown
+            await conversation.mount_all(
+                (
+                    Static("Assistant", classes="conversation-label"),
+                    markdown,
                 )
             )
+            conversation.scroll_end(animate=False)
+            return markdown
+        else:
+            await conversation.mount(
+                Static(
+                    Panel(
+                        Text(text, style="white"),
+                        title=role,
+                        title_align="left",
+                        border_style="cyan",
+                    ),
+                    classes="conversation-user",
+                )
+            )
+        conversation.scroll_end(animate=False)
+        return None
 
     def _append_reasoning(self, source: str, text: str) -> None:
         if not text:
@@ -435,5 +521,6 @@ class ChainAgentsTuiApp(App[int]):
 async def run_tui(runtime: AgentRuntime, args: Any) -> int:
     """Run the Textual TUI and return a process-style exit code."""
     app = ChainAgentsTuiApp(runtime=runtime, args=args)
-    result = await app.run_async()
+    with capture_mcp_stdio_stderr(tui_stderr_log_path(runtime)):
+        result = await app.run_async()
     return int(result or 0)

--- a/chainlit_bridge.py
+++ b/chainlit_bridge.py
@@ -14,6 +14,7 @@ from typing import Any
 import chainlit as cl
 from chainlit.utils import utc_now
 
+from agent_stream_events import AgentStreamEvent, AgentStreamEventAdapter
 from response_exports import attach_response_export_actions
 
 DEFAULT_AUTO_COLLAPSE_DELAY_SECONDS = 3.0
@@ -868,6 +869,7 @@ class ChainlitEventBridge:
         self.response_task_started = False
         self.last_response_flush_at = 0.0
         self.response_streamed_from_messages = False
+        self.stream_adapter = AgentStreamEventAdapter(prompt=prompt)
         self.reasoning_steps: dict[str, cl.Step] = {}
         self.reasoning_buffers: dict[str, str] = {}
         self.tool_steps: dict[str, ToolStepState] = {}
@@ -887,15 +889,34 @@ class ChainlitEventBridge:
         Args:
             part: The part value.
         """
-        kind = part["type"]
-        if kind == "messages":
-            await self._handle_message_chunk(part)
+        if part["type"] == "updates" and self.run_task_list is not None:
+            await self._update_todos_from_update_part(part)
+
+        for stream_event in self.stream_adapter.events_from_part(part):
+            await self._handle_stream_event(stream_event)
+
+    async def _handle_stream_event(self, event: AgentStreamEvent) -> None:
+        """Render one normalized agent stream event."""
+        if event.kind == "response_delta":
+            await self._stream_response(event.text)
+        elif event.kind == "reasoning_delta":
+            await self._stream_reasoning(event.source, event.text)
+        elif event.kind == "tool_call":
+            await self._stream_tool_call_event(event)
+        elif event.kind == "tool_result":
+            await self._complete_tool_event(event)
+        elif event.kind == "summarization_status":
+            await self._stream_summarization_status_event(event)
+
+    async def _update_todos_from_update_part(self, part: dict[str, Any]) -> None:
+        """Refresh Chainlit task list todos from a LangGraph update part."""
+        data_by_node = part.get("data")
+        if not isinstance(data_by_node, dict):
             return
-        if kind == "updates":
-            await self._handle_update_chunk(part)
-            return
-        if kind == "custom":
-            await self._handle_custom_chunk(part)
+        for data in data_by_node.values():
+            todos = todos_from_node_data(data)
+            if todos:
+                await self.run_task_list.update_todos(todos)
 
     async def handle_event(self, event: dict[str, Any]) -> None:
         """Handle one raw LangGraph stream event.
@@ -1036,6 +1057,119 @@ class ChainlitEventBridge:
             step.end = utc_now()
             self._schedule_step_auto_collapse(step)
         await step.update()
+
+    async def _stream_summarization_status_event(self, event: AgentStreamEvent) -> None:
+        """Render a normalized summarization status event."""
+        source = event.source or "main-agent"
+        status = (event.status or "triggered").strip().lower() or "triggered"
+        message = event.text or "Conversation summarization triggered."
+        step = self.summarization_steps.get(source)
+        if step is None:
+            step = cl.Step(
+                name=f"{source} summarization",
+                type="llm",
+                default_open=True,
+            )
+            step.input = self.prompt if source == "main-agent" else ""
+            step.start = utc_now()
+            await step.send()
+            self.summarization_steps[source] = step
+
+        step.output = message
+        if status in {"completed", "skipped", "failed"}:
+            step.end = utc_now()
+            self._schedule_step_auto_collapse(step)
+        await step.update()
+
+    async def _stream_tool_call_event(self, event: AgentStreamEvent) -> None:
+        """Render a normalized streamed tool call event."""
+        if self.chronological_ui_enabled:
+            await self._close_reasoning_step(event.source)
+
+        state = self.tool_steps.get(event.tool_call_id)
+        if state is None:
+            step = cl.Step(
+                name=f"{event.source} tool",
+                type="tool",
+                default_open=True,
+                show_input="json",
+                language="json",
+            )
+            step.start = utc_now()
+            step.output = "Running..."
+            await step.send()
+            state = ToolStepState(
+                call_id=event.tool_call_id,
+                source=event.source,
+                step=step,
+            )
+            self.tool_steps[event.tool_call_id] = state
+
+        if event.tool_name:
+            state.name = event.tool_name
+            state.step.name = f"{event.source} · {state.name}"
+
+        if event.tool_args:
+            state.arg_chunks = [event.tool_args]
+            if state.name == "write_todos" and self.run_task_list is not None:
+                todos = todos_from_write_todos_args(event.tool_args)
+                if todos:
+                    await self.run_task_list.update_todos(todos)
+
+        if self.run_task_list is not None:
+            await self.run_task_list.mark_tool_started(
+                state.call_id,
+                tool_task_title(event.source, state.name, event.tool_args),
+                for_id=getattr(state.step, "id", None),
+            )
+
+        rendered_input = state.rendered_input
+        if rendered_input:
+            state.step.input = rendered_input
+        await state.step.update()
+
+    async def _complete_tool_event(self, event: AgentStreamEvent) -> None:
+        """Render a normalized completed tool call event."""
+        state = self._resolve_tool_step_from_event(event)
+        if state is None:
+            step = cl.Step(
+                name=f"{event.source} · {event.tool_name or 'tool'}",
+                type="tool",
+                default_open=True,
+                show_input="json",
+                language="json",
+            )
+            step.start = utc_now()
+            await step.send()
+            state = ToolStepState(
+                call_id=event.tool_call_id or event.source,
+                source=event.source,
+                step=step,
+                name=event.tool_name or "tool",
+            )
+
+        if event.tool_name:
+            state.name = event.tool_name
+            state.step.name = f"{event.source} · {state.name}"
+        if not state.step.input:
+            state.step.input = state.rendered_input
+        state.step.output = pretty_data(event.tool_result)
+        state.step.end = utc_now()
+        await state.step.update()
+        self._schedule_step_auto_collapse(state.step)
+
+        if self.run_task_list is not None:
+            await self.run_task_list.mark_tool_finished(
+                state.call_id,
+                title=tool_task_title(event.source, state.name, "".join(state.arg_chunks)),
+                for_id=getattr(state.step, "id", None),
+                failed=event.status.lower() == "error",
+            )
+        if state.name == "write_todos" and self.run_task_list is not None:
+            todos = todos_from_tool_message_content(event.tool_result)
+            if todos:
+                await self.run_task_list.update_todos(todos)
+        self.tool_steps.pop(state.call_id, None)
 
     async def _stream_reasoning(self, source: str, text: str) -> None:
         """Stream reasoning text into the active output target.
@@ -1287,6 +1421,44 @@ class ChainlitEventBridge:
             state
             for state in self.tool_steps.values()
             if tool_name is not None and state.name == tool_name
+        ]
+        if name_matches:
+            return name_matches[0]
+
+        if self.tool_steps:
+            return next(iter(self.tool_steps.values()))
+        return None
+
+    def _resolve_tool_step_from_event(
+        self,
+        event: AgentStreamEvent,
+    ) -> ToolStepState | None:
+        """Return the active Chainlit step for a normalized tool event."""
+        if event.tool_call_id and event.tool_call_id in self.tool_steps:
+            return self.tool_steps[event.tool_call_id]
+
+        source_name_matches = [
+            state
+            for state in self.tool_steps.values()
+            if (
+                state.source == event.source
+                and bool(event.tool_name)
+                and state.name == event.tool_name
+            )
+        ]
+        if source_name_matches:
+            return source_name_matches[0]
+
+        source_matches = [
+            state for state in self.tool_steps.values() if state.source == event.source
+        ]
+        if source_matches:
+            return source_matches[0]
+
+        name_matches = [
+            state
+            for state in self.tool_steps.values()
+            if bool(event.tool_name) and state.name == event.tool_name
         ]
         if name_matches:
             return name_matches[0]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "psycopg[binary,pool]>=3.2.0",
     "pytest>=8.3.0",
     "rich>=15.0.0",
+    "textual>=6.1.0",
 ]
 
 [project.scripts]
@@ -30,8 +31,10 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools]
 py-modules = [
     "agent_commands",
+    "agent_stream_events",
     "async_task_notifications",
     "chainagents_cli",
+    "chainagents_tui",
     "chainlit_bridge",
     "deepagent_runtime",
     "langgraph_app",

--- a/tests/test_agent_stream_events.py
+++ b/tests/test_agent_stream_events.py
@@ -1,0 +1,216 @@
+"""Test normalized LangGraph stream event handling."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from agent_stream_events import AgentStreamEvent, AgentStreamEventAdapter
+
+
+class _Token:
+    type = "AIMessageChunk"
+    additional_kwargs: dict[str, str] = {}
+    tool_call_chunks: list[dict[str, str]] = []
+
+    def __init__(self, content: str = "") -> None:
+        self.content = content
+
+
+class _ReasoningToken:
+    type = "AIMessageChunk"
+    content = ""
+    tool_call_chunks: list[dict[str, str]] = []
+
+    def __init__(self, reasoning: str) -> None:
+        self.additional_kwargs = {"reasoning_content": reasoning}
+
+
+class _ToolCallChunkToken:
+    type = "AIMessageChunk"
+    content = ""
+    additional_kwargs: dict[str, str] = {}
+
+    def __init__(self, chunk: dict[str, str]) -> None:
+        self.tool_call_chunks = [chunk]
+
+
+class _ToolMessage:
+    type = "tool"
+    name = "read_file"
+    status = "success"
+    tool_call_id = "call-1"
+
+    def __init__(self, content: str) -> None:
+        self.content = content
+
+
+def _raw_event(chunk: object, *, parent_ids: list[str] | None = None) -> dict[str, object]:
+    return {
+        "event": "on_chain_stream",
+        "parent_ids": parent_ids or [],
+        "data": {"chunk": chunk},
+    }
+
+
+def test_adapter_streams_response_deltas_from_main_message_chunks() -> None:
+    adapter = AgentStreamEventAdapter(prompt="hello")
+
+    first = adapter.events_from_raw_event(
+        _raw_event(((), "messages", (_Token("Hello"), {})))
+    )
+    second = adapter.events_from_raw_event(
+        _raw_event(((), "messages", (_Token("Hello world"), {})))
+    )
+
+    assert first == [
+        AgentStreamEvent(kind="response_delta", source="main-agent", text="Hello")
+    ]
+    assert second == [
+        AgentStreamEvent(kind="response_delta", source="main-agent", text=" world")
+    ]
+
+
+def test_adapter_streams_reasoning_deltas_by_source() -> None:
+    adapter = AgentStreamEventAdapter(prompt="hello")
+
+    first = adapter.events_from_raw_event(
+        _raw_event(((), "messages", (_ReasoningToken("thinking"), {})))
+    )
+    second = adapter.events_from_raw_event(
+        _raw_event(((), "messages", (_ReasoningToken("thinking more"), {})))
+    )
+
+    assert first == [
+        AgentStreamEvent(kind="reasoning_delta", source="main-agent", text="thinking")
+    ]
+    assert second == [
+        AgentStreamEvent(kind="reasoning_delta", source="main-agent", text=" more")
+    ]
+
+
+def test_adapter_accumulates_tool_call_arguments_and_deduplicates_results() -> None:
+    adapter = AgentStreamEventAdapter(prompt="hello")
+
+    start = adapter.events_from_raw_event(
+        _raw_event(
+            (
+                (),
+                "messages",
+                (
+                    _ToolCallChunkToken(
+                        {"id": "call-1", "name": "read_file", "args": '{"path":"REA'}
+                    ),
+                    {},
+                ),
+            )
+        )
+    )
+    update = adapter.events_from_raw_event(
+        _raw_event(
+            (
+                (),
+                "messages",
+                (_ToolCallChunkToken({"id": "call-1", "args": 'DME.md"}'}), {}),
+            )
+        )
+    )
+    result = adapter.events_from_raw_event(
+        _raw_event(((), "messages", (_ToolMessage("content"), {})))
+    )
+    duplicate_result = adapter.events_from_raw_event(
+        _raw_event(((), "messages", (_ToolMessage("content"), {})))
+    )
+
+    assert start == [
+        AgentStreamEvent(
+            kind="tool_call",
+            source="main-agent",
+            tool_call_id="call-1",
+            tool_name="read_file",
+            tool_args='{"path":"REA',
+            tool_args_delta='{"path":"REA',
+            status="start",
+        )
+    ]
+    assert update == [
+        AgentStreamEvent(
+            kind="tool_call",
+            source="main-agent",
+            tool_call_id="call-1",
+            tool_name="read_file",
+            tool_args='{"path":"README.md"}',
+            tool_args_delta='DME.md"}',
+            status="update",
+        )
+    ]
+    assert result == [
+        AgentStreamEvent(
+            kind="tool_result",
+            source="main-agent",
+            tool_call_id="call-1",
+            tool_name="read_file",
+            tool_result="content",
+            status="success",
+        )
+    ]
+    assert duplicate_result == []
+
+
+def test_adapter_uses_update_chunks_for_non_streamed_final_response() -> None:
+    adapter = AgentStreamEventAdapter(prompt="hello")
+    human = SimpleNamespace(type="human", content="hello")
+    assistant = SimpleNamespace(type="ai", content="Final answer")
+
+    events = adapter.events_from_raw_event(
+        _raw_event(("updates", {"agent": {"messages": [human, assistant]}}))
+    )
+
+    assert events == [
+        AgentStreamEvent(
+            kind="response_delta",
+            source="main-agent",
+            text="Final answer",
+        )
+    ]
+
+
+def test_adapter_streams_summarization_status_events() -> None:
+    adapter = AgentStreamEventAdapter(prompt="hello")
+
+    events = adapter.events_from_raw_event(
+        _raw_event(
+            (
+                "custom",
+                {
+                    "kind": "summarization_status",
+                    "status": "started",
+                    "source": "main-agent",
+                    "message": "Conversation summarization triggered.",
+                },
+            )
+        )
+    )
+
+    assert events == [
+        AgentStreamEvent(
+            kind="summarization_status",
+            source="main-agent",
+            status="started",
+            text="Conversation summarization triggered.",
+        )
+    ]
+
+
+def test_adapter_ignores_nested_chain_events() -> None:
+    adapter = AgentStreamEventAdapter(prompt="hello")
+
+    events = adapter.events_from_raw_event(
+        _raw_event(
+            ((), "messages", (_Token("Nested"), {})),
+            parent_ids=["parent"],
+        )
+    )
+
+    assert events == []

--- a/tests/test_chainagents_tui.py
+++ b/tests/test_chainagents_tui.py
@@ -1,0 +1,411 @@
+"""Test the Textual ChainAgents TUI."""
+
+from __future__ import annotations
+
+import asyncio
+import io
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from textual.widgets import Input, RichLog
+
+import chainagents_cli
+from chainagents_tui import DEFAULT_TUI_THREAD_ID, ChainAgentsTuiApp
+
+
+class _Token:
+    type = "AIMessageChunk"
+    additional_kwargs: dict[str, str] = {}
+    tool_call_chunks: list[dict[str, str]] = []
+
+    def __init__(self, content: str = "") -> None:
+        self.content = content
+
+
+class _ReasoningToken:
+    type = "AIMessageChunk"
+    content = ""
+    tool_call_chunks: list[dict[str, str]] = []
+
+    def __init__(self, reasoning: str) -> None:
+        self.additional_kwargs = {"reasoning_content": reasoning}
+
+
+class _ToolCallChunkToken:
+    type = "AIMessageChunk"
+    content = ""
+    additional_kwargs: dict[str, str] = {}
+
+    def __init__(self, chunk: dict[str, str]) -> None:
+        self.tool_call_chunks = [chunk]
+
+
+class _ToolMessage:
+    type = "tool"
+    name = "read_file"
+    status = "success"
+    tool_call_id = "call-1"
+
+    def __init__(self, content: str) -> None:
+        self.content = content
+
+
+def _raw_event(chunk: object) -> dict[str, object]:
+    return {"event": "on_chain_stream", "data": {"chunk": chunk}}
+
+
+def _args(**overrides: Any) -> SimpleNamespace:
+    values = {
+        "thread_id": None,
+        "reasoning": None,
+        "model": None,
+        "async_subagent_url": None,
+        "mcp_session_id": None,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+class _FakeAgent:
+    def __init__(self, events: list[dict[str, object]]) -> None:
+        self.events = events
+        self.payload: dict[str, Any] | None = None
+        self.config: dict[str, Any] | None = None
+
+    def astream_events(self, payload, *, config, version, stream_mode, subgraphs):
+        self.payload = payload
+        self.config = config
+
+        async def events():
+            for event in self.events:
+                yield event
+
+        return events()
+
+
+class _QueuedAgent:
+    def __init__(self, runs: list[list[dict[str, object]]]) -> None:
+        self.runs = runs
+
+    def astream_events(self, payload, *, config, version, stream_mode, subgraphs):
+        events_for_run = self.runs.pop(0)
+
+        async def events():
+            for event in events_for_run:
+                yield event
+
+        return events()
+
+
+class _BlockingAgent:
+    def __init__(self) -> None:
+        self.started = asyncio.Event()
+        self.cancelled = False
+
+    def astream_events(self, payload, *, config, version, stream_mode, subgraphs):
+        async def events():
+            self.started.set()
+            try:
+                await asyncio.sleep(60)
+            except asyncio.CancelledError:
+                self.cancelled = True
+                raise
+            if False:
+                yield None
+
+        return events()
+
+
+class _FakeRuntime:
+    def __init__(self, agent: _FakeAgent | _BlockingAgent) -> None:
+        self.agent = agent
+        self.config = SimpleNamespace(
+            default_reasoning="medium",
+            model_name="fake-model",
+            recursion_limit=100,
+        )
+        self.commands: dict[str, Any] = {}
+
+    async def get_agent(self, *args, **kwargs):
+        return self.agent
+
+    def resolve_chainlit_command(self, name: str):
+        return self.commands.get(name)
+
+    async def invoke_mcp_tool_command(self, **kwargs):
+        return {"ok": True, "kwargs": kwargs}
+
+    @property
+    def chainlit_commands(self):
+        return tuple(self.commands.values())
+
+
+def test_cli_parses_tui_flag() -> None:
+    args = chainagents_cli.parse_args(["--tui"])
+
+    assert args.tui is True
+    assert args.thread_id is None
+
+
+@pytest.mark.anyio
+async def test_cli_rejects_one_shot_prompt_in_tui_mode() -> None:
+    args = chainagents_cli.parse_args(["--tui", "--prompt", "hello"])
+
+    code = await chainagents_cli.run_cli(
+        args,
+        runtime=_FakeRuntime(_FakeAgent([])),  # type: ignore[arg-type]
+        stdout=io.StringIO(),
+        stderr=io.StringIO(),
+        stdin=io.StringIO("should not read"),
+    )
+
+    assert code == 2
+
+
+@pytest.mark.anyio
+async def test_cli_rejects_unsupported_one_shot_flags_in_tui_mode() -> None:
+    args = chainagents_cli.parse_args(["--tui", "--json", "--status"])
+    stderr = io.StringIO()
+
+    code = await chainagents_cli.run_cli(
+        args,
+        runtime=_FakeRuntime(_FakeAgent([])),  # type: ignore[arg-type]
+        stdout=io.StringIO(),
+        stderr=stderr,
+        stdin=io.StringIO(""),
+    )
+
+    assert code == 2
+    assert "unsupported flags in TUI mode: --status, --json" in stderr.getvalue()
+
+
+@pytest.mark.anyio
+async def test_tui_mounts_expected_panes_and_prompt() -> None:
+    app = ChainAgentsTuiApp(
+        runtime=_FakeRuntime(_FakeAgent([])),
+        args=chainagents_cli.parse_args(["--tui"]),
+    )
+
+    async with app.run_test():
+        assert app.thread_id == DEFAULT_TUI_THREAD_ID
+        assert app.query_one("#conversation", RichLog)
+        assert app.query_one("#reasoning", RichLog)
+        assert app.query_one("#tools", RichLog)
+        assert app.query_one("#prompt", Input)
+
+
+@pytest.mark.anyio
+async def test_tui_submits_prompt_and_streams_response() -> None:
+    agent = _FakeAgent([
+        _raw_event(((), "messages", (_Token("Hello from agent"), {}))),
+    ])
+    app = ChainAgentsTuiApp(runtime=_FakeRuntime(agent), args=_args())
+
+    async with app.run_test() as pilot:
+        prompt = app.query_one("#prompt", Input)
+        prompt.value = "hello"
+        await pilot.press("enter")
+        await pilot.pause()
+
+    assert agent.payload == {"messages": [{"role": "user", "content": "hello"}]}
+    assert agent.config == {
+        "configurable": {"thread_id": DEFAULT_TUI_THREAD_ID},
+        "recursion_limit": 100,
+    }
+    assert app.conversation_entries == [
+        ("You", "hello"),
+        ("Assistant", "Hello from agent"),
+    ]
+
+
+@pytest.mark.anyio
+async def test_tui_streams_reasoning_and_tool_activity_to_side_panes() -> None:
+    agent = _FakeAgent(
+        [
+            _raw_event(((), "messages", (_ReasoningToken("thinking"), {}))),
+            _raw_event(
+                (
+                    (),
+                    "messages",
+                    (
+                        _ToolCallChunkToken(
+                            {
+                                "id": "call-1",
+                                "name": "read_file",
+                                "args": '{"path":"README.md"}',
+                            }
+                        ),
+                        {},
+                    ),
+                )
+            ),
+            _raw_event(((), "messages", (_ToolMessage("file content"), {}))),
+        ]
+    )
+    app = ChainAgentsTuiApp(runtime=_FakeRuntime(agent), args=_args())
+
+    async with app.run_test() as pilot:
+        prompt = app.query_one("#prompt", Input)
+        prompt.value = "inspect"
+        await pilot.press("enter")
+        await pilot.pause()
+
+    assert app.reasoning_entries == [("main-agent", "thinking")]
+    assert app.tool_entries == [
+        "main-agent read_file start {\"path\":\"README.md\"}",
+        "main-agent read_file success file content",
+    ]
+
+
+@pytest.mark.anyio
+async def test_tui_accumulates_reasoning_deltas_in_one_entry() -> None:
+    agent = _FakeAgent(
+        [
+            _raw_event(((), "messages", (_ReasoningToken("thinking"), {}))),
+            _raw_event(((), "messages", (_ReasoningToken("thinking through"), {}))),
+            _raw_event(
+                ((), "messages", (_ReasoningToken("thinking through details"), {}))
+            ),
+        ]
+    )
+    app = ChainAgentsTuiApp(runtime=_FakeRuntime(agent), args=_args())
+
+    async with app.run_test() as pilot:
+        prompt = app.query_one("#prompt", Input)
+        prompt.value = "inspect"
+        await pilot.press("enter")
+        await pilot.pause()
+
+    assert app.reasoning_entries == [("main-agent", "thinking through details")]
+
+
+@pytest.mark.anyio
+async def test_tui_starts_new_reasoning_entry_for_each_prompt() -> None:
+    agent = _QueuedAgent(
+        [
+            [
+                _raw_event(((), "messages", (_ReasoningToken("first"), {}))),
+                _raw_event(((), "messages", (_ReasoningToken("first run"), {}))),
+            ],
+            [
+                _raw_event(((), "messages", (_ReasoningToken("second"), {}))),
+                _raw_event(((), "messages", (_ReasoningToken("second run"), {}))),
+            ],
+        ]
+    )
+    app = ChainAgentsTuiApp(runtime=_FakeRuntime(agent), args=_args())
+
+    async with app.run_test() as pilot:
+        prompt = app.query_one("#prompt", Input)
+        prompt.value = "first"
+        await pilot.press("enter")
+        await pilot.pause()
+
+        prompt.value = "second"
+        await pilot.press("enter")
+        await pilot.pause()
+
+    assert app.reasoning_entries == [
+        ("main-agent", "first run"),
+        ("main-agent", "second run"),
+    ]
+
+
+@pytest.mark.anyio
+async def test_tui_applies_prompt_slash_commands() -> None:
+    agent = _FakeAgent([
+        _raw_event(((), "messages", (_Token("summary"), {}))),
+    ])
+    runtime = _FakeRuntime(agent)
+    runtime.commands["summarize"] = SimpleNamespace(
+        name="summarize",
+        description="Summarize",
+        target="prompt",
+        value="Summarize the input",
+        template="Summarize this:\n{input}",
+    )
+    app = ChainAgentsTuiApp(runtime=runtime, args=_args())
+
+    async with app.run_test() as pilot:
+        prompt = app.query_one("#prompt", Input)
+        prompt.value = "/summarize notes"
+        await pilot.press("enter")
+        await pilot.pause()
+
+    assert agent.payload == {
+        "messages": [{"role": "user", "content": "Summarize this:\nnotes"}]
+    }
+
+
+@pytest.mark.anyio
+async def test_tui_shows_filtered_slash_commands_while_typing() -> None:
+    runtime = _FakeRuntime(_FakeAgent([]))
+    runtime.commands["ask-researcher"] = SimpleNamespace(
+        name="ask-researcher",
+        description="Delegate to repo-researcher.",
+        target="subagent",
+        value="repo-researcher",
+        template="{input}",
+    )
+    runtime.commands["summarize"] = SimpleNamespace(
+        name="summarize",
+        description="Summarize input.",
+        target="prompt",
+        value="Summarize",
+        template="{input}",
+    )
+    app = ChainAgentsTuiApp(runtime=runtime, args=_args())
+
+    async with app.run_test():
+        prompt = app.query_one("#prompt", Input)
+        prompt.value = "/su"
+        app.refresh_command_help(prompt.value)
+
+        assert app.command_help_visible is True
+        assert app.visible_command_names == ["summarize"]
+        assert "/summarize - Summarize input." in app.command_help_text
+
+
+@pytest.mark.anyio
+async def test_tui_tab_completes_first_matching_slash_command() -> None:
+    runtime = _FakeRuntime(_FakeAgent([]))
+    runtime.commands["summarize"] = SimpleNamespace(
+        name="summarize",
+        description="Summarize input.",
+        target="prompt",
+        value="Summarize",
+        template="{input}",
+    )
+    app = ChainAgentsTuiApp(runtime=runtime, args=_args())
+
+    async with app.run_test() as pilot:
+        prompt = app.query_one("#prompt", Input)
+        prompt.value = "/su"
+        app.refresh_command_help(prompt.value)
+
+        await pilot.press("tab")
+
+        assert prompt.value == "/summarize "
+        assert app.command_help_visible is False
+
+
+@pytest.mark.anyio
+async def test_tui_ctrl_c_cancels_active_run() -> None:
+    agent = _BlockingAgent()
+    app = ChainAgentsTuiApp(runtime=_FakeRuntime(agent), args=_args())
+
+    async with app.run_test() as pilot:
+        prompt = app.query_one("#prompt", Input)
+        prompt.value = "wait"
+        await pilot.press("enter")
+        await agent.started.wait()
+
+        assert prompt.disabled is True
+
+        await app.action_cancel_or_quit()
+        await pilot.pause()
+
+        assert agent.cancelled is True
+        assert prompt.disabled is False
+        assert app.status_message == "Cancelled."

--- a/tests/test_chainagents_tui.py
+++ b/tests/test_chainagents_tui.py
@@ -4,14 +4,22 @@ from __future__ import annotations
 
 import asyncio
 import io
+import os
 from types import SimpleNamespace
 from typing import Any
 
 import pytest
-from textual.widgets import Input, RichLog
+from textual.containers import VerticalScroll
+from textual.widgets import Input, Markdown, RichLog
 
 import chainagents_cli
-from chainagents_tui import DEFAULT_TUI_THREAD_ID, ChainAgentsTuiApp
+from chainagents_tui import (
+    DEFAULT_TUI_THREAD_ID,
+    ChainAgentsTuiApp,
+    TUI_SIDE_PANEL_WIDTH,
+    capture_mcp_stdio_stderr,
+    run_tui,
+)
 
 
 class _Token:
@@ -141,11 +149,73 @@ class _FakeRuntime:
         return tuple(self.commands.values())
 
 
+@pytest.mark.anyio
+async def test_run_tui_leaves_app_stderr_visible(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+    capfd: pytest.CaptureFixture[str],
+) -> None:
+    runtime = _FakeRuntime(_FakeAgent([]))
+    runtime.project_root = tmp_path
+
+    async def fake_run_async(self):
+        os.write(2, b"Textual terminal output\n")
+        return 0
+
+    monkeypatch.setattr(ChainAgentsTuiApp, "run_async", fake_run_async)
+
+    code = await run_tui(runtime, _args())
+
+    assert code == 0
+    assert "Textual terminal output" in capfd.readouterr().err
+    log_path = tmp_path / ".files" / "tui-stderr.log"
+    assert not log_path.exists() or "Textual terminal output" not in log_path.read_text(
+        encoding="utf-8"
+    )
+
+
+def test_capture_mcp_stdio_stderr_routes_stdio_client_errlog(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from langchain_mcp_adapters import sessions
+
+    captured_errlog = None
+
+    def fake_stdio_client(server, errlog=None):
+        nonlocal captured_errlog
+        captured_errlog = errlog
+        errlog.write("Secure MCP Filesystem Server running on stdio\n")
+        errlog.flush()
+        return "stdio-context"
+
+    monkeypatch.setattr(sessions, "stdio_client", fake_stdio_client)
+    log_path = tmp_path / ".files" / "tui-stderr.log"
+
+    with capture_mcp_stdio_stderr(log_path):
+        assert sessions.stdio_client("server") == "stdio-context"
+
+    assert captured_errlog is not None
+    assert "Secure MCP Filesystem Server running on stdio" in log_path.read_text(
+        encoding="utf-8"
+    )
+
+
 def test_cli_parses_tui_flag() -> None:
     args = chainagents_cli.parse_args(["--tui"])
 
     assert args.tui is True
     assert args.thread_id is None
+
+
+def test_tui_title_is_chainagents() -> None:
+    app = ChainAgentsTuiApp(runtime=_FakeRuntime(_FakeAgent([])), args=_args())
+
+    assert app.title == "ChainAgents"
+
+
+def test_tui_side_panel_width_is_wide_enough() -> None:
+    assert TUI_SIDE_PANEL_WIDTH == 56
 
 
 @pytest.mark.anyio
@@ -189,7 +259,7 @@ async def test_tui_mounts_expected_panes_and_prompt() -> None:
 
     async with app.run_test():
         assert app.thread_id == DEFAULT_TUI_THREAD_ID
-        assert app.query_one("#conversation", RichLog)
+        assert app.query_one("#conversation", VerticalScroll)
         assert app.query_one("#reasoning", RichLog)
         assert app.query_one("#tools", RichLog)
         assert app.query_one("#prompt", Input)
@@ -217,6 +287,27 @@ async def test_tui_submits_prompt_and_streams_response() -> None:
         ("You", "hello"),
         ("Assistant", "Hello from agent"),
     ]
+
+
+@pytest.mark.anyio
+async def test_tui_renders_assistant_response_as_markdown_widget() -> None:
+    agent = _FakeAgent(
+        [
+            _raw_event(((), "messages", (_Token("## Heading\n\n"), {}))),
+            _raw_event(((), "messages", (_Token("- item"), {}))),
+        ]
+    )
+    app = ChainAgentsTuiApp(runtime=_FakeRuntime(agent), args=_args())
+
+    async with app.run_test() as pilot:
+        prompt = app.query_one("#prompt", Input)
+        prompt.value = "format this"
+        await pilot.press("enter")
+        await pilot.pause()
+
+        markdown = app.query_one("#conversation Markdown", Markdown)
+
+    assert markdown.source == "## Heading\n\n- item"
 
 
 @pytest.mark.anyio

--- a/uv.lock
+++ b/uv.lock
@@ -474,6 +474,7 @@ dependencies = [
     { name = "psycopg", extra = ["binary", "pool"] },
     { name = "pytest" },
     { name = "rich" },
+    { name = "textual" },
 ]
 
 [package.metadata]
@@ -491,6 +492,7 @@ requires-dist = [
     { name = "psycopg", extras = ["binary", "pool"], specifier = ">=3.2.0" },
     { name = "pytest", specifier = ">=8.3.0" },
     { name = "rich", specifier = ">=15.0.0" },
+    { name = "textual", specifier = ">=6.1.0" },
 ]
 
 [[package]]
@@ -1590,6 +1592,18 @@ wheels = [
 ]
 
 [[package]]
+name = "linkify-it-py"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "uc-micro-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2e/c9/06ea13676ef354f0af6169587ae292d3e2406e212876a413bf9eece4eb23/linkify_it_py-2.1.0.tar.gz", hash = "sha256:43360231720999c10e9328dc3691160e27a718e280673d444c38d7d3aaa3b98b", size = 29158, upload-time = "2026-03-01T07:48:47.683Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/de/88b3be5c31b22333b3ca2f6ff1de4e863d8fe45aaea7485f591970ec1d3e/linkify_it_py-2.1.0-py3-none-any.whl", hash = "sha256:0d252c1594ecba2ecedc444053db5d3a9b7ec1b0dd929c8f1d74dce89f86c05e", size = 19878, upload-time = "2026-03-01T07:48:46.098Z" },
+]
+
+[[package]]
 name = "literalai"
 version = "0.1.201"
 source = { registry = "https://pypi.org/simple" }
@@ -1612,6 +1626,11 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[package.optional-dependencies]
+linkify = [
+    { name = "linkify-it-py" },
 ]
 
 [[package]]
@@ -1712,6 +1731,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8b/eb/c0cfc62075dc6e1ec1c64d352ae09ac051d9334311ed226f1f425312848a/mcp-1.27.0.tar.gz", hash = "sha256:d3dc35a7eec0d458c1da4976a48f982097ddaab87e278c5511d5a4a56e852b83", size = 607509, upload-time = "2026-04-02T14:48:08.88Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9c/46/f6b4ad632c67ef35209a66127e4bddc95759649dd595f71f13fba11bdf9a/mcp-1.27.0-py3-none-any.whl", hash = "sha256:5ce1fa81614958e267b21fb2aa34e0aea8e2c6ede60d52aba45fd47246b4d741", size = 215967, upload-time = "2026-04-02T14:48:07.24Z" },
+]
+
+[[package]]
+name = "mdit-py-plugins"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d8/3d/e0e8d9d1cee04f758120915e2b2a3a07eb41f8cf4654b4734788a522bcd1/mdit_py_plugins-0.6.0.tar.gz", hash = "sha256:2436f14a7295837ac9228a36feeabda867c4abc488c8d019ad5c0bda88eee040", size = 56025, upload-time = "2026-05-07T12:20:42.295Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/d6/48f5b9e44e2e760855d7b489b1317cd7620e82dcb73197961e5cc1391348/mdit_py_plugins-0.6.0-py3-none-any.whl", hash = "sha256:f7e7a25d8b616fee99cb1e330da73451d11a8061baf39bb9663ab9ce0e005b90", size = 66655, upload-time = "2026-05-07T12:20:41.226Z" },
 ]
 
 [[package]]
@@ -2869,6 +2900,15 @@ wheels = [
 ]
 
 [[package]]
+name = "platformdirs"
+version = "4.9.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/4a/0883b8e3802965322523f0b200ecf33d31f10991d0401162f4b23c698b42/platformdirs-4.9.6.tar.gz", hash = "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a", size = 29400, upload-time = "2026-04-09T00:04:10.812Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl", hash = "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917", size = 21348, upload-time = "2026-04-09T00:04:09.463Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3804,6 +3844,23 @@ wheels = [
 ]
 
 [[package]]
+name = "textual"
+version = "8.2.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py", extra = ["linkify"] },
+    { name = "mdit-py-plugins" },
+    { name = "platformdirs" },
+    { name = "pygments" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/62/1e/1eedc5bac184d00aaa5f9a99095f7e266af3ec46fa926c1051be5d358da1/textual-8.2.5.tar.gz", hash = "sha256:6c894e65a879dadb4f6cf46ddcfedb0173ff7e0cb1fe605ff7b357a597bdbc90", size = 1851596, upload-time = "2026-04-30T08:02:58.956Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cd/01/c4555f9c8a692ff83d84930150540f743ce94c89234f9e9a15ff4baba3a8/textual-8.2.5-py3-none-any.whl", hash = "sha256:247d2aa2faf222749c321f88a736247f37ee2c023604079c7490bfacddfcd4b2", size = 727050, upload-time = "2026-04-30T08:03:01.421Z" },
+]
+
+[[package]]
 name = "tiktoken"
 version = "0.12.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4049,6 +4106,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/19/f5/cd531b2d15a671a40c0f66cf06bc3570a12cd56eef98960068ebbad1bf5a/tzdata-2026.1.tar.gz", hash = "sha256:67658a1903c75917309e753fdc349ac0efd8c27db7a0cb406a25be4840f87f98", size = 197639, upload-time = "2026-04-03T11:25:22.002Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b0/70/d460bd685a170790ec89317e9bd33047988e4bce507b831f5db771e142de/tzdata-2026.1-py2.py3-none-any.whl", hash = "sha256:4b1d2be7ac37ceafd7327b961aa3a54e467efbdb563a23655fbfe0d39cfc42a9", size = 348952, upload-time = "2026-04-03T11:25:20.313Z" },
+]
+
+[[package]]
+name = "uc-micro-py"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/67/9a363818028526e2d4579334460df777115bdec1bb77c08f9db88f6389f2/uc_micro_py-2.0.0.tar.gz", hash = "sha256:c53691e495c8db60e16ffc4861a35469b0ba0821fe409a8a7a0a71864d33a811", size = 6611, upload-time = "2026-03-01T06:31:27.526Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/73/d21edf5b204d1467e06500080a50f79d49ef2b997c79123a536d4a17d97c/uc_micro_py-2.0.0-py3-none-any.whl", hash = "sha256:3603a3859af53e5a39bc7677713c78ea6589ff188d70f4fee165db88e22b242c", size = 6383, upload-time = "2026-03-01T06:31:26.257Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add a full-screen Textual TUI launched with `chainagents --tui`
- Show the conversation in the main pane, reasoning and tool activity in the right sidebar, and the prompt at the bottom
- Add shared LangGraph stream normalization so CLI, Chainlit, and the TUI render the same events
- Support slash-command discovery and Tab completion in the TUI prompt
- Update docs, dependency metadata, and tests for the new UI path

## Testing
- Added unit tests for normalized stream events
- Added TUI interaction tests for prompt submission, reasoning/tool streaming, slash-command help, and completion
- Full test suite passed locally