### PR TITLE
Add Chainlit image uploads and silence LangGraph allowed_objects warning

### DIFF
--- a/.chainlit/config.toml
+++ b/.chainlit/config.toml
@@ -27,6 +27,7 @@ accept = [
   "application/yaml",
   "text/yaml",
   "text/csv",
+  "image/*",
 ]
 max_files = 5
 max_size_mb = 25

--- a/.chainlit/config.toml
+++ b/.chainlit/config.toml
@@ -27,7 +27,10 @@ accept = [
   "application/yaml",
   "text/yaml",
   "text/csv",
-  "image/*",
+  "image/gif",
+  "image/jpeg",
+  "image/png",
+  "image/webp",
 ]
 max_files = 5
 max_size_mb = 25

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ The app is wired for:
 - `ChatOllama` or `ChatOpenAI` with a configurable local model backend
 - native Chainlit streaming for reasoning, tool calls, and final response
 - Chainlit image uploads sent to vision-capable models as photo attachments for OCR or image analysis
+- Chainlit OCR/image uploads accept PNG, JPEG, WEBP, and GIF files
 - config-driven synchronous and async DeepAgents subagents
 - per-response download buttons for Markdown and PDF exports
 - Postgres-backed LangGraph checkpoints and durable `/memories/` when `DATABASE_URL` is set

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ The app is wired for:
 
 - `ChatOllama` or `ChatOpenAI` with a configurable local model backend
 - native Chainlit streaming for reasoning, tool calls, and final response
+- Chainlit image uploads sent to vision-capable models as photo attachments for OCR or image analysis
 - config-driven synchronous and async DeepAgents subagents
 - per-response download buttons for Markdown and PDF exports
 - Postgres-backed LangGraph checkpoints and durable `/memories/` when `DATABASE_URL` is set

--- a/deepagent_runtime.py
+++ b/deepagent_runtime.py
@@ -16,6 +16,10 @@ from pathlib import Path, PurePosixPath
 from typing import Any, Literal
 from urllib.parse import parse_qsl, urlsplit, urlunsplit
 
+from langchain_warning_filters import install_langchain_warning_filters
+
+install_langchain_warning_filters()
+
 from deepagents import AsyncSubAgent, create_deep_agent
 from deepagents.backends import (
     CompositeBackend,

--- a/langchain_warning_filters.py
+++ b/langchain_warning_filters.py
@@ -1,0 +1,29 @@
+"""Install narrow warning filters for known third-party startup warnings."""
+
+from __future__ import annotations
+
+import warnings
+
+try:
+    from langchain_core._api.deprecation import LangChainPendingDeprecationWarning
+except ImportError:  # pragma: no cover - defensive fallback for dependency changes.
+    LangChainPendingDeprecationWarning = Warning
+
+
+ALLOWED_OBJECTS_WARNING_MESSAGE = (
+    r"The default value of `allowed_objects` will change in a future version\..*"
+)
+LANGGRAPH_CHECKPOINT_SERDE_MODULES = (
+    r"langgraph\.checkpoint\.serde\.(encrypted|jsonplus)"
+)
+
+
+def install_langchain_warning_filters() -> None:
+    """Hide LangChain's import-time Reviver warning from LangGraph internals."""
+    warnings.filterwarnings(
+        "ignore",
+        message=ALLOWED_OBJECTS_WARNING_MESSAGE,
+        category=LangChainPendingDeprecationWarning,
+        module=LANGGRAPH_CHECKPOINT_SERDE_MODULES,
+    )
+

--- a/main.py
+++ b/main.py
@@ -3,12 +3,18 @@
 from __future__ import annotations
 
 import asyncio
+import base64
+import mimetypes
 import os
 import secrets
 import traceback
 from contextlib import suppress
 from pathlib import Path
 from typing import Any
+
+from langchain_warning_filters import install_langchain_warning_filters
+
+install_langchain_warning_filters()
 
 import chainlit as cl
 from chainlit.input_widget import Select, TextInput
@@ -75,6 +81,18 @@ RAG_UPLOAD_ACCEPT = {
         ".yaml",
         ".yml",
     ],
+}
+IMAGE_UPLOAD_EXTENSIONS = {
+    ".bmp",
+    ".gif",
+    ".heic",
+    ".heif",
+    ".jpeg",
+    ".jpg",
+    ".png",
+    ".tif",
+    ".tiff",
+    ".webp",
 }
 AUTH_USERNAME = os.getenv("CHAINLIT_AUTH_USERNAME", "").strip()
 AUTH_PASSWORD = os.getenv("CHAINLIT_AUTH_PASSWORD", "").strip()
@@ -272,6 +290,50 @@ def rag_status_line(runtime: AgentRuntime) -> str:
     return f"- RAG: unavailable; {reason}\n"
 
 
+def message_uploads(message: cl.Message) -> list[tuple[Path, str, str]]:
+    """Return readable files attached to a Chainlit message.
+
+    Args:
+        message: Chainlit message or LangChain message to process.
+
+    Returns:
+        Tuples of path, display name, and MIME type for attached files.
+    """
+    uploads: list[tuple[Path, str, str]] = []
+    for element in getattr(message, "elements", []) or []:
+        raw_path = getattr(element, "path", None)
+        if not raw_path:
+            continue
+        path = Path(str(raw_path))
+        if not path.exists() or not path.is_file():
+            continue
+        name = str(getattr(element, "name", "") or path.name).strip() or path.name
+        mime_type = uploaded_file_mime_type(element, path=path, name=name)
+        uploads.append((path, name, mime_type))
+    return uploads
+
+
+def uploaded_file_mime_type(element: Any, *, path: Path, name: str) -> str:
+    """Resolve the MIME type for an uploaded Chainlit file."""
+    for attr in ("mime", "mime_type", "content_type"):
+        raw_mime = getattr(element, attr, None)
+        if isinstance(raw_mime, str) and "/" in raw_mime:
+            return raw_mime.split(";", 1)[0].strip().lower()
+
+    for candidate in (name, path.name):
+        guessed_type, _ = mimetypes.guess_type(candidate)
+        if guessed_type:
+            return guessed_type.lower()
+    return ""
+
+
+def is_image_upload(path: Path, mime_type: str) -> bool:
+    """Return whether an uploaded file should be sent as an image attachment."""
+    if mime_type.startswith("image/"):
+        return True
+    return path.suffix.lower() in IMAGE_UPLOAD_EXTENSIONS
+
+
 def message_uploaded_rag_files(message: cl.Message) -> list[UploadedRagFile]:
     """Build the message for uploaded RAG files.
 
@@ -282,16 +344,86 @@ def message_uploaded_rag_files(message: cl.Message) -> list[UploadedRagFile]:
         The constructed the message for uploaded rag files.
     """
     uploads: list[UploadedRagFile] = []
-    for element in getattr(message, "elements", []) or []:
-        raw_path = getattr(element, "path", None)
-        if not raw_path:
+    for path, name, mime_type in message_uploads(message):
+        if is_image_upload(path, mime_type):
             continue
-        path = Path(str(raw_path))
-        if not path.exists() or not path.is_file():
-            continue
-        name = str(getattr(element, "name", "") or path.name).strip() or path.name
         uploads.append(UploadedRagFile(path=path, name=name))
     return uploads
+
+
+def message_uploaded_image_names(message: cl.Message) -> tuple[str, ...]:
+    """Return names for image files attached to a Chainlit message."""
+    return tuple(
+        name
+        for path, name, mime_type in message_uploads(message)
+        if is_image_upload(path, mime_type)
+    )
+
+
+def message_uploaded_image_parts(message: cl.Message) -> list[dict[str, Any]]:
+    """Build multimodal content parts for uploaded Chainlit images.
+
+    Args:
+        message: Chainlit message or LangChain message to process.
+
+    Returns:
+        OpenAI-compatible image content parts backed by data URLs.
+    """
+    parts: list[dict[str, Any]] = []
+    for path, _name, mime_type in message_uploads(message):
+        if not is_image_upload(path, mime_type):
+            continue
+        image_mime_type = (
+            mime_type
+            or mimetypes.guess_type(path.name)[0]
+            or "image/jpeg"
+        )
+        try:
+            encoded = base64.b64encode(path.read_bytes()).decode("ascii")
+        except OSError:
+            continue
+        parts.append(
+            {
+                "type": "image_url",
+                "image_url": {"url": f"data:{image_mime_type};base64,{encoded}"},
+            }
+        )
+    return parts
+
+
+def chainlit_prompt_text(
+    content: str,
+    *,
+    image_names: tuple[str, ...],
+    prompt_note: str,
+) -> str:
+    """Build the text part of a Chainlit user message sent to the agent."""
+    if not image_names:
+        return f"{content}{prompt_note}"
+
+    prompt = content.strip()
+    if not prompt and image_names:
+        prompt = "Extract any visible text from the attached image(s)."
+
+    attached = ", ".join(f"`{name}`" for name in image_names)
+    prompt = (
+        f"{prompt}\n\n"
+        f"Attached image file(s): {attached}. "
+        "Use the image content directly when answering."
+    )
+
+    return f"{prompt}{prompt_note}"
+
+
+def chainlit_user_message_content(
+    prompt: str,
+    *,
+    image_parts: list[dict[str, Any]],
+) -> str | list[dict[str, Any]]:
+    """Build the multimodal user message content sent from Chainlit."""
+    if not image_parts:
+        return prompt
+    return [{"type": "text", "text": prompt}, *image_parts]
 
 
 def upload_result_prompt_note(added_files: tuple[str, ...]) -> str:
@@ -1064,6 +1196,8 @@ async def on_message(message: cl.Message) -> None:
     mcp_session_id = current_mcp_session_id()
     run_task_list = await get_run_task_list()
     uploaded_files = message_uploaded_rag_files(message)
+    uploaded_image_parts = message_uploaded_image_parts(message)
+    uploaded_image_names = message_uploaded_image_names(message)
     prompt_note = ""
     if uploaded_files:
         upload_result = await runtime.ingest_rag_uploads(
@@ -1084,7 +1218,12 @@ async def on_message(message: cl.Message) -> None:
         selected_command=getattr(message, "command", None),
     )
     slash_command_from_text = parse_native_command(message.content)
-    if not message.content.strip() and uploaded_files and parsed_command is None:
+    if (
+        not message.content.strip()
+        and uploaded_files
+        and not uploaded_image_parts
+        and parsed_command is None
+    ):
         return
 
     if parsed_command is not None:
@@ -1116,6 +1255,11 @@ async def on_message(message: cl.Message) -> None:
                 return
             message.content = transformed_prompt
 
+    agent_prompt = chainlit_prompt_text(
+        message.content,
+        image_names=uploaded_image_names,
+        prompt_note=prompt_note,
+    )
     async_url_override = async_subagent_url_override()
     agent = await runtime.get_agent(
         effective_reasoning_level,
@@ -1130,7 +1274,7 @@ async def on_message(message: cl.Message) -> None:
         url_override=async_url_override,
     )
     bridge = ChainlitEventBridge(
-        prompt=message.content,
+        prompt=agent_prompt,
         run_task_list=run_task_list,
         chronological_ui_enabled=runtime.config.extensions.chainlit_chronological_ui_enabled,
     )
@@ -1144,7 +1288,10 @@ async def on_message(message: cl.Message) -> None:
         "messages": [
             {
                 "role": "user",
-                "content": f"{message.content}{prompt_note}",
+                "content": chainlit_user_message_content(
+                    agent_prompt,
+                    image_parts=uploaded_image_parts,
+                ),
             }
         ]
     }

--- a/main.py
+++ b/main.py
@@ -94,6 +94,20 @@ IMAGE_UPLOAD_EXTENSIONS = {
     ".tiff",
     ".webp",
 }
+VISION_IMAGE_MIME_TYPE_BY_EXTENSION = {
+    ".gif": "image/gif",
+    ".jpeg": "image/jpeg",
+    ".jpg": "image/jpeg",
+    ".png": "image/png",
+    ".webp": "image/webp",
+}
+VISION_IMAGE_MIME_TYPES = frozenset(VISION_IMAGE_MIME_TYPE_BY_EXTENSION.values())
+VISION_IMAGE_MIME_ALIASES = {
+    "image/jpg": "image/jpeg",
+    "image/pjpeg": "image/jpeg",
+    "image/x-png": "image/png",
+}
+GENERIC_UPLOAD_MIME_TYPES = {"", "application/octet-stream"}
 AUTH_USERNAME = os.getenv("CHAINLIT_AUTH_USERNAME", "").strip()
 AUTH_PASSWORD = os.getenv("CHAINLIT_AUTH_PASSWORD", "").strip()
 AUTH_SECRET = os.getenv("CHAINLIT_AUTH_SECRET", "").strip()
@@ -334,6 +348,18 @@ def is_image_upload(path: Path, mime_type: str) -> bool:
     return path.suffix.lower() in IMAGE_UPLOAD_EXTENSIONS
 
 
+def provider_safe_image_mime_type(path: Path, mime_type: str) -> str | None:
+    """Return a vision-provider-safe MIME type for an uploaded image."""
+    normalized_mime = VISION_IMAGE_MIME_ALIASES.get(mime_type, mime_type)
+    if normalized_mime in VISION_IMAGE_MIME_TYPES:
+        return normalized_mime
+
+    inferred_mime = VISION_IMAGE_MIME_TYPE_BY_EXTENSION.get(path.suffix.lower())
+    if inferred_mime and normalized_mime in GENERIC_UPLOAD_MIME_TYPES:
+        return inferred_mime
+    return None
+
+
 def message_uploaded_rag_files(message: cl.Message) -> list[UploadedRagFile]:
     """Build the message for uploaded RAG files.
 
@@ -356,7 +382,17 @@ def message_uploaded_image_names(message: cl.Message) -> tuple[str, ...]:
     return tuple(
         name
         for path, name, mime_type in message_uploads(message)
+        if provider_safe_image_mime_type(path, mime_type) is not None
+    )
+
+
+def unsupported_uploaded_image_names(message: cl.Message) -> tuple[str, ...]:
+    """Return names for image files that cannot be sent to vision providers."""
+    return tuple(
+        name
+        for path, name, mime_type in message_uploads(message)
         if is_image_upload(path, mime_type)
+        and provider_safe_image_mime_type(path, mime_type) is None
     )
 
 
@@ -371,13 +407,9 @@ def message_uploaded_image_parts(message: cl.Message) -> list[dict[str, Any]]:
     """
     parts: list[dict[str, Any]] = []
     for path, _name, mime_type in message_uploads(message):
-        if not is_image_upload(path, mime_type):
+        image_mime_type = provider_safe_image_mime_type(path, mime_type)
+        if image_mime_type is None:
             continue
-        image_mime_type = (
-            mime_type
-            or mimetypes.guess_type(path.name)[0]
-            or "image/jpeg"
-        )
         try:
             encoded = base64.b64encode(path.read_bytes()).decode("ascii")
         except OSError:
@@ -424,6 +456,17 @@ def chainlit_user_message_content(
     if not image_parts:
         return prompt
     return [{"type": "text", "text": prompt}, *image_parts]
+
+
+def unsupported_uploaded_images_message(image_names: tuple[str, ...]) -> str:
+    """Build a user-facing note for unsupported image uploads."""
+    names = ", ".join(f"`{name}`" for name in image_names)
+    return (
+        "Some uploaded images were not attached to the agent request because their "
+        "formats are not supported by the configured vision providers.\n\n"
+        f"- Unsupported: {names}\n"
+        "- Supported image formats: PNG, JPEG, WEBP, GIF"
+    )
 
 
 def upload_result_prompt_note(added_files: tuple[str, ...]) -> str:
@@ -1198,6 +1241,7 @@ async def on_message(message: cl.Message) -> None:
     uploaded_files = message_uploaded_rag_files(message)
     uploaded_image_parts = message_uploaded_image_parts(message)
     uploaded_image_names = message_uploaded_image_names(message)
+    unsupported_image_names = unsupported_uploaded_image_names(message)
     prompt_note = ""
     if uploaded_files:
         upload_result = await runtime.ingest_rag_uploads(
@@ -1213,6 +1257,12 @@ async def on_message(message: cl.Message) -> None:
             upload_message.actions = rag_actions()
         await upload_message.send()
 
+    if unsupported_image_names:
+        await cl.Message(
+            content=unsupported_uploaded_images_message(unsupported_image_names),
+            author="System",
+        ).send()
+
     parsed_command = resolve_native_command(
         raw_text=message.content,
         selected_command=getattr(message, "command", None),
@@ -1221,6 +1271,13 @@ async def on_message(message: cl.Message) -> None:
     if (
         not message.content.strip()
         and uploaded_files
+        and not uploaded_image_parts
+        and parsed_command is None
+    ):
+        return
+    if (
+        not message.content.strip()
+        and not uploaded_files
         and not uploaded_image_parts
         and parsed_command is None
     ):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ py-modules = [
     "chainlit_bridge",
     "deepagent_runtime",
     "langgraph_app",
+    "langchain_warning_filters",
     "main",
     "rag_runtime",
     "response_exports",

--- a/tests/test_langchain_warning_filters.py
+++ b/tests/test_langchain_warning_filters.py
@@ -1,0 +1,32 @@
+"""Test third-party warning handling for runtime startup."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+
+def test_deepagent_runtime_import_suppresses_allowed_objects_warning() -> None:
+    """Verify that startup hides LangChain's import-time allowed_objects warning."""
+    env = {
+        **os.environ,
+        "PYTHONPATH": os.getcwd(),
+    }
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-W",
+            "default",
+            "-c",
+            "import deepagent_runtime",
+        ],
+        check=False,
+        capture_output=True,
+        env=env,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert "allowed_objects" not in result.stderr

--- a/tests/test_main_native_commands.py
+++ b/tests/test_main_native_commands.py
@@ -182,6 +182,53 @@ def test_message_uploaded_image_parts_builds_data_url_parts(tmp_path) -> None:
     ]
 
 
+def test_message_uploaded_image_parts_skips_unsupported_provider_formats(tmp_path) -> None:
+    """Verify that unsupported image formats are not sent to vision providers."""
+    heic = tmp_path / "receipt.heic"
+    heic.write_bytes(b"fake heic bytes")
+    tiff = tmp_path / "scan.tiff"
+    tiff.write_bytes(b"fake tiff bytes")
+    message = SimpleNamespace(
+        elements=[
+            SimpleNamespace(path=str(heic), name="receipt.heic", mime="image/heic"),
+            SimpleNamespace(path=str(tiff), name="scan.tiff", mime="image/tiff"),
+        ]
+    )
+
+    assert main.message_uploaded_image_parts(message) == []
+    assert main.message_uploaded_image_names(message) == ()
+    assert main.unsupported_uploaded_image_names(message) == (
+        "receipt.heic",
+        "scan.tiff",
+    )
+
+
+def test_message_uploaded_image_parts_uses_safe_mime_for_octet_stream_image(
+    tmp_path,
+) -> None:
+    """Verify that safe image extensions override generic upload MIME types."""
+    photo = tmp_path / "receipt.png"
+    photo.write_bytes(b"fake png bytes")
+    message = SimpleNamespace(
+        elements=[
+            SimpleNamespace(
+                path=str(photo),
+                name="receipt.png",
+                mime="application/octet-stream",
+            ),
+        ]
+    )
+
+    image_parts = main.message_uploaded_image_parts(message)
+
+    assert image_parts == [
+        {
+            "type": "image_url",
+            "image_url": {"url": "data:image/png;base64,ZmFrZSBwbmcgYnl0ZXM="},
+        }
+    ]
+
+
 def test_chainlit_user_message_content_includes_uploaded_images() -> None:
     """Verify that agent payload content includes text and uploaded image parts."""
     image_part = {

--- a/tests/test_main_native_commands.py
+++ b/tests/test_main_native_commands.py
@@ -144,6 +144,82 @@ def test_build_langgraph_config_includes_recursion_limit() -> None:
     }
 
 
+def test_message_uploaded_rag_files_skips_image_uploads(tmp_path) -> None:
+    """Verify that RAG uploads ignore Chainlit image attachments."""
+    notes = tmp_path / "notes.md"
+    notes.write_text("# Notes\n", encoding="utf-8")
+    photo = tmp_path / "receipt.jpg"
+    photo.write_bytes(b"fake jpeg bytes")
+    message = SimpleNamespace(
+        elements=[
+            SimpleNamespace(path=str(notes), name="notes.md", mime="text/markdown"),
+            SimpleNamespace(path=str(photo), name="receipt.jpg", mime="image/jpeg"),
+        ]
+    )
+
+    uploads = main.message_uploaded_rag_files(message)
+
+    assert [upload.name for upload in uploads] == ["notes.md"]
+
+
+def test_message_uploaded_image_parts_builds_data_url_parts(tmp_path) -> None:
+    """Verify that Chainlit image attachments become multimodal data URL parts."""
+    photo = tmp_path / "receipt.jpg"
+    photo.write_bytes(b"fake jpeg bytes")
+    message = SimpleNamespace(
+        elements=[
+            SimpleNamespace(path=str(photo), name="receipt.jpg", mime="image/jpeg"),
+        ]
+    )
+
+    image_parts = main.message_uploaded_image_parts(message)
+
+    assert image_parts == [
+        {
+            "type": "image_url",
+            "image_url": {"url": "data:image/jpeg;base64,ZmFrZSBqcGVnIGJ5dGVz"},
+        }
+    ]
+
+
+def test_chainlit_user_message_content_includes_uploaded_images() -> None:
+    """Verify that agent payload content includes text and uploaded image parts."""
+    image_part = {
+        "type": "image_url",
+        "image_url": {"url": "data:image/png;base64,aW1hZ2U="},
+    }
+
+    content = main.chainlit_user_message_content(
+        "OCR this receipt.",
+        image_parts=[image_part],
+    )
+
+    assert content == [{"type": "text", "text": "OCR this receipt."}, image_part]
+
+
+def test_chainlit_prompt_text_defaults_to_ocr_for_image_only_upload() -> None:
+    """Verify that image-only messages ask the agent to extract visible text."""
+    prompt = main.chainlit_prompt_text(
+        "",
+        image_names=("receipt.jpg",),
+        prompt_note="",
+    )
+
+    assert "Extract any visible text" in prompt
+    assert "receipt.jpg" in prompt
+
+
+def test_chainlit_prompt_text_preserves_text_without_images() -> None:
+    """Verify that non-image prompts keep their existing text shape."""
+    prompt = main.chainlit_prompt_text(
+        "  keep my spacing  ",
+        image_names=(),
+        prompt_note="\n\nRAG note",
+    )
+
+    assert prompt == "  keep my spacing  \n\nRAG note"
+
+
 @pytest.mark.anyio
 async def test_publish_modes_ignores_missing_modes_column_error(monkeypatch) -> None:
     """Verify that publish modes ignores missing modes column error.


### PR DESCRIPTION
## Summary
- Enabled Chainlit `image/*` uploads and routed image attachments to the agent as multimodal `image_url` parts for OCR/image analysis.
- Kept text-file RAG uploads separate from image handling and added OCR-oriented fallback text when a message contains images but no prompt.
- Added a narrow startup warning filter to suppress LangGraph/LangChain’s `allowed_objects` pending deprecation warning during import.
- Documented the image-upload behavior in the README.

## Testing
- Added unit coverage for image upload parsing, multimodal payload construction, and prompt shaping.
- Added a subprocess regression test to confirm `deepagent_runtime` imports without emitting the `allowed_objects` warning.
- Full test suite passes locally.