### PR TITLE
[codex] fix DeepAgents backend deprecation warning

### DIFF
--- a/deepagent_runtime.py
+++ b/deepagent_runtime.py
@@ -3077,7 +3077,7 @@ class AgentRuntime:
                         rag_enabled=rag_tool_enabled,
                     ),
                     middleware=middleware,
-                    backend=self._build_backend,
+                    backend=build_deepagent_backend(project_root=self.project_root),
                     store=self.store,
                     checkpointer=self.checkpointer,
                     skills=list(self.config.extensions.skills) or None,

--- a/tests/test_deepagent_runtime_rag.py
+++ b/tests/test_deepagent_runtime_rag.py
@@ -918,6 +918,45 @@ def test_get_agent_includes_rag_tool_when_ready(
     assert any(isinstance(item, ToolExecutionResilienceMiddleware) for item in middleware)
 
 
+def test_get_agent_passes_deepagents_backend_instance(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Verify that get agent passes a concrete DeepAgents backend instance.
+
+    Args:
+        tmp_path: Path to the tmp.
+        monkeypatch: The monkeypatch value.
+    """
+    captured: dict[str, object] = {}
+
+    def fake_create_deep_agent(*, tools=None, **kwargs):
+        """Capture Deep Agent factory arguments for tests.
+
+        Args:
+            tools: The tools value.
+            kwargs: The kwargs value.
+
+        Returns:
+            The fake create deep agent result.
+        """
+        captured["kwargs"] = kwargs
+        return object()
+
+    monkeypatch.setattr(deepagent_runtime, "create_deep_agent", fake_create_deep_agent)
+
+    runtime = AgentRuntime(make_runtime_config(tmp_path), project_root=tmp_path)
+    runtime._store = InMemoryStore()
+    runtime._checkpointer = MemorySaver()
+
+    asyncio.run(runtime.get_agent("medium", thread_id="thread-1"))
+
+    backend = captured["kwargs"]["backend"]
+    assert isinstance(backend, deepagent_runtime.CompositeBackend)
+    assert not callable(backend)
+    assert backend.routes["/workspace/"].cwd == tmp_path
+
+
 def test_get_agent_leaves_summarization_middleware_to_deepagents_when_enabled(
     tmp_path: Path,
     monkeypatch,


### PR DESCRIPTION
## Summary

- Pass a concrete `CompositeBackend` instance to DeepAgents when `AgentRuntime` builds the main agent.
- Add regression coverage that asserts `get_agent()` supplies a non-callable backend with the expected workspace route.

## Root Cause

DeepAgents 0.6.7 still accepts callable backend factories, but that path is deprecated and emits a warning from the filesystem middleware. `AgentRuntime.get_agent()` was passing `self._build_backend` instead of the backend instance now expected by DeepAgents.

## Impact

This removes the `LangChainDeprecationWarning` and keeps the app aligned with DeepAgents' upcoming `0.7.0` backend API.

## Validation

- `uv run pytest` (`133 passed`, 1 unrelated Pydantic deprecation warning from `traceloop`)