### PR TITLE
Avoid duplicate summarization middleware after deepagents 0.6.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,6 +397,8 @@ cwd = "."
 recursion_limit = 200
 skills = ["skills"]
 mcp_servers = ["repo"]
+summarization_trigger_tokens = 6000
+summarization_keep_tokens = 2400
 
 [[subagents]]
 name = "repo-researcher"
@@ -433,7 +435,9 @@ Main `[agent]` additions:
 - `AGENTS.md`: optional repo-root file that is automatically appended to the **main/supervisor** agent system prompt when present. It is not applied to separately configured async graph prompts.
 - `custom_instruction`: optional string appended to the **main/supervisor** agent system prompt. This setting does **not** get applied to separately configured prompts such as the `async_researcher` graph prompt.
 - DeepAgents provides its own summarization middleware in the main agent and sync subagents.
-- Legacy `summarization_middleware_enabled`, `summarization_trigger_tokens`, and `summarization_keep_tokens` entries are still parsed for compatibility, but ChainAgents no longer injects a second summarization middleware.
+- `summarization_trigger_tokens`: optional positive integer token threshold for DeepAgents' built-in summarization middleware.
+- `summarization_keep_tokens`: optional positive integer token budget to keep after DeepAgents summarizes conversation history.
+- Legacy `summarization_middleware_enabled` entries are still parsed for compatibility, but ChainAgents no longer injects a second summarization middleware.
 
 ## Chainlit Native Commands
 

--- a/README.md
+++ b/README.md
@@ -397,9 +397,6 @@ cwd = "."
 recursion_limit = 200
 skills = ["skills"]
 mcp_servers = ["repo"]
-summarization_middleware_enabled = false
-summarization_trigger_tokens = 6000
-summarization_keep_tokens = 2400
 
 [[subagents]]
 name = "repo-researcher"
@@ -435,10 +432,8 @@ Main `[agent]` additions:
 - `recursion_limit`: optional positive integer LangGraph step limit for a single agent run. Defaults to `100` unless overridden by `DEEPAGENT_RECURSION_LIMIT`.
 - `AGENTS.md`: optional repo-root file that is automatically appended to the **main/supervisor** agent system prompt when present. It is not applied to separately configured async graph prompts.
 - `custom_instruction`: optional string appended to the **main/supervisor** agent system prompt. This setting does **not** get applied to separately configured prompts such as the `async_researcher` graph prompt.
-- `summarization_middleware_enabled`: optional boolean (default `false`) to add LangChain's summarization middleware to the main agent and sync subagents.
-- `summarization_trigger_tokens`: optional positive integer token threshold that triggers summarization when reached.
-- `summarization_keep_tokens`: optional positive integer token budget to keep in conversation history after summarization.
-- When summarization runs, the CLI prints a summarization status panel and Chainlit shows a summarization step in the UI.
+- DeepAgents provides its own summarization middleware in the main agent and sync subagents.
+- Legacy `summarization_middleware_enabled`, `summarization_trigger_tokens`, and `summarization_keep_tokens` entries are still parsed for compatibility, but ChainAgents no longer injects a second summarization middleware.
 
 ## Chainlit Native Commands
 

--- a/chainlit.md
+++ b/chainlit.md
@@ -22,7 +22,7 @@ Local-first LangChain Deep Agent UI running on Ollama or any OpenAI-compatible s
 - `deepagent.toml` can define `[model]` with `provider`, `base_url` or OpenAI-compatible `endpoint_url`, `temperature`, `name`, optional `api_key`, and `reasoning_effort`
 - if `deepagent.toml` is missing, the runtime defaults to `http://127.0.0.1:11434`, `gpt-oss:20b`, and `medium`
 - `DEEPAGENT_MODEL_*` env vars override the TOML defaults, and `OLLAMA_BASE_URL`, `OLLAMA_MODEL`, and `OLLAMA_REASONING` remain available as Ollama-only compatibility aliases
-- When summarization middleware compacts conversation history, Chainlit shows a summarization status step.
+- DeepAgents manages conversation summarization in its base agent stack.
 
 ## Optional Persistence
 

--- a/deepagent.toml
+++ b/deepagent.toml
@@ -36,7 +36,11 @@ cwd = "."
 recursion_limit = 200
 skills = ["skills"]
 mcp_servers = ["repo"]
-# DeepAgents 0.6.7 provides summarization middleware in its base agent stack.
+# Legacy flag retained for compatibility; DeepAgents provides summarization.
+summarization_middleware_enabled = true
+# Token thresholds tune DeepAgents' built-in summarizer.
+summarization_trigger_tokens = 150000
+summarization_keep_tokens = 10000
 
 [rag]
 enabled = true

--- a/deepagent.toml
+++ b/deepagent.toml
@@ -36,10 +36,7 @@ cwd = "."
 recursion_limit = 200
 skills = ["skills"]
 mcp_servers = ["repo"]
-summarization_middleware_enabled = true
-# Optional token thresholds used when the installed LangChain middleware supports them.
-summarization_trigger_tokens = 150000
-summarization_keep_tokens = 10000
+# DeepAgents 0.6.7 provides summarization middleware in its base agent stack.
 
 [rag]
 enabled = true

--- a/deepagent.toml.example
+++ b/deepagent.toml.example
@@ -44,8 +44,9 @@ mcp_servers = ["repo"]
 # Optional instruction appended to the main agent system prompt.
 # custom_instruction = "Always ask clarifying questions before editing files."
 # DeepAgents 0.6.7 provides summarization middleware in its base agent stack.
-# Legacy summarization_middleware_enabled and token threshold entries are parsed
-# for compatibility, but ChainAgents no longer injects a second middleware.
+# These optional token thresholds tune DeepAgents' built-in summarizer.
+summarization_trigger_tokens = 6000
+summarization_keep_tokens = 2400
 
 [chainlit]
 # Set false to hide model selection in chat settings and Modes.

--- a/deepagent.toml.example
+++ b/deepagent.toml.example
@@ -43,11 +43,9 @@ skills = ["skills"]
 mcp_servers = ["repo"]
 # Optional instruction appended to the main agent system prompt.
 # custom_instruction = "Always ask clarifying questions before editing files."
-# Set true to add LangChain's SummarizationMiddleware to the main agent and sync subagents.
-summarization_middleware_enabled = false
-# Optional token thresholds used when the installed LangChain middleware supports them.
-summarization_trigger_tokens = 6000
-summarization_keep_tokens = 2400
+# DeepAgents 0.6.7 provides summarization middleware in its base agent stack.
+# Legacy summarization_middleware_enabled and token threshold entries are parsed
+# for compatibility, but ChainAgents no longer injects a second middleware.
 
 [chainlit]
 # Set false to hide model selection in chat settings and Modes.

--- a/deepagent_runtime.py
+++ b/deepagent_runtime.py
@@ -998,22 +998,12 @@ def build_agent_middleware(
     Returns:
         The constructed agent middleware.
     """
+    # DeepAgents 0.6.7 owns summarization middleware in its base main-agent and
+    # sync-subagent stacks. Passing another SummarizationMiddleware here creates
+    # duplicate middleware names that LangChain rejects during agent creation.
     middleware: list[AgentMiddleware[Any, Any, Any]] = [
         ToolExecutionResilienceMiddleware(project_root=project_root)
     ]
-    if (
-        config
-        and config.extensions.summarization_middleware_enabled
-        and reasoning_level is not None
-    ):
-        summarization_middleware = _build_summarization_middleware(
-            config=config,
-            reasoning_level=reasoning_level,
-            model_name=model_name,
-            source=source,
-        )
-        if summarization_middleware is not None:
-            middleware.append(summarization_middleware)
     return middleware
 
 

--- a/deepagent_runtime.py
+++ b/deepagent_runtime.py
@@ -8,6 +8,7 @@ import json
 import logging
 import math
 import os
+import threading
 import tomllib
 from collections.abc import Awaitable, Callable
 from contextlib import AsyncExitStack
@@ -73,6 +74,7 @@ PROJECT_ROOT = Path(__file__).resolve().parent
 DEEPAGENT_ARTIFACTS_DIRECTORY = Path(".files/deepagent")
 AGENTS_MD_FILENAME = "AGENTS.md"
 logger = logging.getLogger(__name__)
+_DEEPAGENTS_SUMMARIZATION_FACTORY_LOCK = threading.RLock()
 OPENAI_CHAT_COMPLETIONS_PATH_SUFFIX = "/chat/completions"
 OPENAI_RESPONSES_PATH_SUFFIX = "/responses"
 ANTHROPIC_MESSAGES_PATH_SUFFIX = "/v1/messages"
@@ -976,6 +978,77 @@ def _build_summarization_middleware(
         )
         return None
     return SummarizationStatusMiddleware(middleware, source=source)
+
+
+def _build_deepagents_summarization_factory(
+    config: RuntimeConfig,
+) -> Callable[[Any, Any], AgentMiddleware[Any, Any, Any]] | None:
+    """Build a DeepAgents summarization factory honoring configured thresholds.
+
+    Args:
+        config: Configuration object used by the operation.
+
+    Returns:
+        A replacement DeepAgents summarization factory, or None when the
+        built-in defaults should be used unchanged.
+    """
+    trigger_tokens = config.extensions.summarization_trigger_tokens
+    keep_tokens = config.extensions.summarization_keep_tokens
+    if trigger_tokens is None and keep_tokens is None:
+        return None
+
+    def factory(model: Any, backend: Any) -> AgentMiddleware[Any, Any, Any]:
+        """Create DeepAgents summarization middleware with configured thresholds."""
+        from deepagents.middleware.summarization import (
+            SummarizationMiddleware,
+            compute_summarization_defaults,
+        )
+
+        defaults = compute_summarization_defaults(model)
+        trigger = (
+            ("tokens", trigger_tokens)
+            if trigger_tokens is not None
+            else defaults["trigger"]
+        )
+        keep = ("tokens", keep_tokens) if keep_tokens is not None else defaults["keep"]
+        return SummarizationMiddleware(
+            model=model,
+            backend=backend,
+            trigger=trigger,
+            keep=keep,
+            trim_tokens_to_summarize=None,
+            truncate_args_settings=defaults["truncate_args_settings"],
+        )
+
+    return factory
+
+
+def create_deep_agent_with_configured_summarization(
+    config: RuntimeConfig,
+    **kwargs: Any,
+) -> Any:
+    """Create a DeepAgents graph while applying configured summarization thresholds.
+
+    Args:
+        config: Configuration object used by the operation.
+        kwargs: Keyword arguments passed to create_deep_agent.
+
+    Returns:
+        The created DeepAgents graph.
+    """
+    summarization_factory = _build_deepagents_summarization_factory(config)
+    if summarization_factory is None:
+        return create_deep_agent(**kwargs)
+
+    import deepagents.graph as deepagents_graph
+
+    with _DEEPAGENTS_SUMMARIZATION_FACTORY_LOCK:
+        original_factory = deepagents_graph.create_summarization_middleware
+        deepagents_graph.create_summarization_middleware = summarization_factory
+        try:
+            return create_deep_agent(**kwargs)
+        finally:
+            deepagents_graph.create_summarization_middleware = original_factory
 
 
 def build_agent_middleware(
@@ -2674,7 +2747,8 @@ def create_configured_graph(
     else:
         if config.rag_requested and config.rag_error:
             logger.warning("RAG is configured but unavailable: %s", config.rag_error)
-    return create_deep_agent(
+    return create_deep_agent_with_configured_summarization(
+        config,
         model=build_model(config, config.default_reasoning),
         tools=sanitize_tools_for_model(config.model_provider, tools) or None,
         system_prompt=compose_rag_system_prompt(
@@ -2990,7 +3064,8 @@ class AgentRuntime:
                     )
                     for subagent in self.config.extensions.async_subagents
                 )
-                agent = create_deep_agent(
+                agent = create_deep_agent_with_configured_summarization(
+                    self.config,
                     model=model,
                     tools=main_tools or None,
                     system_prompt=compose_rag_system_prompt(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.12"
 dependencies = [
     "asyncpg>=0.30.0",
     "chainlit>=2.8.0",
-    "deepagents>=0.5.0",
+    "deepagents>=0.6.7",
     "langchain-anthropic>=1.3.0",
     "langchain-chroma>=0.2.0",
     "langchain-mcp-adapters>=0.1.9",

--- a/tests/test_deepagent_runtime_rag.py
+++ b/tests/test_deepagent_runtime_rag.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from types import SimpleNamespace
 
 from langchain.agents.middleware.types import ToolCallRequest
+from langchain_core.language_models.fake_chat_models import FakeListChatModel
 from langchain_core.messages import AIMessageChunk, ToolMessage
 from langgraph.checkpoint.memory import MemorySaver
 from langgraph.store.memory import InMemoryStore
@@ -917,11 +918,11 @@ def test_get_agent_includes_rag_tool_when_ready(
     assert any(isinstance(item, ToolExecutionResilienceMiddleware) for item in middleware)
 
 
-def test_get_agent_includes_summarization_middleware_when_enabled(
+def test_get_agent_leaves_summarization_middleware_to_deepagents_when_enabled(
     tmp_path: Path,
     monkeypatch,
 ) -> None:
-    """Verify that get agent includes summarization middleware when enabled.
+    """Verify that get agent does not duplicate DeepAgents summarization middleware.
 
     Args:
         tmp_path: Path to the tmp.
@@ -943,33 +944,7 @@ def test_get_agent_includes_summarization_middleware_when_enabled(
         captured["kwargs"] = kwargs
         return object()
 
-    class FakeSummarizationMiddleware:
-        """Represent fake summarization middleware."""
-
-        def __init__(self, model=None, trigger=None, keep=None, **kwargs) -> None:
-            """Initialize the fake summarization middleware instance.
-
-            Args:
-                model: Model name or model object used by the runtime.
-                trigger: The trigger value.
-                keep: The keep value.
-                kwargs: The kwargs value.
-            """
-            self.model = model
-            self.trigger = trigger
-            self.keep = keep
-            self.kwargs = kwargs
-
     monkeypatch.setattr(deepagent_runtime, "create_deep_agent", fake_create_deep_agent)
-    monkeypatch.setattr(
-        "langchain.agents.middleware.SummarizationMiddleware",
-        FakeSummarizationMiddleware,
-    )
-    monkeypatch.setattr(
-        deepagent_runtime,
-        "build_model",
-        lambda *_args, model_name=None, **_kwargs: f"model::{model_name or 'default'}",
-    )
 
     runtime = AgentRuntime(
         make_runtime_config(
@@ -997,26 +972,62 @@ def test_get_agent_includes_summarization_middleware_when_enabled(
 
     middleware = captured["kwargs"]["middleware"]
     assert any(isinstance(item, ToolExecutionResilienceMiddleware) for item in middleware)
-    summarizers = [
-        item.inner
+    assert not any(
+        isinstance(item, deepagent_runtime.SummarizationStatusMiddleware)
         for item in middleware
-        if isinstance(item, deepagent_runtime.SummarizationStatusMiddleware)
-    ]
-    assert len(summarizers) == 1
-    assert isinstance(summarizers[0], FakeSummarizationMiddleware)
-    assert summarizers[0].model == "model::gpt-oss:20b"
-    assert summarizers[0].trigger == ("tokens", 5000)
-    assert summarizers[0].keep == ("tokens", 2000)
+    )
     subagent_specs = captured["kwargs"]["subagents"]
     subagent_middleware = subagent_specs[0]["middleware"]
-    subagent_summarizers = [
-        item.inner
+    assert any(
+        isinstance(item, ToolExecutionResilienceMiddleware)
         for item in subagent_middleware
-        if isinstance(item, deepagent_runtime.SummarizationStatusMiddleware)
-    ]
-    assert len(subagent_summarizers) == 1
-    assert isinstance(subagent_summarizers[0], FakeSummarizationMiddleware)
-    assert subagent_summarizers[0].model == "model::gpt-oss:120b"
+    )
+    assert not any(
+        isinstance(item, deepagent_runtime.SummarizationStatusMiddleware)
+        for item in subagent_middleware
+    )
+
+
+def test_get_agent_with_summarization_subagent_does_not_duplicate_middleware(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Verify DeepAgents managed summarization does not collide with subagents.
+
+    Args:
+        tmp_path: Path to the tmp.
+        monkeypatch: The monkeypatch value.
+    """
+    monkeypatch.setattr(
+        deepagent_runtime,
+        "build_model",
+        lambda *_args, **_kwargs: FakeListChatModel(responses=["ok"]),
+    )
+
+    runtime = AgentRuntime(
+        make_runtime_config(
+            tmp_path,
+            extensions=ExtensionsConfig(
+                config_path=None,
+                summarization_middleware_enabled=True,
+                summarization_trigger_tokens=5000,
+                summarization_keep_tokens=2000,
+                subagents=(
+                    SubagentConfig(
+                        name="repo-researcher",
+                        description="Researches the repo",
+                        system_prompt="Do research",
+                    ),
+                ),
+            ),
+        )
+    )
+    runtime._store = InMemoryStore()
+    runtime._checkpointer = MemorySaver()
+
+    agent = asyncio.run(runtime.get_agent("medium", thread_id="thread-1"))
+
+    assert agent is not None
 
 
 def test_summarization_status_middleware_emits_stream_events() -> None:

--- a/tests/test_deepagent_runtime_rag.py
+++ b/tests/test_deepagent_runtime_rag.py
@@ -1030,6 +1030,76 @@ def test_get_agent_with_summarization_subagent_does_not_duplicate_middleware(
     assert agent is not None
 
 
+def test_get_agent_applies_configured_deepagents_summarization_thresholds(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Verify configured summarization token thresholds reach DeepAgents.
+
+    Args:
+        tmp_path: Path to the tmp.
+        monkeypatch: The monkeypatch value.
+    """
+    created_summarizers: list[dict[str, object]] = []
+
+    class CapturingSummarizationMiddleware(deepagent_runtime.AgentMiddleware):
+        """Capture summarization construction arguments."""
+
+        @property
+        def name(self) -> str:
+            """Return the public summarization middleware name."""
+            return "SummarizationMiddleware"
+
+        def __init__(self, model, *, backend, trigger=None, keep=None, **kwargs) -> None:
+            """Initialize the fake summarization middleware instance."""
+            created_summarizers.append(
+                {
+                    "model": model,
+                    "backend": backend,
+                    "trigger": trigger,
+                    "keep": keep,
+                    "kwargs": kwargs,
+                }
+            )
+
+    monkeypatch.setattr(
+        "deepagents.middleware.summarization.SummarizationMiddleware",
+        CapturingSummarizationMiddleware,
+    )
+    monkeypatch.setattr(
+        deepagent_runtime,
+        "build_model",
+        lambda *_args, **_kwargs: FakeListChatModel(responses=["ok"]),
+    )
+
+    runtime = AgentRuntime(
+        make_runtime_config(
+            tmp_path,
+            extensions=ExtensionsConfig(
+                config_path=None,
+                summarization_trigger_tokens=5000,
+                summarization_keep_tokens=2000,
+                subagents=(
+                    SubagentConfig(
+                        name="repo-researcher",
+                        description="Researches the repo",
+                        system_prompt="Do research",
+                    ),
+                ),
+            ),
+        )
+    )
+    runtime._store = InMemoryStore()
+    runtime._checkpointer = MemorySaver()
+
+    agent = asyncio.run(runtime.get_agent("medium", thread_id="thread-1"))
+
+    assert agent is not None
+    assert created_summarizers
+    assert {item["trigger"] for item in created_summarizers} == {("tokens", 5000)}
+    assert {item["keep"] for item in created_summarizers} == {("tokens", 2000)}
+
+
 def test_summarization_status_middleware_emits_stream_events() -> None:
     """Verify that summarization status middleware emits stream events."""
     events: list[dict[str, str]] = []

--- a/uv.lock
+++ b/uv.lock
@@ -143,7 +143,7 @@ wheels = [
 
 [[package]]
 name = "anthropic"
-version = "0.95.0"
+version = "0.105.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -155,9 +155,9 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f0/cb/b1896da12f12680c39c90af1b9c9fdf75354899317e2a7900ab37fe3a640/anthropic-0.95.0.tar.gz", hash = "sha256:e4d815351489e5627f39806f12561c52b574e69be10d12fcab723264f955c11d", size = 654528, upload-time = "2026-04-14T19:04:34.114Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/46/47581b8c689c743ceabf6a0f9ff48472160900ce802d26c0fb50423997b3/anthropic-0.105.2.tar.gz", hash = "sha256:0e26b90841c2dced7cc6e98d21d5517d0be33f1876b8e779f478202e28bcaa07", size = 853789, upload-time = "2026-05-29T00:21:14.104Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/64/29/a0285521eeaacf9ff5d0fad2d437389aefa0adf3db79b0e0bda49f809ce9/anthropic-0.95.0-py3-none-any.whl", hash = "sha256:9fd3503cb666446e28ab5a5d0ec7feda39968399e494bd2cca2f0b927f8aa7a6", size = 627749, upload-time = "2026-04-14T19:04:35.549Z" },
+    { url = "https://files.pythonhosted.org/packages/83/75/be0c357e33a5a56c8f9db5b4212f886138d2bf59c0952d858f6b75d710ef/anthropic-0.105.2-py3-none-any.whl", hash = "sha256:e53ed5f6bf36fb1ecb9b25d8634cfd30e02fab9fb3374a0c2d5c585874757230", size = 837507, upload-time = "2026-05-29T00:21:15.528Z" },
 ]
 
 [[package]]
@@ -482,7 +482,7 @@ dependencies = [
 requires-dist = [
     { name = "asyncpg", specifier = ">=0.30.0" },
     { name = "chainlit", specifier = ">=2.8.0" },
-    { name = "deepagents", specifier = ">=0.5.0" },
+    { name = "deepagents", specifier = ">=0.6.7" },
     { name = "langchain-anthropic", specifier = ">=1.3.0" },
     { name = "langchain-chroma", specifier = ">=0.2.0" },
     { name = "langchain-mcp-adapters", specifier = ">=0.1.9" },
@@ -751,7 +751,7 @@ wheels = [
 
 [[package]]
 name = "deepagents"
-version = "0.5.3"
+version = "0.6.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain" },
@@ -761,9 +761,9 @@ dependencies = [
     { name = "langsmith" },
     { name = "wcmatch" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bd/c5/fbf36ff707f7ad4ff2d1590ba8c3b44622370955c74f0c84e4bb1b101d7d/deepagents-0.5.3.tar.gz", hash = "sha256:cbe63bd482c37d3aef883326f5dde70effcd489e67fc91834ffe7a8769796a5f", size = 122654, upload-time = "2026-04-15T13:06:34.875Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/51/bb/bb837a2c51631fe9d7eedf6aca7629ddca6336831801e75efcd2f5fa9c27/deepagents-0.6.7.tar.gz", hash = "sha256:af7b5857b28e29a847a4ced4cc7aaa809d33d42107696b1ca5d978d17e96b831", size = 194236, upload-time = "2026-05-30T04:42:14.591Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/30/8f/40c91a29e4f094e5a1375e33309a3d0ca2e5204816d1dcdcd41ac38410d8/deepagents-0.5.3-py3-none-any.whl", hash = "sha256:f1f1c968f17a5bfb0a6d588d00c2e83264cdac0faa91f7b522892d5a2bd303cb", size = 138475, upload-time = "2026-04-15T13:06:33.593Z" },
+    { url = "https://files.pythonhosted.org/packages/97/25/3a7f23d04778ccb95542f1b1ed39826290916221cc8203d0fb8b26c3edc1/deepagents-0.6.7-py3-none-any.whl", hash = "sha256:3518c1e5f4b9f6588ba39912b668b42b5c864b99a638e94c166d1c7176c7388e", size = 218740, upload-time = "2026-05-30T04:42:13.225Z" },
 ]
 
 [[package]]
@@ -1366,30 +1366,30 @@ wheels = [
 
 [[package]]
 name = "langchain"
-version = "1.2.15"
+version = "1.3.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/98/3f/888a7099d2bd2917f8b0c3ffc7e347f1e664cf64267820b0b923c4f339fc/langchain-1.2.15.tar.gz", hash = "sha256:1717b6719daefae90b2728314a5e2a117ff916291e2862595b6c3d6fba33d652", size = 574732, upload-time = "2026-04-03T14:26:03.994Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d5/d0/c7f9d3d26c0e3f8bb146c6d707ee0fc1d30d8da65a59626e8a580085e929/langchain-1.3.2.tar.gz", hash = "sha256:ffd5f204a46b5fa1a38bf89ba3b45ca0902c02d18fa7d2a2eaeaeb1f5bf19d0a", size = 600598, upload-time = "2026-05-26T18:17:57.715Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3f/e8/a3b8cb0005553f6a876865073c81ef93bd7c5b18381bcb9ba4013af96ebc/langchain-1.2.15-py3-none-any.whl", hash = "sha256:e349db349cb3e9550c4044077cf90a1717691756cc236438404b23500e615874", size = 112714, upload-time = "2026-04-03T14:26:02.557Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/82/a54edcd1c48163de5642eb10fa2cb58b13a8889c659964f63f0306b58b1e/langchain-1.3.2-py3-none-any.whl", hash = "sha256:900f6b3f4ee08b9ba3cdbe667dbf42525bd6f66a4a07a7f1db26262673e41ed6", size = 121225, upload-time = "2026-05-26T18:17:56.075Z" },
 ]
 
 [[package]]
 name = "langchain-anthropic"
-version = "1.4.0"
+version = "1.4.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anthropic" },
     { name = "langchain-core" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/98/c7/259d4d805c6ac90c8695714fc15498a4557bb515eb24f692fd611966e383/langchain_anthropic-1.4.0.tar.gz", hash = "sha256:bbf64e99f9149a34ba67813e9582b2160a0968de9e9f54f7ba8d1658f253c2e5", size = 674360, upload-time = "2026-03-17T18:42:20.751Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/f6/113cf54064b5847367b5a535d80ca2bee34edaea9fddb56ac4466de5e595/langchain_anthropic-1.4.4.tar.gz", hash = "sha256:9ea39ed345f8b13f13bb37549130eedcec2d032eb08b4942642e758c5ba3ece5", size = 687917, upload-time = "2026-05-28T20:20:20.342Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2e/c0/77f99373276d4f06c38a887ef6023f101cfc7ba3b2bf9af37064cdbadde5/langchain_anthropic-1.4.0-py3-none-any.whl", hash = "sha256:c84f55722336935f7574d5771598e674f3959fdca0b51de14c9788dbf52761be", size = 48463, upload-time = "2026-03-17T18:42:19.742Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/e6/d13340529db7fc52ffb1436b18e988df29ebfdd207a2944975136cc82093/langchain_anthropic-1.4.4-py3-none-any.whl", hash = "sha256:10a5d2915e8d4fd8a9f169774e760b089c7f14de044e13259db5f1c2d3d59d9b", size = 51263, upload-time = "2026-05-28T20:20:18.757Z" },
 ]
 
 [[package]]
@@ -1408,7 +1408,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.3.3"
+version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonpatch" },
@@ -1421,9 +1421,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "uuid-utils" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d3/ae/8b74458fc3850ec3d150eb9f45e857db129dafa801fb5cf173dfc9f8bbf3/langchain_core-1.3.3.tar.gz", hash = "sha256:fa510a5db8efdc0c6ff41c0939fb5c00a0183c11f6b84233e892e3227ff69182", size = 915041, upload-time = "2026-05-05T19:02:36.612Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/59/de/679a53472c25860837e32c0442c962fa86e95317a36460e2c9d5c91b17c2/langchain_core-1.4.0.tar.gz", hash = "sha256:1dc341eed802ed9c117c0df3923c991e5e9e226571e5725c194eeb5bd93d1a7f", size = 920260, upload-time = "2026-05-11T18:42:35.919Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1f/01/4771b7ab2af1d1aba5b710bd8f13d9225c609425214b357590a17b01be77/langchain_core-1.3.3-py3-none-any.whl", hash = "sha256:18aae8506f37da7f74398492279a7d6efcee4f8e23c4c41c7af080eeb7ef7bd1", size = 543857, upload-time = "2026-05-05T19:02:34.52Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/1a/86c38c27b81913a1c6c12448cab55defb5a1097c7dc9a4cea83f55477a2d/langchain_core-1.4.0-py3-none-any.whl", hash = "sha256:23cbbdb46e38ddd1dd5247e6167e96013eae74bea4c5949c550809970a9e565c", size = 548120, upload-time = "2026-05-11T18:42:33.992Z" },
 ]
 
 [[package]]
@@ -1508,7 +1508,7 @@ wheels = [
 
 [[package]]
 name = "langgraph"
-version = "1.1.6"
+version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
@@ -1518,22 +1518,22 @@ dependencies = [
     { name = "pydantic" },
     { name = "xxhash" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5c/e5/d3f72ead3c7f15769d5a9c07e373628f1fbaf6cbe7735694d7085859acf6/langgraph-1.1.6.tar.gz", hash = "sha256:1783f764b08a607e9f288dbcf6da61caeb0dd40b337e5c9fb8b412341fbc0b60", size = 549634, upload-time = "2026-04-03T19:01:32.561Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e6/5a/ffc12434ee8aecab830d58b4d204ddea45073eae7639c963310f671a5bf5/langgraph-1.2.2.tar.gz", hash = "sha256:f54a98458976b3ff0774683867df125fb52d8dbedeb2441d0b0656a51331cee5", size = 695730, upload-time = "2026-05-26T18:07:28.49Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/71/e6/b36ecdb3ff4ba9a290708d514bae89ebbe2f554b6abbe4642acf3fddbe51/langgraph-1.1.6-py3-none-any.whl", hash = "sha256:fdbf5f54fa5a5a4c4b09b7b5e537f1b2fa283d2f0f610d3457ddeecb479458b9", size = 169755, upload-time = "2026-04-03T19:01:30.686Z" },
+    { url = "https://files.pythonhosted.org/packages/42/9b/b08d578bba73e25351152dfd3d6d21e81210a5fff1b6f26e56f33197c8f5/langgraph-1.2.2-py3-none-any.whl", hash = "sha256:0a851bf4ba5939c5474a2fd57e6b439b5315283e254e42943bd392c2d71a5e03", size = 236376, upload-time = "2026-05-26T18:07:26.577Z" },
 ]
 
 [[package]]
 name = "langgraph-checkpoint"
-version = "4.0.2"
+version = "4.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "ormsgpack" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2e/f2/cf8086e1f1a3358d9228805614e72602c281b18307f3fae64a5b854aad2d/langgraph_checkpoint-4.0.2.tar.gz", hash = "sha256:4f6f99cba8e272deabf81b2d8cdc96582af07a57a6ad591cdf216bb310497039", size = 160810, upload-time = "2026-04-15T21:03:00.062Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/83/47/886af6f886f0bff2273164a45f008694e48a96ff3cd25ff0228f2aa9480e/langgraph_checkpoint-4.1.1.tar.gz", hash = "sha256:6c2bdb530c91f91d7d9c1bd100925d0fc4f498d418c17f3587d1526279482a25", size = 184020, upload-time = "2026-05-22T16:57:38.503Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b9/5a/6dba29dd89b0a46ae21c707da0f9d17e94f27d3e481ed15bc99d6bd20aa6/langgraph_checkpoint-4.0.2-py3-none-any.whl", hash = "sha256:59b0f29216128a629c58dd07c98aa004f82f51805d5573126ffb419b753ff253", size = 51000, upload-time = "2026-04-15T21:02:59.096Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/b4/71425e3e38be92611300b9cc5e46a5bf98ab23f5ea8a75b73d02a2f1413c/langgraph_checkpoint-4.1.1-py3-none-any.whl", hash = "sha256:25d29144b082827218e7bc3f1e9b0566a4bb007895cd6cc26f66a8428739f56e", size = 56212, upload-time = "2026-05-22T16:57:37.203Z" },
 ]
 
 [[package]]
@@ -1553,15 +1553,15 @@ wheels = [
 
 [[package]]
 name = "langgraph-prebuilt"
-version = "1.0.9"
+version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph-checkpoint" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/99/4c/06dac899f4945bedb0c3a1583c19484c2cc894114ea30d9a538dd270086e/langgraph_prebuilt-1.0.9.tar.gz", hash = "sha256:93de7512e9caade4b77ead92428f6215c521fdb71b8ffda8cd55f0ad814e64de", size = 165850, upload-time = "2026-04-03T14:06:37.721Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/29/66/ed9b93f56bc17ef22d551892f0ac2b225a97fe0fcf23a511b857f70d590b/langgraph_prebuilt-1.1.0.tar.gz", hash = "sha256:3c579cf6eed2d17f9c157c2d0fcaddcd8688524e7022d3b22b37a3bf4589d528", size = 178833, upload-time = "2026-05-12T03:37:49.332Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1d/a2/8368ac187b75e7f9d938ca075d34f116683f5cfc48d924029ee79aea147b/langgraph_prebuilt-1.0.9-py3-none-any.whl", hash = "sha256:776c8e3154a5aef5ad0e5bf3f263f2dcaab3983786cc20014b7f955d99d2d1b2", size = 35958, upload-time = "2026-04-03T14:06:36.58Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/43/3fe1a700b8490ed02679cdbbc8c915eb23a092faf496c9c1118abcd10be3/langgraph_prebuilt-1.1.0-py3-none-any.whl", hash = "sha256:51e311747d755b751d5c6b39b0c1446124d3a7643d2515017e6714b323508fc9", size = 41043, upload-time = "2026-05-12T03:37:48.007Z" },
 ]
 
 [[package]]
@@ -1579,7 +1579,7 @@ wheels = [
 
 [[package]]
 name = "langsmith"
-version = "0.8.0"
+version = "0.8.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -1589,12 +1589,13 @@ dependencies = [
     { name = "requests" },
     { name = "requests-toolbelt" },
     { name = "uuid-utils" },
+    { name = "websockets" },
     { name = "xxhash" },
     { name = "zstandard" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a8/64/95f1f013531395f4e8ed73caeee780f65c7c58fe028cb543f8937b45611b/langsmith-0.8.0.tar.gz", hash = "sha256:59fe5b2a56bbbe14a08aa76691f84b49e8675dd21e11b57d80c6db8c08bac2e3", size = 4432996, upload-time = "2026-04-30T22:13:07.341Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/8a/9c4a27612f08b607fad56c1c093334d61d3e65d6b1783205118deb1da4bd/langsmith-0.8.7.tar.gz", hash = "sha256:1d0f2b4bcfbf26e9e37bf978dfe23e50d4c90bf1a0f26717879d56f941465a85", size = 4467388, upload-time = "2026-05-29T12:40:16.044Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f3/e1/a4be2e696c9473bb53298df398237da5674704d781d4b748ed35aeef592a/langsmith-0.8.0-py3-none-any.whl", hash = "sha256:12cc4bc5622b835a6d841964d6034df3617bdb912dae0c1381fd0a68a9b3a3ef", size = 393268, upload-time = "2026-04-30T22:13:05.56Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/6e/a99e22455925eccb45aa2c5de1c4773309420bcc0ee1f8fec5bb20e70d9d/langsmith-0.8.7-py3-none-any.whl", hash = "sha256:bfc9bd3276c75201edbf85d12367502aed60752e2da720daee46dccb96f0c3cb", size = 402326, upload-time = "2026-05-29T12:40:13.623Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Bump `deepagents` from `0.5.0` to `0.6.7` and refresh the lockfile.
- Stop injecting ChainAgents' legacy summarization middleware, which now duplicates
  the middleware that DeepAgents adds in its own base stack.
- Update the docs and sample config to reflect DeepAgents-owned summarization.
- Add regression coverage for `AgentRuntime.get_agent(...)` with sync subagents.

## Testing
- `uv run pytest` passed (`131 passed`).
- Verified `AgentRuntime.get_agent(...)` now builds a `CompiledStateGraph` instead
  of raising LangChain's duplicate middleware assertion.