### PR TITLE
Allow disabling streaming for tool calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ export DATABASE_URL="postgresql://USER:PASSWORD@HOST:5432/DBNAME?sslmode=disable
 export DEEPAGENT_MODEL_PROVIDER="ollama"
 export DEEPAGENT_MODEL_BASE_URL="http://127.0.0.1:11434"
 # export DEEPAGENT_MODEL_ENDPOINT_URL="https://api.example.test/custom/v1/messages"
+# export DEEPAGENT_MODEL_DISABLE_STREAMING_FOR_TOOL_CALLS="true"
 export DEEPAGENT_MODEL_NAME="gpt-oss:20b"
 export DEEPAGENT_MODEL_REASONING="medium"
 export DEEPAGENT_RECURSION_LIMIT="200"
@@ -52,6 +53,7 @@ export CHAINLIT_AUTH_PASSWORD="change-me"
 - they override the matching `[model]` values in `deepagent.toml`
 - `DEEPAGENT_MODEL_API_KEY` is used for secured OpenAI-compatible servers and can also supply the Anthropic API key
 - `ANTHROPIC_API_KEY` is also read when `provider = "anthropic"` or `provider = "claude"`
+- `DEEPAGENT_MODEL_DISABLE_STREAMING` accepts `true`, `false`, or `tool_calling`; `DEEPAGENT_MODEL_DISABLE_STREAMING_FOR_TOOL_CALLS=true` is a convenience alias for `tool_calling`
 - `OLLAMA_BASE_URL`, `OLLAMA_MODEL`, and `OLLAMA_REASONING` remain supported as Ollama-only compatibility aliases
 
 `DEEPAGENT_RECURSION_LIMIT` is optional:
@@ -202,6 +204,9 @@ repeat_penalty = 1.1
 name = "gpt-oss:20b"
 models = ["gpt-oss:20b", "gemma4:27b"]
 reasoning_effort = "medium"
+# Disable streaming only for requests that include tools, which can help
+# model servers that emit malformed streamed tool-call chunks.
+disable_streaming_for_tool_calls = false
 ```
 
 For LM Studio or another OpenAI-compatible server:
@@ -246,13 +251,14 @@ Notes:
 - `provider = "claude"` is accepted as an alias for `provider = "anthropic"`.
 - Preferred shared fields are `base_url`, `name`, `temperature`, and `reasoning_effort`.
 - `repeat_penalty` is optional and currently applies to `provider = "ollama"`; when omitted, Ollama defaults are used.
+- `disable_streaming = "tool_calling"` or `disable_streaming_for_tool_calls = true` bypasses model streaming only when tools are attached to the request; use this for providers that have trouble streaming tool-call chunks. `disable_streaming = true` disables model streaming for all requests.
 - `endpoint_url` is an override for full non-standard model endpoint URLs. OpenAI-compatible paths ending in `/chat/completions` or `/responses` are normalized to the client base URL and query parameters are forwarded as OpenAI client default query parameters. Anthropic paths ending in `/v1/messages` are normalized to the Claude client base URL.
 - `models` is an optional list of model IDs surfaced in Chainlit settings and modes so users can switch models per session or per message.
 - `api_key` is optional for `provider = "openai_compatible"`; when omitted, the runtime sends a placeholder token that local servers like LM Studio accept.
 - Anthropic requires an API key from `api_key`, `DEEPAGENT_MODEL_API_KEY`, or `ANTHROPIC_API_KEY`.
 - Legacy Ollama `endpoint` and `port` are still accepted when `provider = "ollama"` or omitted.
 - `reasoning_effort` sets the default Chainlit reasoning level for new chats. Ollama uses that level directly, Anthropic maps it to Claude `effort`, and OpenAI-compatible servers may ignore it.
-- `DEEPAGENT_MODEL_PROVIDER`, `DEEPAGENT_MODEL_BASE_URL`, `DEEPAGENT_MODEL_ENDPOINT_URL`, `DEEPAGENT_MODEL_NAME`, `DEEPAGENT_MODEL_API_KEY`, and `DEEPAGENT_MODEL_REASONING` override the TOML defaults when set.
+- `DEEPAGENT_MODEL_PROVIDER`, `DEEPAGENT_MODEL_BASE_URL`, `DEEPAGENT_MODEL_ENDPOINT_URL`, `DEEPAGENT_MODEL_NAME`, `DEEPAGENT_MODEL_API_KEY`, `DEEPAGENT_MODEL_REASONING`, `DEEPAGENT_MODEL_DISABLE_STREAMING`, and `DEEPAGENT_MODEL_DISABLE_STREAMING_FOR_TOOL_CALLS` override the TOML defaults when set.
 - `OLLAMA_BASE_URL`, `OLLAMA_MODEL`, and `OLLAMA_REASONING` still work as Ollama-only compatibility aliases.
 
 ## Agent Runtime Config

--- a/chainagents_cli.py
+++ b/chainagents_cli.py
@@ -104,6 +104,14 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--api-key", help="API key for OpenAI-compatible model servers.")
     parser.add_argument("--temperature", type=float, help="Model temperature.")
     parser.add_argument(
+        "--disable-streaming-for-tool-calls",
+        action="store_true",
+        help=(
+            "Bypass model streaming only for requests that include tools. "
+            "Useful for model servers with unreliable streamed tool-call chunks."
+        ),
+    )
+    parser.add_argument(
         "--reasoning",
         choices=("low", "medium", "high"),
         help="Reasoning effort for this run.",
@@ -215,6 +223,9 @@ def runtime_overrides_from_args(args: argparse.Namespace) -> RuntimeConfigOverri
         model_endpoint_url=args.endpoint_url,
         model_api_key=args.api_key,
         model_temperature=args.temperature,
+        model_disable_streaming=(
+            "tool_calling" if args.disable_streaming_for_tool_calls else None
+        ),
         reasoning_level=args.reasoning,
         recursion_limit=args.recursion_limit,
         disable_rag=args.no_rag,
@@ -882,6 +893,7 @@ def runtime_status_payload(runtime: AgentRuntime) -> dict[str, Any]:
         "model_choices": list(runtime.config.model_choices),
         "model_base_url": runtime.config.model_base_url,
         "reasoning": runtime.config.default_reasoning,
+        "model_disable_streaming": runtime.config.model_disable_streaming,
         "recursion_limit": runtime.config.recursion_limit,
         "persistence": runtime.config.persistence_mode,
         "rag": rag_status_payload(runtime.rag_status),
@@ -944,6 +956,10 @@ def print_runtime_status(
         Text(str(payload["model_base_url"] or "not set"), "white"),
     )
     table.add_row("Reasoning", Text(str(payload["reasoning"]), "cyan"))
+    table.add_row(
+        "Disable streaming",
+        Text(str(payload["model_disable_streaming"]), "white"),
+    )
     table.add_row("Recursion limit", Text(str(payload["recursion_limit"]), "white"))
     table.add_row("Persistence", Text(str(payload["persistence"]), "white"))
     table.add_row("RAG", rag_status_text(payload["rag"]))

--- a/deepagent.toml
+++ b/deepagent.toml
@@ -8,6 +8,8 @@ name = "qwen3.6:35b-a3b"
 #models = ["gpt-oss:20b", "gemma4:26b", "qwen3.6:27b"]
 
 reasoning_effort = "medium"
+# Set true to bypass model streaming only for tool-calling requests.
+disable_streaming_for_tool_calls = false
 
 # For LM Studio or another OpenAI-compatible server, switch to:
 #[model]

--- a/deepagent.toml.example
+++ b/deepagent.toml.example
@@ -5,6 +5,8 @@ temperature = 0
 name = "gpt-oss:20b"
 models = ["gpt-oss:20b", "gemma4:27b"]
 reasoning_effort = "medium"
+# Set true to bypass model streaming only for tool-calling requests.
+disable_streaming_for_tool_calls = false
 # For LM Studio or another OpenAI-compatible server, switch to:
 # provider = "openai_compatible"
 # base_url = "http://127.0.0.1:1234/v1"

--- a/deepagent_runtime.py
+++ b/deepagent_runtime.py
@@ -57,6 +57,7 @@ from rag_runtime import (
 
 ModelProvider = Literal["ollama", "openai_compatible", "anthropic"]
 ReasoningLevel = Literal["low", "medium", "high"]
+DisableStreaming = bool | Literal["tool_calling"]
 PersistenceMode = Literal["memory", "postgres"]
 DEFAULT_MODEL = "gpt-oss:20b"
 DEFAULT_MODEL_PROVIDER: ModelProvider = "ollama"
@@ -125,6 +126,74 @@ def normalize_reasoning_level(
     if candidate not in {"low", "medium", "high"}:
         return default
     return candidate  # type: ignore[return-value]
+
+
+def normalize_disable_streaming(value: Any | None) -> DisableStreaming:
+    """Normalize the LangChain disable_streaming model option.
+
+    Args:
+        value: Value to normalize, convert, or serialize.
+
+    Returns:
+        The normalized disable streaming value.
+
+    Raises:
+        ValueError: If the supplied value is invalid.
+    """
+    if value is None:
+        return False
+    if isinstance(value, bool):
+        return value
+    candidate = str(value).strip().lower().replace("-", "_")
+    if not candidate:
+        return False
+    if candidate in {"true", "1", "yes", "on"}:
+        return True
+    if candidate in {"false", "0", "no", "off"}:
+        return False
+    if candidate == "tool_calling":
+        return "tool_calling"
+    raise ValueError(
+        "Model disable_streaming must be a boolean or 'tool_calling'."
+    )
+
+
+def normalize_disable_streaming_for_tool_calls(value: Any | None) -> bool:
+    """Normalize whether to disable streaming only when tools are bound.
+
+    Args:
+        value: Value to normalize, convert, or serialize.
+
+    Returns:
+        Whether streaming should be disabled for tool-calling requests.
+
+    Raises:
+        ValueError: If the supplied value is invalid.
+    """
+    normalized = normalize_disable_streaming(value)
+    if normalized == "tool_calling":
+        return True
+    if isinstance(normalized, bool):
+        return normalized
+    return False
+
+
+def parse_model_disable_streaming(raw_model: dict[str, Any]) -> DisableStreaming:
+    """Parse model streaming-disabling settings.
+
+    Args:
+        raw_model: Raw model config table.
+
+    Returns:
+        The parsed LangChain disable_streaming value.
+    """
+    if "disable_streaming" in raw_model:
+        return normalize_disable_streaming(raw_model.get("disable_streaming"))
+    if normalize_disable_streaming_for_tool_calls(
+        raw_model.get("disable_streaming_for_tool_calls")
+    ):
+        return "tool_calling"
+    return False
 
 
 def normalize_model_provider(
@@ -1337,6 +1406,7 @@ class ModelDefaults:
         reasoning_effort: The reasoning effort value.
         temperature: The temperature value.
         repeat_penalty: The repeat penalty value.
+        disable_streaming: Whether to disable model streaming.
     """
 
     provider: ModelProvider = DEFAULT_MODEL_PROVIDER
@@ -1349,6 +1419,7 @@ class ModelDefaults:
     reasoning_effort: ReasoningLevel = DEFAULT_REASONING_LEVEL
     temperature: float = DEFAULT_TEMPERATURE
     repeat_penalty: float | None = None
+    disable_streaming: DisableStreaming = False
 
 
 @dataclass(frozen=True)
@@ -1455,6 +1526,7 @@ def parse_model_defaults(raw_config: dict[str, Any]) -> ModelDefaults:
             raw_model.get("temperature", raw_model.get("tempreature"))
         ),
         repeat_penalty=normalize_repeat_penalty(raw_model.get("repeat_penalty")),
+        disable_streaming=parse_model_disable_streaming(raw_model),
     )
 
 
@@ -1926,6 +1998,7 @@ class RuntimeConfigOverrides:
         reasoning_level: The reasoning level value.
         recursion_limit: The recursion limit value.
         disable_rag: The disable RAG value.
+        model_disable_streaming: Whether to disable model streaming.
     """
 
     config_path: str | Path | None = None
@@ -1940,6 +2013,7 @@ class RuntimeConfigOverrides:
     reasoning_level: str | None = None
     recursion_limit: int | None = None
     disable_rag: bool = False
+    model_disable_streaming: DisableStreaming | None = None
 
 
 @dataclass(frozen=True)
@@ -1963,6 +2037,7 @@ class RuntimeConfig:
         rag: The RAG value.
         rag_error: The RAG error value.
         model_endpoint_query: The model endpoint query value.
+        model_disable_streaming: Whether to disable model streaming.
     """
 
     database_url: str | None
@@ -1981,6 +2056,7 @@ class RuntimeConfig:
     rag: ResolvedRagConfig | None = None
     rag_error: str | None = None
     model_endpoint_query: tuple[tuple[str, str], ...] = ()
+    model_disable_streaming: DisableStreaming = False
 
     @classmethod
     def from_env(
@@ -2159,6 +2235,23 @@ class RuntimeConfig:
             else model_defaults.temperature
         )
         model_repeat_penalty = model_defaults.repeat_penalty
+        if overrides.model_disable_streaming is not None:
+            model_disable_streaming = normalize_disable_streaming(
+                overrides.model_disable_streaming
+            )
+        else:
+            raw_disable_streaming = os.getenv("DEEPAGENT_MODEL_DISABLE_STREAMING")
+            if raw_disable_streaming is not None:
+                model_disable_streaming = normalize_disable_streaming(raw_disable_streaming)
+            elif os.getenv("DEEPAGENT_MODEL_DISABLE_STREAMING_FOR_TOOL_CALLS") is not None:
+                if normalize_disable_streaming_for_tool_calls(
+                    os.getenv("DEEPAGENT_MODEL_DISABLE_STREAMING_FOR_TOOL_CALLS")
+                ):
+                    model_disable_streaming = "tool_calling"
+                else:
+                    model_disable_streaming = False
+            else:
+                model_disable_streaming = model_defaults.disable_streaming
         default_reasoning = normalize_reasoning_level(
             generic_model_reasoning or model_reasoning_alias,
             default=model_defaults.reasoning_effort,
@@ -2202,6 +2295,7 @@ class RuntimeConfig:
             rag=rag,
             rag_error=rag_error,
             model_endpoint_query=model_endpoint_query,
+            model_disable_streaming=model_disable_streaming,
         )
 
 
@@ -2228,6 +2322,7 @@ def build_model(
             "base_url": config.model_base_url,
             "reasoning": reasoning_level,
             "temperature": config.model_temperature,
+            "disable_streaming": config.model_disable_streaming,
         }
         if config.model_repeat_penalty is not None:
             kwargs["repeat_penalty"] = config.model_repeat_penalty
@@ -2239,6 +2334,7 @@ def build_model(
             "base_url": config.model_base_url,
             "temperature": config.model_temperature,
             "effort": reasoning_level,
+            "disable_streaming": config.model_disable_streaming,
         }
         if config.model_api_key:
             kwargs["api_key"] = config.model_api_key
@@ -2249,6 +2345,7 @@ def build_model(
         "base_url": config.model_base_url,
         "api_key": config.model_api_key or "deepagent",
         "temperature": config.model_temperature,
+        "disable_streaming": config.model_disable_streaming,
     }
     default_query = model_endpoint_query_to_dict(config.model_endpoint_query)
     if default_query:

--- a/tests/test_agent_cli.py
+++ b/tests/test_agent_cli.py
@@ -30,6 +30,7 @@ def test_cli_parses_prompt_and_runtime_flags() -> None:
             "--thread-id",
             "thread-1",
             "--no-stream",
+            "--disable-streaming-for-tool-calls",
             "--json",
         ]
     )
@@ -40,6 +41,7 @@ def test_cli_parses_prompt_and_runtime_flags() -> None:
     assert args.reasoning == "high"
     assert args.thread_id == "thread-1"
     assert args.stream is False
+    assert args.disable_streaming_for_tool_calls is True
     assert args.json_output is True
 
 
@@ -88,6 +90,7 @@ recursion_limit = 20
             "cli-key",
             "--temperature",
             "0.7",
+            "--disable-streaming-for-tool-calls",
             "--reasoning",
             "high",
             "--recursion-limit",
@@ -105,6 +108,7 @@ recursion_limit = 20
     assert config.model_name == "cli-model"
     assert config.model_api_key == "cli-key"
     assert config.model_temperature == 0.7
+    assert config.model_disable_streaming == "tool_calling"
     assert config.default_reasoning == "high"
     assert config.recursion_limit == 77
     assert config.rag_requested is False
@@ -478,6 +482,7 @@ async def test_cli_json_combines_multiple_actions(tmp_path: Path) -> None:
         model_choices=["fake-model"],
         model_base_url=None,
         default_reasoning="medium",
+        model_disable_streaming=False,
         recursion_limit=50,
         persistence_mode="memory",
         extensions=SimpleNamespace(

--- a/tests/test_deepagent_runtime_rag.py
+++ b/tests/test_deepagent_runtime_rag.py
@@ -314,6 +314,65 @@ models = ["gpt-oss:20b", "gemma4:27b"]
     assert config.model_choices == ("gpt-oss:20b", "gemma4:27b")
 
 
+def test_runtime_config_disables_streaming_for_tool_calls_from_toml(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Verify TOML can disable streaming only for tool-calling requests.
+
+    Args:
+        tmp_path: Path to the tmp.
+        monkeypatch: The monkeypatch value.
+    """
+    config_path = tmp_path / "deepagent.toml"
+    config_path.write_text(
+        """
+[model]
+provider = "ollama"
+base_url = "http://127.0.0.1:11434"
+name = "gpt-oss:20b"
+disable_streaming_for_tool_calls = true
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DEEPAGENT_CONFIG", str(config_path))
+
+    config = deepagent_runtime.RuntimeConfig.from_env()
+    model = deepagent_runtime.build_model(config, "medium")
+
+    assert config.model_disable_streaming == "tool_calling"
+    assert model.disable_streaming == "tool_calling"
+
+
+def test_runtime_config_disable_streaming_env_overrides_toml(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Verify environment can override the model disable_streaming option.
+
+    Args:
+        tmp_path: Path to the tmp.
+        monkeypatch: The monkeypatch value.
+    """
+    config_path = tmp_path / "deepagent.toml"
+    config_path.write_text(
+        """
+[model]
+provider = "ollama"
+base_url = "http://127.0.0.1:11434"
+name = "gpt-oss:20b"
+disable_streaming = false
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DEEPAGENT_CONFIG", str(config_path))
+    monkeypatch.setenv("DEEPAGENT_MODEL_DISABLE_STREAMING", "tool_calling")
+
+    config = deepagent_runtime.RuntimeConfig.from_env()
+
+    assert config.model_disable_streaming == "tool_calling"
+
+
 def test_runtime_config_reads_openai_endpoint_url_from_toml(
     tmp_path: Path,
     monkeypatch,


### PR DESCRIPTION
### Motivation

- Some model servers emit unreliable or malformed streamed tool-call chunks that break renderer logic, so provide a way to disable streaming specifically for requests that include tools.

### Description

- Add normalization and parsing helpers (`normalize_disable_streaming`, `normalize_disable_streaming_for_tool_calls`, `parse_model_disable_streaming`) and extend `ModelDefaults` / `RuntimeConfig` to carry a `model_disable_streaming` setting.
- Wire the resolved setting into `build_model()` and pass `disable_streaming` into `ChatOllama`, `ChatAnthropic`, and the OpenAI-compatible model so LangChain can disable streaming or use the `"tool_calling"` mode.
- Expose the capability via TOML (`disable_streaming` or `disable_streaming_for_tool_calls`), environment variables (`DEEPAGENT_MODEL_DISABLE_STREAMING`, `DEEPAGENT_MODEL_DISABLE_STREAMING_FOR_TOOL_CALLS`), and a CLI flag `--disable-streaming-for-tool-calls` that sets `model_disable_streaming = "tool_calling"`.
- Update CLI status output and documentation (`README.md`, `deepagent.toml`, `deepagent.toml.example`) and add regression tests for TOML, env, and CLI behavior in `tests/test_deepagent_runtime_rag.py` and `tests/test_agent_cli.py`.

### Testing

- Ran the focused tests `uv run pytest tests/test_deepagent_runtime_rag.py tests/test_agent_cli.py` and they passed.
- Ran the full test suite `uv run pytest` and all tests passed (130 passed, 2 warnings).
- Ran code checks used in the workflow (`git diff --check` / test compile steps) and they produced no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b678350108324b08e3405095820d1)