### PR TITLE
Fix Anthropic provider config handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ Notes:
 - Preferred shared fields are `base_url`, `name`, `temperature`, and `reasoning_effort`.
 - `repeat_penalty` is optional and currently applies to `provider = "ollama"`; when omitted, Ollama defaults are used.
 - `disable_streaming = "tool_calling"` or `disable_streaming_for_tool_calls = true` bypasses model streaming only when tools are attached to the request; use this for providers that have trouble streaming tool-call chunks. `disable_streaming = true` disables model streaming for all requests.
-- `endpoint_url` is an override for full non-standard model endpoint URLs. OpenAI-compatible paths ending in `/chat/completions` or `/responses` are normalized to the client base URL and query parameters are forwarded as OpenAI client default query parameters. Anthropic paths ending in `/v1/messages` are normalized to the Claude client base URL.
+- `endpoint_url` is an override for full non-standard model endpoint URLs. OpenAI-compatible paths ending in `/chat/completions` or `/responses` are normalized to the client base URL and query parameters are forwarded as OpenAI client default query parameters. Anthropic paths ending in `/v1/messages` are normalized to the Claude client base URL and query parameters are forwarded as Anthropic client default query parameters.
 - `models` is an optional list of model IDs surfaced in Chainlit settings and modes so users can switch models per session or per message.
 - `api_key` is optional for `provider = "openai_compatible"`; when omitted, the runtime sends a placeholder token that local servers like LM Studio accept.
 - Anthropic requires an API key from `ANTHROPIC_API_KEY`, `DEEPAGENT_MODEL_API_KEY`, or `api_key`; when multiple are set, `ANTHROPIC_API_KEY` takes precedence over the generic key.

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ export CHAINLIT_AUTH_PASSWORD="change-me"
 - they override the matching `[model]` values in `deepagent.toml`
 - `DEEPAGENT_MODEL_API_KEY` is used for secured OpenAI-compatible servers and can also supply the Anthropic API key when `ANTHROPIC_API_KEY` is unset
 - `ANTHROPIC_API_KEY` is read first when `provider = "anthropic"` or `provider = "claude"`, so stale generic keys do not override the Claude credential
-- when switching to Anthropic with `DEEPAGENT_MODEL_PROVIDER`, unset stale `DEEPAGENT_MODEL_BASE_URL`; use `DEEPAGENT_MODEL_ENDPOINT_URL` with the `/v1/messages` path for Anthropic proxies
+- when switching to Anthropic with `DEEPAGENT_MODEL_PROVIDER`, unset stale `DEEPAGENT_MODEL_BASE_URL`; use `DEEPAGENT_MODEL_ENDPOINT_URL` with the `/v1/messages` path for env-based Anthropic proxy switches, or pass `--base-url` explicitly from the CLI
 - `DEEPAGENT_MODEL_DISABLE_STREAMING` accepts `true`, `false`, or `tool_calling`; `DEEPAGENT_MODEL_DISABLE_STREAMING_FOR_TOOL_CALLS=true` is a convenience alias for `tool_calling`
 - `OLLAMA_BASE_URL`, `OLLAMA_MODEL`, and `OLLAMA_REASONING` remain supported as Ollama-only compatibility aliases
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ export CHAINLIT_AUTH_PASSWORD="change-me"
 - they override the matching `[model]` values in `deepagent.toml`
 - `DEEPAGENT_MODEL_API_KEY` is used for secured OpenAI-compatible servers and can also supply the Anthropic API key when `ANTHROPIC_API_KEY` is unset
 - `ANTHROPIC_API_KEY` is read first when `provider = "anthropic"` or `provider = "claude"`, so stale generic keys do not override the Claude credential
+- when switching to Anthropic with `DEEPAGENT_MODEL_PROVIDER`, unset stale `DEEPAGENT_MODEL_BASE_URL`; use `DEEPAGENT_MODEL_ENDPOINT_URL` with the `/v1/messages` path for Anthropic proxies
 - `DEEPAGENT_MODEL_DISABLE_STREAMING` accepts `true`, `false`, or `tool_calling`; `DEEPAGENT_MODEL_DISABLE_STREAMING_FOR_TOOL_CALLS=true` is a convenience alias for `tool_calling`
 - `OLLAMA_BASE_URL`, `OLLAMA_MODEL`, and `OLLAMA_REASONING` remain supported as Ollama-only compatibility aliases
 
@@ -276,6 +277,7 @@ Notes:
 - `models` is an optional list of model IDs surfaced in Chainlit settings and modes so users can switch models per session or per message.
 - `api_key` is optional for `provider = "openai_compatible"`; when omitted, the runtime sends a placeholder token that local servers like LM Studio accept.
 - Anthropic requires an API key from `ANTHROPIC_API_KEY`, `DEEPAGENT_MODEL_API_KEY`, or `api_key`; when multiple are set, `ANTHROPIC_API_KEY` takes precedence over the generic key.
+- When switching from another provider to Anthropic through environment or CLI overrides, provide Anthropic credentials through `ANTHROPIC_API_KEY`, `DEEPAGENT_MODEL_API_KEY`, or `--api-key`; the runtime will not reuse an `api_key` from another provider's TOML config.
 - Legacy Ollama `endpoint` and `port` are still accepted when `provider = "ollama"` or omitted.
 - `reasoning_effort` sets the default Chainlit reasoning level for new chats. Ollama uses that level directly, Anthropic maps it to Claude `effort`, and OpenAI-compatible servers may ignore it.
 - `DEEPAGENT_MODEL_PROVIDER`, `DEEPAGENT_MODEL_BASE_URL`, `DEEPAGENT_MODEL_ENDPOINT_URL`, `DEEPAGENT_MODEL_NAME`, `DEEPAGENT_MODEL_API_KEY`, `DEEPAGENT_MODEL_REASONING`, `DEEPAGENT_MODEL_DISABLE_STREAMING`, and `DEEPAGENT_MODEL_DISABLE_STREAMING_FOR_TOOL_CALLS` override the TOML defaults when set.

--- a/deepagent_runtime.py
+++ b/deepagent_runtime.py
@@ -536,7 +536,7 @@ def normalize_anthropic_endpoint_url(
     if path.endswith(ANTHROPIC_MESSAGES_PATH_SUFFIX):
         path = path[: -len(ANTHROPIC_MESSAGES_PATH_SUFFIX)].rstrip("/")
 
-    return urlunsplit((parsed.scheme, parsed.netloc, path, "", "")).rstrip("/")
+    return urlunsplit((parsed.scheme, parsed.netloc, path, parsed.query, "")).rstrip("/")
 
 
 def model_endpoint_query_to_dict(
@@ -2217,6 +2217,19 @@ class RuntimeConfig:
             )
 
         if (
+            provider_changed
+            and model_provider == "anthropic"
+            and generic_model_base_url
+            and not generic_model_endpoint_url
+        ):
+            raise ValueError(
+                "Switching model providers to Anthropic with a model base URL "
+                "override is ambiguous. Use DEEPAGENT_MODEL_ENDPOINT_URL or "
+                "--endpoint-url with the Anthropic /v1/messages path for proxy "
+                "endpoints, or remove stale DEEPAGENT_MODEL_BASE_URL."
+            )
+
+        if (
             model_provider == "openai_compatible"
             and not generic_model_name
             and not model_defaults.name_is_explicit
@@ -2286,10 +2299,15 @@ class RuntimeConfig:
                 if model_provider == "anthropic"
                 else None
             )
+            model_default_api_key = (
+                model_defaults.api_key
+                if model_defaults.provider == model_provider
+                else None
+            )
             model_api_key = (
                 provider_specific_api_key
                 or normalize_optional_string(os.getenv("DEEPAGENT_MODEL_API_KEY"))
-                or model_defaults.api_key
+                or model_default_api_key
             )
         if model_provider == "anthropic" and not model_api_key:
             raise ValueError(

--- a/deepagent_runtime.py
+++ b/deepagent_runtime.py
@@ -13,6 +13,7 @@ import tomllib
 from collections.abc import Awaitable, Callable
 from contextlib import AsyncExitStack
 from dataclasses import dataclass
+from functools import cached_property
 from pathlib import Path, PurePosixPath
 from typing import Any, Literal
 from urllib.parse import parse_qsl, urlsplit, urlunsplit
@@ -330,6 +331,20 @@ class OpenAICompatibleChatOpenAI(ChatOpenAI):
         return generation_chunk
 
 
+class AnthropicDefaultQueryChatAnthropic(ChatAnthropic):
+    """ChatAnthropic variant that forwards endpoint query params to the SDK."""
+
+    default_query: dict[str, object] | None = None
+
+    @cached_property
+    def _client_params(self) -> dict[str, Any]:
+        """Return Anthropic client params with optional default query values."""
+        params = super()._client_params.copy()
+        if self.default_query:
+            params["default_query"] = self.default_query
+        return params
+
+
 def normalize_model_endpoint(value: str | None) -> str:
     """Normalize model endpoint.
 
@@ -517,7 +532,7 @@ def normalize_anthropic_endpoint_url(
     value: Any | None,
     *,
     required_message: str | None = None,
-) -> str:
+) -> tuple[str, tuple[tuple[str, str], ...]]:
     """Normalize Anthropic endpoint URL to the API base URL.
 
     Args:
@@ -525,7 +540,7 @@ def normalize_anthropic_endpoint_url(
         required_message: The required message value.
 
     Returns:
-        The normalized Anthropic API base URL.
+        The normalized Anthropic API base URL and query params.
     """
     candidate = normalize_model_base_url(
         value,
@@ -536,7 +551,8 @@ def normalize_anthropic_endpoint_url(
     if path.endswith(ANTHROPIC_MESSAGES_PATH_SUFFIX):
         path = path[: -len(ANTHROPIC_MESSAGES_PATH_SUFFIX)].rstrip("/")
 
-    return urlunsplit((parsed.scheme, parsed.netloc, path, parsed.query, "")).rstrip("/")
+    base_url = urlunsplit((parsed.scheme, parsed.netloc, path, "", "")).rstrip("/")
+    return base_url, tuple(parse_qsl(parsed.query, keep_blank_values=True))
 
 
 def model_endpoint_query_to_dict(
@@ -1569,7 +1585,7 @@ def parse_model_defaults(raw_config: dict[str, Any]) -> ModelDefaults:
             )
     else:
         if normalize_optional_string(raw_endpoint_url):
-            base_url = normalize_anthropic_endpoint_url(raw_endpoint_url)
+            base_url, endpoint_query = normalize_anthropic_endpoint_url(raw_endpoint_url)
         else:
             base_url = normalize_model_base_url(
                 raw_model.get("base_url"),
@@ -2260,7 +2276,7 @@ class RuntimeConfig:
         model_endpoint_query = model_defaults.endpoint_query
         if model_provider == "anthropic":
             if generic_model_endpoint_url:
-                model_base_url = normalize_anthropic_endpoint_url(
+                model_base_url, model_endpoint_query = normalize_anthropic_endpoint_url(
                     generic_model_endpoint_url,
                     required_message="The Anthropic model endpoint URL cannot be empty.",
                 )
@@ -2276,7 +2292,11 @@ class RuntimeConfig:
                     ),
                     default=DEFAULT_ANTHROPIC_BASE_URL,
                 )
-            model_endpoint_query = ()
+                model_endpoint_query = (
+                    model_defaults.endpoint_query
+                    if model_defaults.provider == "anthropic"
+                    else ()
+                )
         elif model_provider == "openai_compatible" and generic_model_endpoint_url:
             model_base_url, model_endpoint_query = normalize_openai_endpoint_url(
                 generic_model_endpoint_url,
@@ -2414,7 +2434,7 @@ def build_model(
         return ChatOllama(**kwargs)
 
     if config.model_provider == "anthropic":
-        kwargs = {
+        kwargs: dict[str, Any] = {
             "model": selected_model,
             "base_url": config.model_base_url,
             "temperature": config.model_temperature,
@@ -2423,6 +2443,10 @@ def build_model(
         }
         if config.model_api_key:
             kwargs["api_key"] = config.model_api_key
+        default_query = model_endpoint_query_to_dict(config.model_endpoint_query)
+        if default_query:
+            kwargs["default_query"] = default_query
+            return AnthropicDefaultQueryChatAnthropic(**kwargs)
         return ChatAnthropic(**kwargs)
 
     kwargs: dict[str, Any] = {

--- a/deepagent_runtime.py
+++ b/deepagent_runtime.py
@@ -2180,9 +2180,13 @@ class RuntimeConfig:
             normalize_optional_string(overrides.model_name)
             or os.getenv("DEEPAGENT_MODEL_NAME", "").strip()
         )
-        generic_model_base_url = (
-            normalize_optional_string(overrides.model_base_url)
-            or os.getenv("DEEPAGENT_MODEL_BASE_URL", "").strip()
+        override_model_base_url = normalize_optional_string(overrides.model_base_url)
+        env_model_base_url = normalize_optional_string(
+            os.getenv("DEEPAGENT_MODEL_BASE_URL")
+        )
+        generic_model_base_url = override_model_base_url or env_model_base_url or ""
+        generic_model_base_url_from_env = (
+            override_model_base_url is None and env_model_base_url is not None
         )
         generic_model_endpoint_url = (
             normalize_optional_string(overrides.model_endpoint_url)
@@ -2236,13 +2240,15 @@ class RuntimeConfig:
             provider_changed
             and model_provider == "anthropic"
             and generic_model_base_url
+            and generic_model_base_url_from_env
             and not generic_model_endpoint_url
         ):
             raise ValueError(
-                "Switching model providers to Anthropic with a model base URL "
-                "override is ambiguous. Use DEEPAGENT_MODEL_ENDPOINT_URL or "
-                "--endpoint-url with the Anthropic /v1/messages path for proxy "
-                "endpoints, or remove stale DEEPAGENT_MODEL_BASE_URL."
+                "Switching model providers to Anthropic with "
+                "DEEPAGENT_MODEL_BASE_URL is ambiguous. Remove stale "
+                "DEEPAGENT_MODEL_BASE_URL, pass --base-url explicitly, or use "
+                "DEEPAGENT_MODEL_ENDPOINT_URL or --endpoint-url with the "
+                "Anthropic /v1/messages path for proxy endpoints."
             )
 
         if (

--- a/tests/test_deepagent_runtime_rag.py
+++ b/tests/test_deepagent_runtime_rag.py
@@ -672,9 +672,11 @@ api_key = "toml-key"
     config = deepagent_runtime.RuntimeConfig.from_env()
     model = deepagent_runtime.build_model(config, "medium")
 
-    expected_url = "https://claude-proxy.example/anthropic?route=claude&token=abc"
-    assert config.model_base_url == expected_url
-    assert model.anthropic_api_url == expected_url
+    assert config.model_base_url == "https://claude-proxy.example/anthropic"
+    assert config.model_endpoint_query == (("route", "claude"), ("token", "abc"))
+    assert model.anthropic_api_url == "https://claude-proxy.example/anthropic"
+    assert model._client.default_query == {"route": "claude", "token": "abc"}
+    assert model._async_client.default_query == {"route": "claude", "token": "abc"}
 
 
 def test_runtime_config_requires_anthropic_model_name_when_switching_providers(

--- a/tests/test_deepagent_runtime_rag.py
+++ b/tests/test_deepagent_runtime_rag.py
@@ -585,6 +585,98 @@ name = "local-model"
     assert config.model_base_url == "https://claude-proxy.example/proxy"
 
 
+def test_runtime_config_rejects_non_anthropic_toml_key_for_anthropic_switch(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Verify Anthropic provider switches do not reuse another provider's key.
+
+    Args:
+        tmp_path: Path to the tmp.
+        monkeypatch: The monkeypatch value.
+    """
+    config_path = tmp_path / "deepagent.toml"
+    config_path.write_text(
+        """
+[model]
+provider = "openai_compatible"
+base_url = "https://api.openai.example/v1"
+name = "openai-model"
+api_key = "openai-key"
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DEEPAGENT_CONFIG", str(config_path))
+    monkeypatch.setenv("DEEPAGENT_MODEL_PROVIDER", "anthropic")
+    monkeypatch.setenv("DEEPAGENT_MODEL_NAME", "claude-opus-4-8")
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("DEEPAGENT_MODEL_API_KEY", raising=False)
+
+    with pytest.raises(ValueError, match="ANTHROPIC_API_KEY"):
+        deepagent_runtime.RuntimeConfig.from_env()
+
+
+def test_runtime_config_rejects_stale_base_url_for_anthropic_switch(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Verify Anthropic provider switches do not inherit generic stale base URLs.
+
+    Args:
+        tmp_path: Path to the tmp.
+        monkeypatch: The monkeypatch value.
+    """
+    config_path = tmp_path / "deepagent.toml"
+    config_path.write_text(
+        """
+[model]
+provider = "ollama"
+base_url = "http://127.0.0.1:11434"
+name = "local-model"
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DEEPAGENT_CONFIG", str(config_path))
+    monkeypatch.setenv("DEEPAGENT_MODEL_PROVIDER", "anthropic")
+    monkeypatch.setenv("DEEPAGENT_MODEL_NAME", "claude-opus-4-8")
+    monkeypatch.setenv("DEEPAGENT_MODEL_BASE_URL", "https://api.openai.example/v1")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "env-key")
+
+    with pytest.raises(ValueError, match="DEEPAGENT_MODEL_ENDPOINT_URL"):
+        deepagent_runtime.RuntimeConfig.from_env()
+
+
+def test_runtime_config_preserves_anthropic_endpoint_query_params(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Verify Anthropic endpoint URL query params remain available to proxies.
+
+    Args:
+        tmp_path: Path to the tmp.
+        monkeypatch: The monkeypatch value.
+    """
+    config_path = tmp_path / "deepagent.toml"
+    config_path.write_text(
+        """
+[model]
+provider = "anthropic"
+endpoint_url = "https://claude-proxy.example/anthropic/v1/messages?route=claude&token=abc"
+name = "claude-sonnet-4-6"
+api_key = "toml-key"
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DEEPAGENT_CONFIG", str(config_path))
+
+    config = deepagent_runtime.RuntimeConfig.from_env()
+    model = deepagent_runtime.build_model(config, "medium")
+
+    expected_url = "https://claude-proxy.example/anthropic?route=claude&token=abc"
+    assert config.model_base_url == expected_url
+    assert model.anthropic_api_url == expected_url
+
+
 def test_runtime_config_requires_anthropic_model_name_when_switching_providers(
     tmp_path: Path,
     monkeypatch,

--- a/tests/test_deepagent_runtime_rag.py
+++ b/tests/test_deepagent_runtime_rag.py
@@ -646,6 +646,42 @@ name = "local-model"
         deepagent_runtime.RuntimeConfig.from_env()
 
 
+def test_runtime_config_allows_cli_base_url_for_anthropic_switch(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Verify explicit CLI base URL overrides work for Anthropic switches.
+
+    Args:
+        tmp_path: Path to the tmp.
+        monkeypatch: The monkeypatch value.
+    """
+    config_path = tmp_path / "deepagent.toml"
+    config_path.write_text(
+        """
+[model]
+provider = "ollama"
+base_url = "http://127.0.0.1:11434"
+name = "local-model"
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DEEPAGENT_CONFIG", str(config_path))
+
+    config = deepagent_runtime.RuntimeConfig.from_env(
+        deepagent_runtime.RuntimeConfigOverrides(
+            model_provider="anthropic",
+            model_base_url="https://corp-proxy.example",
+            model_name="claude-opus-4-8",
+            model_api_key="cli-key",
+        )
+    )
+
+    assert config.model_provider == "anthropic"
+    assert config.model_base_url == "https://corp-proxy.example"
+    assert config.model_api_key == "cli-key"
+
+
 def test_runtime_config_preserves_anthropic_endpoint_query_params(
     tmp_path: Path,
     monkeypatch,


### PR DESCRIPTION
## Summary
- prevent Anthropic switches from reusing stale TOML API keys from other providers
- reject ambiguous stale `DEEPAGENT_MODEL_BASE_URL` when switching to Anthropic
- preserve query parameters on Anthropic `/v1/messages` proxy endpoints
- add regression tests for the Anthropic config and endpoint cases

## Testing
- `uv run pytest tests/test_deepagent_runtime_rag.py -k anthropic -q`
- `uv run pytest -q`