### PR TITLE
Prefer Anthropic API key for Claude provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ export CHAINLIT_AUTH_PASSWORD="change-me"
 `DEEPAGENT_MODEL_*` variables are optional:
 
 - they override the matching `[model]` values in `deepagent.toml`
-- `DEEPAGENT_MODEL_API_KEY` is used for secured OpenAI-compatible servers and can also supply the Anthropic API key
-- `ANTHROPIC_API_KEY` is also read when `provider = "anthropic"` or `provider = "claude"`
+- `DEEPAGENT_MODEL_API_KEY` is used for secured OpenAI-compatible servers and can also supply the Anthropic API key when `ANTHROPIC_API_KEY` is unset
+- `ANTHROPIC_API_KEY` is read first when `provider = "anthropic"` or `provider = "claude"`, so stale generic keys do not override the Claude credential
 - `DEEPAGENT_MODEL_DISABLE_STREAMING` accepts `true`, `false`, or `tool_calling`; `DEEPAGENT_MODEL_DISABLE_STREAMING_FOR_TOOL_CALLS=true` is a convenience alias for `tool_calling`
 - `OLLAMA_BASE_URL`, `OLLAMA_MODEL`, and `OLLAMA_REASONING` remain supported as Ollama-only compatibility aliases
 
@@ -255,7 +255,7 @@ Notes:
 - `endpoint_url` is an override for full non-standard model endpoint URLs. OpenAI-compatible paths ending in `/chat/completions` or `/responses` are normalized to the client base URL and query parameters are forwarded as OpenAI client default query parameters. Anthropic paths ending in `/v1/messages` are normalized to the Claude client base URL.
 - `models` is an optional list of model IDs surfaced in Chainlit settings and modes so users can switch models per session or per message.
 - `api_key` is optional for `provider = "openai_compatible"`; when omitted, the runtime sends a placeholder token that local servers like LM Studio accept.
-- Anthropic requires an API key from `api_key`, `DEEPAGENT_MODEL_API_KEY`, or `ANTHROPIC_API_KEY`.
+- Anthropic requires an API key from `ANTHROPIC_API_KEY`, `DEEPAGENT_MODEL_API_KEY`, or `api_key`; when multiple are set, `ANTHROPIC_API_KEY` takes precedence over the generic key.
 - Legacy Ollama `endpoint` and `port` are still accepted when `provider = "ollama"` or omitted.
 - `reasoning_effort` sets the default Chainlit reasoning level for new chats. Ollama uses that level directly, Anthropic maps it to Claude `effort`, and OpenAI-compatible servers may ignore it.
 - `DEEPAGENT_MODEL_PROVIDER`, `DEEPAGENT_MODEL_BASE_URL`, `DEEPAGENT_MODEL_ENDPOINT_URL`, `DEEPAGENT_MODEL_NAME`, `DEEPAGENT_MODEL_API_KEY`, `DEEPAGENT_MODEL_REASONING`, `DEEPAGENT_MODEL_DISABLE_STREAMING`, and `DEEPAGENT_MODEL_DISABLE_STREAMING_FOR_TOOL_CALLS` override the TOML defaults when set.

--- a/deepagent_runtime.py
+++ b/deepagent_runtime.py
@@ -2281,13 +2281,14 @@ class RuntimeConfig:
         if overrides.model_api_key is not None:
             model_api_key = normalize_optional_string(overrides.model_api_key)
         else:
+            provider_specific_api_key = (
+                normalize_optional_string(os.getenv("ANTHROPIC_API_KEY"))
+                if model_provider == "anthropic"
+                else None
+            )
             model_api_key = (
-                normalize_optional_string(os.getenv("DEEPAGENT_MODEL_API_KEY"))
-                or (
-                    normalize_optional_string(os.getenv("ANTHROPIC_API_KEY"))
-                    if model_provider == "anthropic"
-                    else None
-                )
+                provider_specific_api_key
+                or normalize_optional_string(os.getenv("DEEPAGENT_MODEL_API_KEY"))
                 or model_defaults.api_key
             )
         if model_provider == "anthropic" and not model_api_key:

--- a/tests/test_deepagent_runtime_rag.py
+++ b/tests/test_deepagent_runtime_rag.py
@@ -485,6 +485,37 @@ api_key = "toml-key"
     assert model.anthropic_api_url == "https://claude-proxy.example/anthropic"
 
 
+def test_runtime_config_prefers_anthropic_api_key_for_anthropic_provider(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Verify Anthropic uses its provider-specific key before generic keys.
+
+    Args:
+        tmp_path: Path to the tmp.
+        monkeypatch: The monkeypatch value.
+    """
+    config_path = tmp_path / "deepagent.toml"
+    config_path.write_text(
+        """
+[model]
+provider = "anthropic"
+name = "claude-sonnet-4-6"
+api_key = "toml-key"
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DEEPAGENT_CONFIG", str(config_path))
+    monkeypatch.setenv("DEEPAGENT_MODEL_API_KEY", "generic-key")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "anthropic-key")
+
+    config = deepagent_runtime.RuntimeConfig.from_env()
+    model = deepagent_runtime.build_model(config, "medium")
+
+    assert config.model_api_key == "anthropic-key"
+    assert model.anthropic_api_key.get_secret_value() == "anthropic-key"
+
+
 def test_runtime_config_switches_to_anthropic_without_base_url_override(
     tmp_path: Path,
     monkeypatch,


### PR DESCRIPTION
### Motivation
- Anthropic/Claude runs could fail with 401s when a stale generic `DEEPAGENT_MODEL_API_KEY` was chosen before a provider-specific `ANTHROPIC_API_KEY` during runtime configuration.
- Make the runtime resolve Anthropic credentials in a safer, provider-aware order to avoid accidental use of the wrong key.

### Description
- Change `RuntimeConfig.from_env` to prefer `ANTHROPIC_API_KEY` when `model_provider == "anthropic"` before falling back to `DEEPAGENT_MODEL_API_KEY` or `[model].api_key` in `deepagent_runtime.py`.
- Add `test_runtime_config_prefers_anthropic_api_key_for_anthropic_provider` to `tests/test_deepagent_runtime_rag.py` to assert provider-specific key precedence.
- Update `README.md` to document that `ANTHROPIC_API_KEY` is read first for Anthropic/Claude and that `DEEPAGENT_MODEL_API_KEY` is used only when the provider-specific key is unset.

### Testing
- Ran the targeted tests: `uv run pytest tests/test_deepagent_runtime_rag.py -k 'anthropic_api_key or anthropic_model or anthropic_endpoint or switches_to_anthropic'`, which passed (6 passed).
- Ran the full test suite: `uv run pytest`, which succeeded (140 passed, 1 warning).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f31e151388324b88c3cf82f8bbb2b)