### PR TITLE
[codex] handle Anthropic thinking blocks as reasoning

### DIFF
--- a/agent_stream_events.py
+++ b/agent_stream_events.py
@@ -25,6 +25,7 @@ LANGGRAPH_STREAM_MODES = {
     "debug",
 }
 SUMMARIZATION_STATUS_KIND = "summarization_status"
+ANTHROPIC_THINKING_BLOCK_TYPES = {"thinking", "redacted_thinking"}
 
 
 @dataclass(frozen=True)
@@ -51,12 +52,23 @@ def stringify_content(value: Any) -> str:
     if isinstance(value, list):
         return "".join(stringify_content(item) for item in value)
     if isinstance(value, dict):
+        if value.get("type") in ANTHROPIC_THINKING_BLOCK_TYPES:
+            return ""
         for key in ("text", "reasoning", "content"):
             nested = value.get(key)
             if isinstance(nested, (str, list, dict)):
                 return stringify_content(nested)
         return json.dumps(value, indent=2, sort_keys=True, ensure_ascii=True)
     return str(value)
+
+
+def anthropic_thinking_text(value: Any) -> str:
+    """Extract Claude thinking text from LangChain Anthropic content blocks."""
+    if isinstance(value, list):
+        return "".join(anthropic_thinking_text(item) for item in value)
+    if not isinstance(value, dict) or value.get("type") != "thinking":
+        return ""
+    return stringify_content(value.get("thinking"))
 
 
 def langgraph_part_from_event_chunk(chunk: Any) -> dict[str, Any] | None:
@@ -104,6 +116,8 @@ def reasoning_text_from_token(token: Any) -> str:
             return text
     if hasattr(token, "reasoning_content"):
         return stringify_content(token.reasoning_content)
+    if hasattr(token, "content"):
+        return anthropic_thinking_text(token.content)
     return ""
 
 
@@ -170,7 +184,9 @@ def message_text(message: Any) -> str:
     return stringify_content(getattr(message, "content", "")).strip()
 
 
-def assistant_messages_for_current_prompt(messages: list[Any], prompt: str) -> list[Any]:
+def assistant_messages_for_current_prompt(
+    messages: list[Any], prompt: str
+) -> list[Any]:
     """Return assistant messages produced after the current prompt began."""
     prompt_text = prompt.strip()
     current_prompt_index = -1
@@ -230,7 +246,9 @@ class AgentStreamEventAdapter:
             return self._events_from_custom_chunk(part)
         return []
 
-    def _events_from_message_chunk(self, part: dict[str, Any]) -> list[AgentStreamEvent]:
+    def _events_from_message_chunk(
+        self, part: dict[str, Any]
+    ) -> list[AgentStreamEvent]:
         token, metadata = part["data"]
         metadata = metadata if isinstance(metadata, dict) else {}
         ns = tuple(part.get("ns", ()))
@@ -311,7 +329,11 @@ class AgentStreamEventAdapter:
         ]
 
     def _response_event(self, source: str, text: str) -> AgentStreamEvent | None:
-        delta = text[len(self.response_buffer) :] if text.startswith(self.response_buffer) else text
+        delta = (
+            text[len(self.response_buffer) :]
+            if text.startswith(self.response_buffer)
+            else text
+        )
         if not delta:
             return None
         self.response_buffer += delta

--- a/chainagents_cli.py
+++ b/chainagents_cli.py
@@ -42,6 +42,7 @@ from rag_runtime import RagStatus, RagUploadResult, UploadedRagFile
 DEFAULT_CLI_THREAD_ID = "cli"
 TOOL_RESULT_PREVIEW_CHARS = 200
 SUMMARIZATION_STATUS_KIND = "summarization_status"
+ANTHROPIC_THINKING_BLOCK_TYPES = {"thinking", "redacted_thinking"}
 LANGGRAPH_STREAM_MODES = {
     "values",
     "updates",
@@ -382,12 +383,30 @@ def stringify_content(value: Any) -> str:
     if isinstance(value, list):
         return "".join(stringify_content(item) for item in value)
     if isinstance(value, dict):
+        if value.get("type") in ANTHROPIC_THINKING_BLOCK_TYPES:
+            return ""
         for key in ("text", "reasoning", "content"):
             nested = value.get(key)
             if isinstance(nested, (str, list, dict)):
                 return stringify_content(nested)
         return json.dumps(value, indent=2, sort_keys=True, ensure_ascii=True)
     return str(value)
+
+
+def anthropic_thinking_text(value: Any) -> str:
+    """Extract Claude thinking text from LangChain Anthropic content blocks.
+
+    Args:
+        value: Message content to inspect.
+
+    Returns:
+        Extracted thinking text, if present.
+    """
+    if isinstance(value, list):
+        return "".join(anthropic_thinking_text(item) for item in value)
+    if not isinstance(value, dict) or value.get("type") != "thinking":
+        return ""
+    return stringify_content(value.get("thinking"))
 
 
 def truncate_tool_result_content(value: Any) -> str:
@@ -488,6 +507,8 @@ def reasoning_text_from_token(token: Any) -> str:
             return text
     if hasattr(token, "reasoning_content"):
         return stringify_content(token.reasoning_content)
+    if hasattr(token, "content"):
+        return anthropic_thinking_text(token.content)
     return ""
 
 

--- a/chainlit_bridge.py
+++ b/chainlit_bridge.py
@@ -67,6 +67,7 @@ def load_auto_collapse_delay_seconds() -> float:
 
 
 AUTO_COLLAPSE_DELAY_SECONDS = load_auto_collapse_delay_seconds()
+ANTHROPIC_THINKING_BLOCK_TYPES = {"thinking", "redacted_thinking"}
 
 
 def stringify_content(value: Any) -> str:
@@ -86,12 +87,30 @@ def stringify_content(value: Any) -> str:
         parts = [stringify_content(item) for item in value]
         return "".join(part for part in parts if part)
     if isinstance(value, dict):
+        if value.get("type") in ANTHROPIC_THINKING_BLOCK_TYPES:
+            return ""
         for key in ("text", "reasoning", "content"):
             nested = value.get(key)
             if isinstance(nested, (str, list, dict)):
                 return stringify_content(nested)
         return json.dumps(value, indent=2, sort_keys=True, ensure_ascii=True)
     return str(value)
+
+
+def anthropic_thinking_text(value: Any) -> str:
+    """Extract Claude thinking text from LangChain Anthropic content blocks.
+
+    Args:
+        value: Message content to inspect.
+
+    Returns:
+        Extracted thinking text, if present.
+    """
+    if isinstance(value, list):
+        return "".join(anthropic_thinking_text(item) for item in value)
+    if not isinstance(value, dict) or value.get("type") != "thinking":
+        return ""
+    return stringify_content(value.get("thinking"))
 
 
 def pretty_data(value: Any) -> str:
@@ -201,6 +220,8 @@ def reasoning_text_from_token(token: Any) -> str:
             return text
     if hasattr(token, "reasoning_content"):
         return stringify_content(token.reasoning_content)
+    if hasattr(token, "content"):
+        return anthropic_thinking_text(token.content)
     return ""
 
 

--- a/deepagent_runtime.py
+++ b/deepagent_runtime.py
@@ -79,6 +79,9 @@ OPENAI_CHAT_COMPLETIONS_PATH_SUFFIX = "/chat/completions"
 OPENAI_RESPONSES_PATH_SUFFIX = "/responses"
 ANTHROPIC_MESSAGES_PATH_SUFFIX = "/v1/messages"
 
+# Anthropic reasoning is not represented by OpenAI-style `delta` keys here.
+# LangChain Anthropic maps Claude `thinking_delta` and `signature_delta` stream
+# events into structured `thinking` content blocks.
 OPENAI_COMPATIBLE_REASONING_DELTA_KEYS = (
     "reasoning_content",
     "reasoning",

--- a/tests/test_agent_cli.py
+++ b/tests/test_agent_cli.py
@@ -538,6 +538,42 @@ class _Token:
         self.content = content
 
 
+class _AnthropicThinkingToken:
+    """Provide an internal helper for Anthropic thinking token."""
+
+    type = "AIMessageChunk"
+    additional_kwargs: dict[str, str] = {}
+    tool_call_chunks: list[dict[str, str]] = []
+
+    def __init__(self, thinking: str) -> None:
+        """Initialize the Anthropic thinking token instance.
+
+        Args:
+            thinking: The thinking delta value.
+        """
+        self.content = [
+            {
+                "type": "thinking",
+                "thinking": thinking,
+                "index": 0,
+            }
+        ]
+
+
+def test_reasoning_text_from_token_extracts_anthropic_thinking_block() -> None:
+    """Verify that Anthropic thinking content blocks are treated as reasoning."""
+    token = _AnthropicThinkingToken("checking Claude reasoning")
+
+    assert chainagents_cli.reasoning_text_from_token(token) == "checking Claude reasoning"
+
+
+def test_stringify_content_omits_anthropic_thinking_block() -> None:
+    """Verify that Anthropic thinking content blocks do not render as answer text."""
+    token = _AnthropicThinkingToken("hidden reasoning")
+
+    assert chainagents_cli.stringify_content(token.content) == ""
+
+
 class _ReasoningToken:
     """Provide an internal helper for reasoning token.
 

--- a/tests/test_agent_stream_events.py
+++ b/tests/test_agent_stream_events.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
-import pytest
 
 from agent_stream_events import AgentStreamEvent, AgentStreamEventAdapter
 
@@ -27,6 +26,15 @@ class _ReasoningToken:
         self.additional_kwargs = {"reasoning_content": reasoning}
 
 
+class _AnthropicThinkingToken:
+    type = "AIMessageChunk"
+    additional_kwargs: dict[str, str] = {}
+    tool_call_chunks: list[dict[str, str]] = []
+
+    def __init__(self, content: object) -> None:
+        self.content = content
+
+
 class _ToolCallChunkToken:
     type = "AIMessageChunk"
     content = ""
@@ -46,7 +54,9 @@ class _ToolMessage:
         self.content = content
 
 
-def _raw_event(chunk: object, *, parent_ids: list[str] | None = None) -> dict[str, object]:
+def _raw_event(
+    chunk: object, *, parent_ids: list[str] | None = None
+) -> dict[str, object]:
     return {
         "event": "on_chain_stream",
         "parent_ids": parent_ids or [],
@@ -87,6 +97,74 @@ def test_adapter_streams_reasoning_deltas_by_source() -> None:
     ]
     assert second == [
         AgentStreamEvent(kind="reasoning_delta", source="main-agent", text=" more")
+    ]
+
+
+def test_adapter_streams_anthropic_thinking_blocks_as_reasoning() -> None:
+    adapter = AgentStreamEventAdapter(prompt="hello")
+
+    events = adapter.events_from_raw_event(
+        _raw_event(
+            (
+                (),
+                "messages",
+                (
+                    _AnthropicThinkingToken(
+                        [
+                            {
+                                "type": "thinking",
+                                "thinking": "checking Claude reasoning",
+                            },
+                            {"type": "redacted_thinking", "data": "signature"},
+                        ]
+                    ),
+                    {},
+                ),
+            )
+        )
+    )
+
+    assert events == [
+        AgentStreamEvent(
+            kind="reasoning_delta",
+            source="main-agent",
+            text="checking Claude reasoning",
+        )
+    ]
+
+
+def test_adapter_omits_anthropic_thinking_blocks_from_response_text() -> None:
+    adapter = AgentStreamEventAdapter(prompt="hello")
+
+    events = adapter.events_from_raw_event(
+        _raw_event(
+            (
+                (),
+                "messages",
+                (
+                    _AnthropicThinkingToken(
+                        [
+                            {"type": "thinking", "thinking": "private reasoning"},
+                            {"type": "text", "text": "Final answer"},
+                        ]
+                    ),
+                    {},
+                ),
+            )
+        )
+    )
+
+    assert events == [
+        AgentStreamEvent(
+            kind="reasoning_delta",
+            source="main-agent",
+            text="private reasoning",
+        ),
+        AgentStreamEvent(
+            kind="response_delta",
+            source="main-agent",
+            text="Final answer",
+        ),
     ]
 
 

--- a/tests/test_chainlit_bridge_streaming.py
+++ b/tests/test_chainlit_bridge_streaming.py
@@ -10,6 +10,42 @@ import chainlit_bridge
 from chainlit_bridge import ChainlitEventBridge, RunTaskList
 
 
+class _AnthropicThinkingToken:
+    """Provide an internal helper for Anthropic thinking token."""
+
+    type = "AIMessageChunk"
+    additional_kwargs: dict[str, str] = {}
+    tool_call_chunks: list[dict[str, str]] = []
+
+    def __init__(self, thinking: str) -> None:
+        """Initialize the Anthropic thinking token instance.
+
+        Args:
+            thinking: The thinking delta value.
+        """
+        self.content = [
+            {
+                "type": "thinking",
+                "thinking": thinking,
+                "index": 0,
+            }
+        ]
+
+
+def test_reasoning_text_from_token_extracts_anthropic_thinking_block() -> None:
+    """Verify that Anthropic thinking content blocks are treated as reasoning."""
+    token = _AnthropicThinkingToken("checking Claude reasoning")
+
+    assert chainlit_bridge.reasoning_text_from_token(token) == "checking Claude reasoning"
+
+
+def test_stringify_content_omits_anthropic_thinking_block() -> None:
+    """Verify that Anthropic thinking content blocks do not render as answer text."""
+    token = _AnthropicThinkingToken("hidden reasoning")
+
+    assert chainlit_bridge.stringify_content(token.content) == ""
+
+
 class _TaskStatus:
     """Provide an internal helper for task status."""
 


### PR DESCRIPTION
## Summary

- Extract LangChain Anthropic `thinking` content blocks as streamed reasoning in Chainlit and CLI output.
- Omit Anthropic `thinking` and `redacted_thinking` blocks from normal assistant text rendering.
- Clarify that the OpenAI-compatible reasoning delta keys do not apply to Anthropic streams.
- Add regression coverage for Anthropic thinking blocks in both Chainlit and CLI helpers.

## Root Cause

The OpenAI-compatible path preserves reasoning through provider-specific `delta` keys such as `reasoning_content`. Anthropic streams are different: LangChain Anthropic maps Claude `thinking_delta` and `signature_delta` events into structured `thinking` content blocks. The existing renderers only checked `additional_kwargs.reasoning_content` and token `reasoning_content`, so Claude thinking blocks were not surfaced as reasoning and could be stringified as normal assistant content.

## Impact

Claude thinking output now goes to the reasoning UI/CLI stream instead of assistant answer text, matching the existing behavior for OpenAI-compatible reasoning deltas.

## Validation

- `uv run pytest` (`137 passed`, 1 unrelated Pydantic deprecation warning from `traceloop`)