### PR TITLE
Add Dockerized app and multi-user Chainlit auth

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,28 @@
+# Python-generated files
+__pycache__
+*.py[oc]
+build
+dist
+wheels
+*.egg-info
+ChainAgents.egg-info
+
+# Local environments and caches
+.venv
+.pytest_cache
+.ruff_cache
+.mypy_cache
+
+# Git and local agent state
+.git
+.github
+.codex
+AGENTS.md
+
+# Runtime state mounted as Docker volumes
+.files
+.rag
+
+# Local-only files
+.DS_Store
+mock_test.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    UV_COMPILE_BYTECODE=1 \
+    UV_LINK_MODE=copy \
+    PATH="/app/.venv/bin:${PATH}"
+
+WORKDIR /app
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends nodejs npm \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY pyproject.toml uv.lock README.md ./
+RUN uv sync --frozen --no-install-project
+
+COPY . .
+RUN uv sync --frozen
+
+EXPOSE 8000
+
+CMD ["uv", "run", "--frozen", "chainlit", "run", "main.py", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ export DEEPAGENT_RECURSION_LIMIT="200"
 # export DEEPAGENT_MODEL_API_KEY="optional-for-secured-openai-compatible-servers"
 export DEEPAGENT_CONFIG="deepagent.toml"
 export CHAINLIT_AUTH_SECRET="replace-with-a-long-random-string"
+export CHAINLIT_AUTH_USERS_FILE=".files/users.json"
 export CHAINLIT_AUTH_USERNAME="admin"
 export CHAINLIT_AUTH_PASSWORD="change-me"
 ```
@@ -55,27 +56,42 @@ export CHAINLIT_AUTH_PASSWORD="change-me"
 - it controls the maximum LangGraph steps for a single agent run
 - raise it when long tool-heavy Deep Agent runs hit `GraphRecursionError`
 
-`CHAINLIT_AUTH_SECRET`, `CHAINLIT_AUTH_USERNAME`, and `CHAINLIT_AUTH_PASSWORD` are optional:
+`CHAINLIT_AUTH_SECRET`, `CHAINLIT_AUTH_USERS_FILE`, `CHAINLIT_AUTH_USERNAME`, and `CHAINLIT_AUTH_PASSWORD` are optional:
 
-- when all three are set, the app enables Chainlit password authentication
+- when `CHAINLIT_AUTH_SECRET` and `CHAINLIT_AUTH_USERS_FILE` are set, the app enables multi-user Chainlit password authentication from the users file
+- the legacy `CHAINLIT_AUTH_USERNAME` and `CHAINLIT_AUTH_PASSWORD` pair is still supported for a single environment-defined user
 - together with `DATABASE_URL`, that unlocks the native Chainlit history bar and chat resume UI
 - when they are unset, the app stays unauthenticated and the history bar remains unavailable
 
-## Optional: Install Postgres
+## Run With Docker Compose
 
-You only need Postgres if you want durable LangGraph checkpoints and `/memories/`.
-If `DATABASE_URL` is unset, the app runs fully in memory for the current process.
-
-This repo includes a Compose file for a local Postgres instance:
+Build and run the Chainlit app container with Postgres:
 
 ```bash
-docker compose up -d postgres
+docker compose up --build app
 ```
 
-Point the app at that database:
+Open the UI at [http://localhost:8000](http://localhost:8000).
+
+`docker compose up app` also starts the `postgres` service, waits for its healthcheck, and points the app at `postgresql://chainagents:chainagents@postgres:5432/chainagents?sslmode=disable` unless you explicitly set `DATABASE_URL`.
+
+By default, the app container expects an Ollama-compatible model server on the host at `http://host.docker.internal:11434`; override the model settings with the same `DEEPAGENT_MODEL_*` variables described above:
 
 ```bash
-export DATABASE_URL="postgresql://chainagents:chainagents@127.0.0.1:5432/chainagents?sslmode=disable"
+DEEPAGENT_MODEL_BASE_URL="http://host.docker.internal:1234/v1" \
+DEEPAGENT_MODEL_PROVIDER="openai_compatible" \
+DEEPAGENT_MODEL_NAME="your-loaded-model-id" \
+docker compose up --build app
+```
+
+The app service stores Chainlit files and the local RAG index in Docker volumes named `chainagents-files` and `chainagents-rag`.
+
+## Optional: Run Without Postgres
+
+If you want in-memory-only state for a one-off run, set `DATABASE_URL` to an empty value and skip dependencies:
+
+```bash
+DATABASE_URL= docker compose up --build --no-deps app
 ```
 
 Optional verification:
@@ -86,7 +102,7 @@ docker compose exec postgres psql -U chainagents -d chainagents -c "select 1;"
 
 Notes:
 
-- The Compose file lives at [compose.yaml](compose.yaml) and creates a persistent `postgres-data` volume.
+- The Postgres container creates a persistent `postgres-data` volume.
 - If you already have Postgres installed locally, create an empty database and set `DATABASE_URL` to that instance instead.
 - No separate migration step is required for this app. On startup it calls the LangGraph Postgres store and checkpointer `setup()` routines automatically.
 
@@ -94,21 +110,37 @@ Notes:
 
 Chainlit only shows its built-in history sidebar when both persistence and authentication are enabled.
 
-This app includes a simple password-based auth callback driven by environment variables:
+This app includes password-based auth for one or more local users. User records are stored as salted password hashes in a JSON file.
 
 ```bash
 export CHAINLIT_AUTH_SECRET="replace-with-a-long-random-string"
-export CHAINLIT_AUTH_USERNAME="admin"
-export CHAINLIT_AUTH_PASSWORD="change-me"
+export CHAINLIT_AUTH_USERS_FILE=".files/users.json"
+printf "change-me-now\n" | uv run chainagents users add admin --password-stdin
 ```
 
-With both `DATABASE_URL` and the `CHAINLIT_AUTH_*` variables set:
+Manage users with the CLI:
+
+```bash
+uv run chainagents users list
+printf "new-password\n" | uv run chainagents users add alice --display-name "Alice" --password-stdin
+uv run chainagents users remove alice
+```
+
+For Docker Compose, the default users file is `/app/.files/users.json`, stored in the `chainagents-files` volume:
+
+```bash
+export CHAINLIT_AUTH_SECRET="replace-with-a-long-random-string"
+printf "change-me-now\n" | docker compose run --rm --no-deps app chainagents users add admin --password-stdin
+docker compose up --build app
+```
+
+With both `DATABASE_URL` and Chainlit auth configured:
 
 - users can sign in through Chainlit's native auth screen
 - the history sidebar can list and reopen prior chats
 - resumed chats default the LangGraph thread ID to the persisted Chainlit thread ID for that conversation
 
-If you leave auth disabled, Chainlit can still persist thread records in Postgres, but the native history bar will stay hidden.
+If you prefer the old single-user environment setup, set `CHAINLIT_AUTH_USERNAME` and `CHAINLIT_AUTH_PASSWORD` along with `CHAINLIT_AUTH_SECRET`. If you leave auth disabled, Chainlit can still persist thread records in Postgres, but the native history bar will stay hidden.
 
 ## Setup
 
@@ -590,7 +622,7 @@ See [deepagent.toml.example](deepagent.toml.example) for a complete example.
 
 ## Notes
 
-- Native Chainlit history is available when both `DATABASE_URL` and the `CHAINLIT_AUTH_*` variables are configured.
+- Native Chainlit history is available when `DATABASE_URL`, `CHAINLIT_AUTH_SECRET`, and either `CHAINLIT_AUTH_USERS_FILE` or the legacy `CHAINLIT_AUTH_USERNAME` / `CHAINLIT_AUTH_PASSWORD` pair are configured.
 - If `DATABASE_URL` is set but authentication is not configured, Chainlit still persists thread records, but they are not browseable from the UI.
 - When `DATABASE_URL` is unset, thread IDs only persist while the process stays alive.
 - When `DATABASE_URL` is set, durable state is available through LangGraph thread IDs. You can reuse a thread ID from the chat settings panel to continue the same checkpointed thread.

--- a/chainagents_cli.py
+++ b/chainagents_cli.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import base64
+import getpass
 import json
 import mimetypes
 import sys
@@ -26,6 +27,14 @@ from agent_commands import (
     parse_native_command,
     resolve_native_command,
     resolve_runtime_command,
+)
+from chainlit_users import (
+    CHAINLIT_AUTH_USERS_FILE_ENV,
+    UserStoreError,
+    add_user,
+    list_users,
+    remove_user,
+    resolve_users_file,
 )
 from deepagent_runtime import (
     AgentRuntime,
@@ -191,6 +200,201 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         The parsed args.
     """
     return build_parser().parse_args(argv)
+
+
+def build_users_parser() -> argparse.ArgumentParser:
+    """Build the Chainlit user management parser.
+
+    Returns:
+        The constructed parser.
+    """
+    parser = argparse.ArgumentParser(
+        prog="chainagents users",
+        description="Manage local Chainlit password users.",
+    )
+    parser.add_argument(
+        "--file",
+        dest="users_file",
+        help=(
+            "Path to users.json. Defaults to "
+            f"${CHAINLIT_AUTH_USERS_FILE_ENV} or .files/users.json."
+        ),
+    )
+    parser.add_argument(
+        "--json",
+        dest="json_output",
+        action="store_true",
+        help="Print machine-readable JSON output.",
+    )
+    subparsers = parser.add_subparsers(dest="users_command", required=True)
+
+    add_parser = subparsers.add_parser("add", help="Add a Chainlit user.")
+    add_parser.add_argument("username")
+    add_parser.add_argument("--display-name", help="Display name shown in Chainlit.")
+    add_parser.add_argument("--password", help="Password to store as a salted hash.")
+    add_parser.add_argument(
+        "--password-stdin",
+        action="store_true",
+        help="Read the password from stdin.",
+    )
+    add_parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Replace the user if it already exists.",
+    )
+    add_parser.add_argument(
+        "--json",
+        dest="json_output",
+        action="store_true",
+        default=argparse.SUPPRESS,
+        help="Print machine-readable JSON output.",
+    )
+
+    remove_parser = subparsers.add_parser("remove", help="Remove a Chainlit user.")
+    remove_parser.add_argument("username")
+    remove_parser.add_argument(
+        "--json",
+        dest="json_output",
+        action="store_true",
+        default=argparse.SUPPRESS,
+        help="Print machine-readable JSON output.",
+    )
+
+    list_parser = subparsers.add_parser("list", help="List Chainlit users.")
+    list_parser.add_argument(
+        "--json",
+        dest="json_output",
+        action="store_true",
+        default=argparse.SUPPRESS,
+        help="Print machine-readable JSON output.",
+    )
+    return parser
+
+
+def password_from_user_args(
+    args: argparse.Namespace,
+    *,
+    stdin: TextIO,
+    stderr: TextIO,
+) -> str | None:
+    """Resolve the password supplied to a user-management command.
+
+    Args:
+        args: Parsed user-management arguments.
+        stdin: The stdin value.
+        stderr: The stderr value.
+
+    Returns:
+        The resolved password, if one was supplied.
+    """
+    if args.password and args.password_stdin:
+        print("users add: use only one of --password or --password-stdin.", file=stderr)
+        return None
+    if args.password_stdin:
+        return stdin.read().rstrip("\r\n")
+    if args.password:
+        return args.password
+    return getpass.getpass("Password: ")
+
+
+def run_users_cli(
+    argv: list[str],
+    *,
+    stdout: TextIO,
+    stderr: TextIO,
+    stdin: TextIO,
+) -> int:
+    """Run the Chainlit user management CLI.
+
+    Args:
+        argv: User command argv, excluding the leading "users".
+        stdout: The stdout value.
+        stderr: The stderr value.
+        stdin: The stdin value.
+
+    Returns:
+        A process-style status code.
+    """
+    parser = build_users_parser()
+    try:
+        args = parser.parse_args(argv)
+    except SystemExit as exc:
+        return int(exc.code)
+
+    users_file = resolve_users_file(args.users_file)
+    try:
+        if args.users_command == "add":
+            password = password_from_user_args(args, stdin=stdin, stderr=stderr)
+            if password is None:
+                return 2
+            user = add_user(
+                users_file,
+                username=args.username,
+                password=password,
+                display_name=args.display_name,
+                overwrite=args.overwrite,
+            )
+            payload = {
+                "user": {
+                    "username": user.username,
+                    "display_name": user.display_name,
+                },
+                "users_file": str(users_file),
+            }
+            if args.json_output:
+                print(json.dumps(payload, indent=2, sort_keys=True), file=stdout)
+            else:
+                print(f"Added user {user.username} to {users_file}", file=stdout)
+            return 0
+        if args.users_command == "remove":
+            removed = remove_user(users_file, args.username)
+            if not removed:
+                print(f"User {args.username} does not exist in {users_file}", file=stderr)
+                return 1
+            if args.json_output:
+                print(
+                    json.dumps(
+                        {
+                            "removed": args.username,
+                            "users_file": str(users_file),
+                        },
+                        indent=2,
+                        sort_keys=True,
+                    ),
+                    file=stdout,
+                )
+            else:
+                print(f"Removed user {args.username} from {users_file}", file=stdout)
+            return 0
+        if args.users_command == "list":
+            users = [
+                {"display_name": user.display_name, "username": user.username}
+                for user in list_users(users_file)
+            ]
+            if args.json_output:
+                print(json.dumps({"users": users}, indent=2, sort_keys=True), file=stdout)
+            else:
+                table = Table(
+                    box=CLI_TABLE_BOX,
+                    border_style="bright_black",
+                    header_style="bold cyan",
+                )
+                table.add_column("Username", style="bold bright_white")
+                table.add_column("Display Name", style="white")
+                for user in users:
+                    table.add_row(user["username"], user["display_name"])
+                cli_console(stdout).print(
+                    cli_panel(
+                        table,
+                        title=f"Chainlit Users ({len(users)})",
+                        border_style="cyan",
+                    )
+                )
+            return 0
+    except UserStoreError as exc:
+        print(f"users: {exc}", file=stderr)
+        return 1
+    return 2
 
 
 def runtime_overrides_from_args(args: argparse.Namespace) -> RuntimeConfigOverrides:
@@ -1520,6 +1724,15 @@ def main(argv: list[str] | None = None) -> int:
     Returns:
         The main result.
     """
+    if argv is None:
+        argv = sys.argv[1:]
+    if argv and argv[0] == "users":
+        return run_users_cli(
+            argv[1:],
+            stdout=sys.stdout,
+            stderr=sys.stderr,
+            stdin=sys.stdin,
+        )
     return asyncio.run(async_main(argv))
 
 

--- a/chainlit_users.py
+++ b/chainlit_users.py
@@ -1,0 +1,302 @@
+"""Manage Chainlit password users for local ChainAgents deployments."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import os
+import re
+import secrets
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+CHAINLIT_AUTH_USERS_FILE_ENV = "CHAINLIT_AUTH_USERS_FILE"
+DEFAULT_USERS_FILE = Path(".files/users.json")
+HASH_ALGORITHM = "pbkdf2_sha256"
+HASH_ITERATIONS = 600_000
+STORE_VERSION = 1
+USERNAME_PATTERN = re.compile(r"^[A-Za-z0-9_.@-]{1,128}$")
+
+
+class UserStoreError(ValueError):
+    """Raised when the Chainlit users file cannot be used safely."""
+
+
+@dataclass(frozen=True)
+class ChainlitUserRecord:
+    """Represent one configured Chainlit password user."""
+
+    username: str
+    display_name: str
+
+
+def resolve_users_file(path: str | os.PathLike[str] | None = None) -> Path:
+    """Resolve a Chainlit auth users file path.
+
+    Args:
+        path: Explicit path value.
+
+    Returns:
+        The resolved user file path.
+    """
+    raw_path = str(path or os.getenv(CHAINLIT_AUTH_USERS_FILE_ENV) or DEFAULT_USERS_FILE)
+    return Path(raw_path).expanduser().resolve()
+
+
+def normalize_username(username: str) -> str:
+    """Normalize and validate a user name.
+
+    Args:
+        username: Raw username.
+
+    Returns:
+        The normalized username.
+
+    Raises:
+        UserStoreError: If the username is unsupported.
+    """
+    candidate = username.strip()
+    if not candidate:
+        raise UserStoreError("Username cannot be empty.")
+    if not USERNAME_PATTERN.fullmatch(candidate):
+        raise UserStoreError(
+            "Username must use only letters, numbers, dot, underscore, at sign, or dash."
+        )
+    return candidate
+
+
+def validate_password(password: str) -> str:
+    """Validate a password supplied for a local Chainlit user.
+
+    Args:
+        password: Raw password.
+
+    Returns:
+        The password.
+
+    Raises:
+        UserStoreError: If the password is unsupported.
+    """
+    if len(password) < 8:
+        raise UserStoreError("Password must be at least 8 characters.")
+    return password
+
+
+def hash_password(password: str) -> str:
+    """Return a salted password hash.
+
+    Args:
+        password: Plain-text password.
+
+    Returns:
+        Encoded password hash.
+    """
+    validate_password(password)
+    salt = secrets.token_bytes(16)
+    digest = hashlib.pbkdf2_hmac(
+        "sha256",
+        password.encode("utf-8"),
+        salt,
+        HASH_ITERATIONS,
+    )
+    encoded_salt = base64.urlsafe_b64encode(salt).decode("ascii")
+    encoded_digest = base64.urlsafe_b64encode(digest).decode("ascii")
+    return f"{HASH_ALGORITHM}${HASH_ITERATIONS}${encoded_salt}${encoded_digest}"
+
+
+def verify_password(password: str, password_hash: str) -> bool:
+    """Return whether a plain-text password matches an encoded hash.
+
+    Args:
+        password: Plain-text password.
+        password_hash: Encoded password hash.
+
+    Returns:
+        Whether the password matches.
+    """
+    parts = password_hash.split("$")
+    if len(parts) != 4:
+        return False
+    algorithm, raw_iterations, encoded_salt, encoded_digest = parts
+    if algorithm != HASH_ALGORITHM:
+        return False
+    try:
+        iterations = int(raw_iterations)
+        salt = base64.urlsafe_b64decode(encoded_salt.encode("ascii"))
+        expected = base64.urlsafe_b64decode(encoded_digest.encode("ascii"))
+    except (TypeError, ValueError):
+        return False
+    actual = hashlib.pbkdf2_hmac(
+        "sha256",
+        password.encode("utf-8"),
+        salt,
+        iterations,
+    )
+    return secrets.compare_digest(actual, expected)
+
+
+def load_user_store(path: str | os.PathLike[str] | Path) -> dict[str, Any]:
+    """Load a Chainlit user store.
+
+    Args:
+        path: User store path.
+
+    Returns:
+        The loaded store payload.
+
+    Raises:
+        UserStoreError: If the store cannot be parsed.
+    """
+    users_file = Path(path)
+    if not users_file.exists():
+        return {"version": STORE_VERSION, "users": {}}
+    try:
+        payload = json.loads(users_file.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise UserStoreError(f"Invalid users file JSON: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise UserStoreError("Users file must contain a JSON object.")
+    users = payload.get("users")
+    if not isinstance(users, dict):
+        raise UserStoreError("Users file must contain a 'users' object.")
+    return {"version": payload.get("version", STORE_VERSION), "users": users}
+
+
+def save_user_store(path: str | os.PathLike[str] | Path, payload: dict[str, Any]) -> None:
+    """Write a Chainlit user store atomically.
+
+    Args:
+        path: User store path.
+        payload: Store payload.
+    """
+    users_file = Path(path)
+    users_file.parent.mkdir(parents=True, exist_ok=True)
+    body = json.dumps(payload, indent=2, sort_keys=True)
+    tmp_path = users_file.with_name(f".{users_file.name}.{os.getpid()}.tmp")
+    tmp_path.write_text(f"{body}\n", encoding="utf-8")
+    os.chmod(tmp_path, 0o600)
+    os.replace(tmp_path, users_file)
+    os.chmod(users_file, 0o600)
+
+
+def _record_from_store(username: str, value: Any) -> ChainlitUserRecord | None:
+    if not isinstance(value, dict):
+        return None
+    display_name = str(value.get("display_name") or username).strip() or username
+    return ChainlitUserRecord(username=username, display_name=display_name)
+
+
+def list_users(path: str | os.PathLike[str] | Path) -> list[ChainlitUserRecord]:
+    """List configured Chainlit users.
+
+    Args:
+        path: User store path.
+
+    Returns:
+        User records sorted by username.
+    """
+    payload = load_user_store(path)
+    users = payload["users"]
+    records = [
+        record
+        for username, value in sorted(users.items())
+        if (record := _record_from_store(str(username), value)) is not None
+    ]
+    return records
+
+
+def add_user(
+    path: str | os.PathLike[str] | Path,
+    *,
+    username: str,
+    password: str,
+    display_name: str | None = None,
+    overwrite: bool = False,
+) -> ChainlitUserRecord:
+    """Add or replace a Chainlit password user.
+
+    Args:
+        path: User store path.
+        username: Username to add.
+        password: Plain-text password to hash.
+        display_name: Optional display name.
+        overwrite: Whether to replace an existing user.
+
+    Returns:
+        The added user record.
+
+    Raises:
+        UserStoreError: If the user already exists or data is invalid.
+    """
+    normalized_username = normalize_username(username)
+    normalized_display_name = (display_name or normalized_username).strip()
+    if not normalized_display_name:
+        normalized_display_name = normalized_username
+    payload = load_user_store(path)
+    users = payload["users"]
+    if normalized_username in users and not overwrite:
+        raise UserStoreError(f"User '{normalized_username}' already exists.")
+    record = {
+        "display_name": normalized_display_name,
+        "password_hash": hash_password(password),
+    }
+    users[normalized_username] = record
+    payload["version"] = STORE_VERSION
+    save_user_store(path, payload)
+    return ChainlitUserRecord(
+        username=normalized_username,
+        display_name=normalized_display_name,
+    )
+
+
+def remove_user(path: str | os.PathLike[str] | Path, username: str) -> bool:
+    """Remove a Chainlit password user.
+
+    Args:
+        path: User store path.
+        username: Username to remove.
+
+    Returns:
+        Whether a user was removed.
+    """
+    normalized_username = normalize_username(username)
+    payload = load_user_store(path)
+    users = payload["users"]
+    if normalized_username not in users:
+        return False
+    del users[normalized_username]
+    payload["version"] = STORE_VERSION
+    save_user_store(path, payload)
+    return True
+
+
+def authenticate_user(
+    path: str | os.PathLike[str] | Path,
+    username: str,
+    password: str,
+) -> ChainlitUserRecord | None:
+    """Authenticate a user against a Chainlit users file.
+
+    Args:
+        path: User store path.
+        username: Username to authenticate.
+        password: Plain-text password.
+
+    Returns:
+        The authenticated record, if credentials are valid.
+    """
+    try:
+        normalized_username = normalize_username(username)
+        payload = load_user_store(path)
+    except UserStoreError:
+        return None
+    value = payload["users"].get(normalized_username)
+    if not isinstance(value, dict):
+        return None
+    password_hash = str(value.get("password_hash") or "")
+    if not password_hash or not verify_password(password, password_hash):
+        return None
+    return _record_from_store(normalized_username, value)

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,4 +1,37 @@
 services:
+  app:
+    build:
+      context: .
+    image: chainagents:local
+    container_name: chainagents-app
+    restart: unless-stopped
+    ports:
+      - "${CHAINAGENTS_PORT:-8000}:8000"
+    environment:
+      DEEPAGENT_CONFIG: ${DEEPAGENT_CONFIG:-deepagent.toml}
+      DEEPAGENT_MODEL_PROVIDER: ${DEEPAGENT_MODEL_PROVIDER:-ollama}
+      DEEPAGENT_MODEL_BASE_URL: ${DEEPAGENT_MODEL_BASE_URL:-http://host.docker.internal:11434}
+      DEEPAGENT_MODEL_ENDPOINT_URL: ${DEEPAGENT_MODEL_ENDPOINT_URL:-}
+      DEEPAGENT_MODEL_NAME: ${DEEPAGENT_MODEL_NAME:-gemma4:26b}
+      DEEPAGENT_MODEL_API_KEY: ${DEEPAGENT_MODEL_API_KEY:-}
+      DEEPAGENT_MODEL_REASONING: ${DEEPAGENT_MODEL_REASONING:-medium}
+      DEEPAGENT_RECURSION_LIMIT: ${DEEPAGENT_RECURSION_LIMIT:-200}
+      DATABASE_URL: ${DATABASE_URL-postgresql://chainagents:chainagents@postgres:5432/chainagents?sslmode=disable}
+      CHAINLIT_AUTH_SECRET: ${CHAINLIT_AUTH_SECRET:-}
+      CHAINLIT_AUTH_USERNAME: ${CHAINLIT_AUTH_USERNAME:-}
+      CHAINLIT_AUTH_PASSWORD: ${CHAINLIT_AUTH_PASSWORD:-}
+      CHAINLIT_AUTH_USERS_FILE: ${CHAINLIT_AUTH_USERS_FILE:-/app/.files/users.json}
+      CHAINLIT_ASYNC_SUBAGENT_URL: ${CHAINLIT_ASYNC_SUBAGENT_URL:-}
+      CHAINLIT_ASYNC_TASK_POLL_SECONDS: ${CHAINLIT_ASYNC_TASK_POLL_SECONDS:-}
+    volumes:
+      - chainagents-files:/app/.files
+      - chainagents-rag:/app/.rag
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    depends_on:
+      postgres:
+        condition: service_healthy
+
   postgres:
     image: postgres:17
     container_name: chainagents-postgres
@@ -18,4 +51,6 @@ services:
       retries: 10
 
 volumes:
+  chainagents-files:
+  chainagents-rag:
   postgres-data:

--- a/main.py
+++ b/main.py
@@ -24,6 +24,11 @@ from agent_commands import (
 )
 from async_task_notifications import AsyncTaskNotifier, async_subagent_url_override
 from chainlit_bridge import ChainlitEventBridge, RunTaskList
+from chainlit_users import (
+    CHAINLIT_AUTH_USERS_FILE_ENV,
+    authenticate_user,
+    resolve_users_file,
+)
 from deepagent_runtime import (
     DEFAULT_REASONING_LEVEL,
     AgentRuntime,
@@ -79,7 +84,8 @@ RAG_UPLOAD_ACCEPT = {
 AUTH_USERNAME = os.getenv("CHAINLIT_AUTH_USERNAME", "").strip()
 AUTH_PASSWORD = os.getenv("CHAINLIT_AUTH_PASSWORD", "").strip()
 AUTH_SECRET = os.getenv("CHAINLIT_AUTH_SECRET", "").strip()
-AUTH_ENABLED = bool(AUTH_SECRET and AUTH_USERNAME and AUTH_PASSWORD)
+AUTH_USERS_FILE = os.getenv(CHAINLIT_AUTH_USERS_FILE_ENV, "").strip()
+AUTH_ENABLED = bool(AUTH_SECRET and ((AUTH_USERNAME and AUTH_PASSWORD) or AUTH_USERS_FILE))
 
 
 def current_chainlit_thread_id() -> str:
@@ -692,6 +698,56 @@ def resolve_model_name_for_message(
     )
 
 
+def auth_enabled_from_env() -> bool:
+    """Return whether Chainlit password auth is configured.
+
+    Returns:
+        Whether password auth should be enabled.
+    """
+    auth_secret = os.getenv("CHAINLIT_AUTH_SECRET", "").strip()
+    auth_username = os.getenv("CHAINLIT_AUTH_USERNAME", "").strip()
+    auth_password = os.getenv("CHAINLIT_AUTH_PASSWORD", "").strip()
+    auth_users_file = os.getenv(CHAINLIT_AUTH_USERS_FILE_ENV, "").strip()
+    return bool(auth_secret and ((auth_username and auth_password) or auth_users_file))
+
+
+def authenticate_configured_user(username: str, password: str) -> cl.User | None:
+    """Authenticate a Chainlit password user from configured credentials.
+
+    Args:
+        username: Username supplied by Chainlit.
+        password: Password supplied by Chainlit.
+
+    Returns:
+        The authenticated Chainlit user, if credentials are valid.
+    """
+    if not auth_enabled_from_env():
+        return None
+
+    users_file = os.getenv(CHAINLIT_AUTH_USERS_FILE_ENV, "").strip()
+    if users_file:
+        record = authenticate_user(resolve_users_file(users_file), username, password)
+        if record is not None:
+            return cl.User(
+                identifier=record.username,
+                display_name=record.display_name,
+                metadata={"provider": "credentials", "source": "users_file"},
+            )
+
+    auth_username = os.getenv("CHAINLIT_AUTH_USERNAME", "").strip()
+    auth_password = os.getenv("CHAINLIT_AUTH_PASSWORD", "").strip()
+    if auth_username and auth_password and (
+        secrets.compare_digest(username, auth_username)
+        and secrets.compare_digest(password, auth_password)
+    ):
+        return cl.User(
+            identifier=auth_username,
+            display_name=auth_username,
+            metadata={"provider": "credentials", "source": "env"},
+        )
+    return None
+
+
 if AUTH_ENABLED:
 
     @cl.password_auth_callback
@@ -705,17 +761,7 @@ if AUTH_ENABLED:
         Returns:
             The password auth callback result.
         """
-        if not (
-            secrets.compare_digest(username, AUTH_USERNAME)
-            and secrets.compare_digest(password, AUTH_PASSWORD)
-        ):
-            return None
-
-        return cl.User(
-            identifier=AUTH_USERNAME,
-            display_name=AUTH_USERNAME,
-            metadata={"provider": "credentials"},
-        )
+        return authenticate_configured_user(username, password)
 
 
 async def get_runtime_or_notify() -> AgentRuntime | None:
@@ -819,7 +865,7 @@ async def on_chat_start() -> None:
     history_line = (
         "- History bar: enabled for authenticated users\n"
         if runtime.persistence_enabled and AUTH_ENABLED
-        else "- History bar: disabled; set `DATABASE_URL`, `CHAINLIT_AUTH_SECRET`, `CHAINLIT_AUTH_USERNAME`, and `CHAINLIT_AUTH_PASSWORD` to enable native Chainlit history\n"
+        else "- History bar: disabled; set `DATABASE_URL`, `CHAINLIT_AUTH_SECRET`, and `CHAINLIT_AUTH_USERS_FILE` to enable native Chainlit history\n"
     )
     extensions = runtime.config.extensions
     configured_command_count = len(extensions.chainlit_commands)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ py-modules = [
     "async_task_notifications",
     "chainagents_cli",
     "chainagents_tui",
+    "chainlit_users",
     "chainlit_bridge",
     "deepagent_runtime",
     "langgraph_app",

--- a/tests/test_chainlit_users.py
+++ b/tests/test_chainlit_users.py
@@ -1,0 +1,257 @@
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+
+import pytest
+
+import chainagents_cli
+import main
+from chainlit_users import (
+    UserStoreError,
+    add_user,
+    authenticate_user,
+    list_users,
+    remove_user,
+    resolve_users_file,
+)
+
+
+def test_user_store_add_authenticate_list_and_remove_user(tmp_path: Path) -> None:
+    users_file = tmp_path / "users.json"
+
+    added = add_user(
+        users_file,
+        username="alice",
+        password="correct horse battery staple",
+        display_name="Alice Example",
+    )
+
+    assert added.username == "alice"
+    assert added.display_name == "Alice Example"
+    assert list_users(users_file) == [added]
+
+    raw_store = json.loads(users_file.read_text())
+    assert "correct horse battery staple" not in users_file.read_text()
+    assert raw_store["users"]["alice"]["password_hash"].startswith("pbkdf2_sha256$")
+
+    assert authenticate_user(users_file, "alice", "wrong password") is None
+    authenticated = authenticate_user(
+        users_file,
+        "alice",
+        "correct horse battery staple",
+    )
+
+    assert authenticated == added
+
+    assert remove_user(users_file, "alice") is True
+    assert list_users(users_file) == []
+    assert authenticate_user(users_file, "alice", "correct horse battery staple") is None
+
+
+def test_user_store_rejects_duplicate_user_without_overwrite(tmp_path: Path) -> None:
+    users_file = tmp_path / "users.json"
+    add_user(users_file, username="alice", password="first password")
+
+    with pytest.raises(UserStoreError, match="already exists"):
+        add_user(users_file, username="alice", password="second password")
+
+
+def test_user_store_can_overwrite_existing_user(tmp_path: Path) -> None:
+    users_file = tmp_path / "users.json"
+    add_user(users_file, username="alice", password="first password")
+
+    add_user(
+        users_file,
+        username="alice",
+        password="second password",
+        display_name="Alice Updated",
+        overwrite=True,
+    )
+
+    assert authenticate_user(users_file, "alice", "first password") is None
+    authenticated = authenticate_user(users_file, "alice", "second password")
+    assert authenticated is not None
+    assert authenticated.display_name == "Alice Updated"
+
+
+def test_resolve_users_file_prefers_explicit_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("CHAINLIT_AUTH_USERS_FILE", str(tmp_path / "env.json"))
+
+    assert resolve_users_file(str(tmp_path / "explicit.json")) == tmp_path / "explicit.json"
+
+
+def test_resolve_users_file_uses_env_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("CHAINLIT_AUTH_USERS_FILE", str(tmp_path / "env.json"))
+
+    assert resolve_users_file(None) == tmp_path / "env.json"
+
+
+def test_cli_users_add_list_and_remove(tmp_path: Path) -> None:
+    users_file = tmp_path / "users.json"
+
+    add_code = chainagents_cli.run_users_cli(
+        [
+            "--file",
+            str(users_file),
+            "add",
+            "alice",
+            "--display-name",
+            "Alice Example",
+            "--password",
+            "correct horse battery staple",
+        ],
+        stdout=io.StringIO(),
+        stderr=io.StringIO(),
+        stdin=io.StringIO(""),
+    )
+
+    list_stdout = io.StringIO()
+    list_code = chainagents_cli.run_users_cli(
+        ["--file", str(users_file), "list", "--json"],
+        stdout=list_stdout,
+        stderr=io.StringIO(),
+        stdin=io.StringIO(""),
+    )
+
+    remove_code = chainagents_cli.run_users_cli(
+        ["--file", str(users_file), "remove", "alice"],
+        stdout=io.StringIO(),
+        stderr=io.StringIO(),
+        stdin=io.StringIO(""),
+    )
+
+    assert add_code == 0
+    assert list_code == 0
+    assert remove_code == 0
+    assert json.loads(list_stdout.getvalue()) == {
+        "users": [{"display_name": "Alice Example", "username": "alice"}]
+    }
+    assert list_users(users_file) == []
+
+
+def test_cli_users_json_flag_works_before_or_after_subcommand(tmp_path: Path) -> None:
+    users_file = tmp_path / "users.json"
+    add_user(users_file, username="alice", password="correct horse battery staple")
+
+    before_stdout = io.StringIO()
+    after_stdout = io.StringIO()
+
+    before_code = chainagents_cli.run_users_cli(
+        ["--file", str(users_file), "--json", "list"],
+        stdout=before_stdout,
+        stderr=io.StringIO(),
+        stdin=io.StringIO(""),
+    )
+    after_code = chainagents_cli.run_users_cli(
+        ["--file", str(users_file), "list", "--json"],
+        stdout=after_stdout,
+        stderr=io.StringIO(),
+        stdin=io.StringIO(""),
+    )
+
+    assert before_code == 0
+    assert after_code == 0
+    assert json.loads(before_stdout.getvalue()) == json.loads(after_stdout.getvalue())
+
+
+def test_cli_users_add_reads_password_from_stdin(tmp_path: Path) -> None:
+    users_file = tmp_path / "users.json"
+
+    code = chainagents_cli.run_users_cli(
+        [
+            "--file",
+            str(users_file),
+            "add",
+            "alice",
+            "--password-stdin",
+        ],
+        stdout=io.StringIO(),
+        stderr=io.StringIO(),
+        stdin=io.StringIO("correct horse battery staple\n"),
+    )
+
+    assert code == 0
+    assert authenticate_user(users_file, "alice", "correct horse battery staple") is not None
+
+
+def test_main_routes_users_command_before_runtime_startup(tmp_path: Path) -> None:
+    users_file = tmp_path / "users.json"
+
+    code = chainagents_cli.main(
+        [
+            "users",
+            "--file",
+            str(users_file),
+            "add",
+            "alice",
+            "--password",
+            "correct horse battery staple",
+        ]
+    )
+
+    assert code == 0
+    assert authenticate_user(users_file, "alice", "correct horse battery staple") is not None
+
+
+def test_main_authenticates_users_from_configured_user_store(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    users_file = tmp_path / "users.json"
+    add_user(
+        users_file,
+        username="alice",
+        password="correct horse battery staple",
+        display_name="Alice Example",
+    )
+    monkeypatch.setenv("CHAINLIT_AUTH_SECRET", "secret")
+    monkeypatch.setenv("CHAINLIT_AUTH_USERS_FILE", str(users_file))
+    monkeypatch.delenv("CHAINLIT_AUTH_USERNAME", raising=False)
+    monkeypatch.delenv("CHAINLIT_AUTH_PASSWORD", raising=False)
+
+    user = main.authenticate_configured_user(
+        "alice",
+        "correct horse battery staple",
+    )
+
+    assert user is not None
+    assert user.identifier == "alice"
+    assert user.display_name == "Alice Example"
+    assert user.metadata == {"provider": "credentials", "source": "users_file"}
+
+
+def test_main_preserves_legacy_single_user_auth(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CHAINLIT_AUTH_SECRET", "secret")
+    monkeypatch.setenv("CHAINLIT_AUTH_USERNAME", "admin")
+    monkeypatch.setenv("CHAINLIT_AUTH_PASSWORD", "change-me")
+    monkeypatch.delenv("CHAINLIT_AUTH_USERS_FILE", raising=False)
+
+    user = main.authenticate_configured_user("admin", "change-me")
+
+    assert user is not None
+    assert user.identifier == "admin"
+    assert user.metadata == {"provider": "credentials", "source": "env"}
+
+
+def test_main_authentication_is_disabled_without_secret(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    users_file = tmp_path / "users.json"
+    add_user(users_file, username="alice", password="correct horse battery staple")
+    monkeypatch.delenv("CHAINLIT_AUTH_SECRET", raising=False)
+    monkeypatch.setenv("CHAINLIT_AUTH_USERS_FILE", str(users_file))
+
+    assert main.auth_enabled_from_env() is False
+    assert main.authenticate_configured_user(
+        "alice",
+        "correct horse battery staple",
+    ) is None

--- a/tests/test_docker_deployment.py
+++ b/tests/test_docker_deployment.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _read(path: str) -> str:
+    return (PROJECT_ROOT / path).read_text()
+
+
+def _block_after(text: str, header: str, *, indent: int) -> str:
+    target = f"{' ' * indent}{header}:"
+    lines = text.splitlines()
+    for index, line in enumerate(lines):
+        if line == target or line.startswith(f"{target} "):
+            block: list[str] = []
+            for child in lines[index + 1 :]:
+                stripped = child.strip()
+                child_indent = len(child) - len(child.lstrip(" "))
+                if stripped and child_indent <= indent:
+                    break
+                block.append(child)
+            return "\n".join(block)
+    return ""
+
+
+def test_compose_defines_default_chainagents_app_service() -> None:
+    compose = _read("compose.yaml")
+
+    app = _block_after(compose, "app", indent=2)
+
+    assert app
+    assert "build:" in app
+    assert "context: ." in app
+    assert '"${CHAINAGENTS_PORT:-8000}:8000"' in app
+    assert "DEEPAGENT_MODEL_BASE_URL: ${DEEPAGENT_MODEL_BASE_URL:-http://host.docker.internal:11434}" in app
+    assert "DATABASE_URL: ${DATABASE_URL-postgresql://chainagents:chainagents@postgres:5432/chainagents?sslmode=disable}" in app
+    assert "CHAINLIT_AUTH_USERS_FILE: ${CHAINLIT_AUTH_USERS_FILE:-/app/.files/users.json}" in app
+    assert "depends_on:" in app
+    assert "postgres:" in app
+    assert "condition: service_healthy" in app
+    assert "chainagents-files:/app/.files" in app
+    assert "chainagents-rag:/app/.rag" in app
+
+
+def test_compose_starts_postgres_with_app_service() -> None:
+    compose = _read("compose.yaml")
+
+    app = _block_after(compose, "app", indent=2)
+    postgres = _block_after(compose, "postgres", indent=2)
+
+    assert postgres
+    assert "depends_on:" in app
+    assert "postgres:" in app
+    assert "profiles:" not in postgres
+    assert "POSTGRES_USER: chainagents" in postgres
+    assert "pg_isready -U chainagents -d chainagents" in postgres
+    assert "postgres-data:/var/lib/postgresql/data" in postgres
+
+
+def test_dockerfile_launches_chainlit_on_container_interface() -> None:
+    dockerfile = _read("Dockerfile")
+
+    assert "ghcr.io/astral-sh/uv:python3.12-bookworm-slim" in dockerfile
+    assert "nodejs" in dockerfile
+    assert "npm" in dockerfile
+    assert "EXPOSE 8000" in dockerfile
+    assert '"chainlit"' in dockerfile
+    assert '"run"' in dockerfile
+    assert '"main.py"' in dockerfile
+    assert '"--host"' in dockerfile
+    assert '"0.0.0.0"' in dockerfile
+    assert '"--port"' in dockerfile
+    assert '"8000"' in dockerfile
+
+
+def test_dockerignore_excludes_local_runtime_state() -> None:
+    dockerignore = _read(".dockerignore").splitlines()
+
+    ignored = {line.strip() for line in dockerignore if line.strip() and not line.startswith("#")}
+
+    assert ".git" in ignored
+    assert ".venv" in ignored
+    assert ".files" in ignored
+    assert ".rag" in ignored
+    assert ".pytest_cache" in ignored
+    assert "__pycache__" in ignored
+    assert "ChainAgents.egg-info" in ignored


### PR DESCRIPTION
## Summary
- Add a Docker image and compose app service for running ChainAgents with the existing Postgres service
- Add a local JSON-backed Chainlit user store with salted password hashes and support for add/list/remove flows
- Wire Chainlit auth to the user store while keeping the legacy single-user env vars as a fallback
- Update README and deployment tests to cover the new container and auth workflows

## Testing
- Added unit coverage for the user store, CLI user management commands, and auth routing
- Added deployment tests for the Docker image and compose configuration
- Full test suite passed locally