### PR TITLE
Add QUICKSTART.md: first-time user guide

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -1,0 +1,194 @@
+# Quick Start Guide
+
+A friendly introduction to ChainAgents. If you're looking for the full documentation, see [README.md](README.md).
+
+## What is this?
+
+ChainAgents is a local-first LangChain DeepAgent project that powers a highly configurable AI assistant. You can interact with it through:
+
+- **Chainlit UI** — a web-based chat interface
+- **CLI** — terminal-based command-line interface
+- **TUI** — a full-screen terminal UI with Markdown formatting
+
+Everything runs locally on your machine by default.
+
+## Prerequisites
+
+- **Python 3.12+**
+- **[uv](https://github.com/astral-sh/uv)** — the fast Python package installer
+- **[Ollama](https://ollama.com)** (optional, for running models locally)
+- **[Docker](https://www.docker.com)** (optional, for Postgres persistence)
+
+## 5-Minute Setup
+
+### 1. Clone and install
+
+```bash
+git clone git@github.com:AminMahPour/ChainAgents.git
+cd ChainAgents
+uv sync
+```
+
+### 2. Pick a model provider
+
+**Option A: Ollama (local, free)**
+
+```bash
+ollama install   # if not already installed
+ollama pull gpt-oss:20b
+```
+
+**Option B: LM Studio (local, OpenAI-compatible)**
+
+1. Download [LM Studio](https://lmstudio.ai/) and load a model
+2. Start its local server (usually on `http://localhost:1234`)
+3. Skip the `ollama pull` step below
+
+**Option C: OpenAI or Anthropic (cloud)**
+
+Set your API key:
+
+```bash
+export DEEPAGENT_MODEL_API_KEY="your-openai-key"
+# or
+export ANTHROPIC_API_KEY="your-anthropic-key"
+```
+
+### 3. Run the app
+
+```bash
+chainlit run main.py -w
+```
+
+Open your browser at `http://localhost:8000`. You should see a "Workspace agent ready" message.
+
+## Your First Chat
+
+Try one of these prompts:
+
+- `"Summarize this repository"`
+- `"What does this project do?"`
+- `"Tell me about the available skills"`
+
+## Choosing a Model Provider
+
+| Provider | Cost | Speed | Privacy | Setup |
+|---|---|---|---|---|
+| **Ollama** | Free | Depends on hardware | Full privacy | `ollama pull <model>` |
+| **LM Studio** | Free | Depends on hardware | Full privacy | Start local server |
+| **OpenAI** | Pay-per-token | Fast | Data sent to OpenAI | Set `DEEPAGENT_MODEL_API_KEY` |
+| **Anthropic** | Pay-per-token | Fast | Data sent to Anthropic | Set `ANTHROPIC_API_KEY` |
+
+To switch providers, edit `deepagent.toml`:
+
+```toml
+[model]
+provider = "ollama"        # or "openai_compatible" or "anthropic"
+name = "gpt-oss:20b"       # change model name
+base_url = "http://127.0.0.1:11434"   # for Ollama or LM Studio
+```
+
+Then restart the app.
+
+## Common Next Steps
+
+### Enable RAG (document search)
+
+Edit `deepagent.toml`:
+
+```toml
+[rag]
+enabled = true
+include_globs = ["README.md", "prompts/**/*.md", "skills/**/*.md"]
+```
+
+### Add a Skill
+
+1. Create a folder: `mkdir -p skills/my-skill`
+2. Add `SKILL.md`:
+
+```markdown
+---
+name: my-skill
+description: Use this skill when you need to do X.
+---
+
+# my-skill
+
+When asked to do something:
+1. First step...
+2. Second step...
+```
+
+3. Add to `deepagent.toml`:
+
+```toml
+[agent]
+skills = ["skills"]
+```
+
+### Use Postgres for Chat History
+
+```bash
+docker compose up -d postgres
+export DATABASE_URL="postgresql://chainagents:chainagents@127.0.0.1:5432/chainagents?sslmode=disable"
+```
+
+### Enable Authentication
+
+```bash
+export CHAINLIT_AUTH_SECRET="a-long-random-string"
+export CHAINLIT_AUTH_USERNAME="admin"
+export CHAINLIT_AUTH_PASSWORD="change-me"
+```
+
+With both `DATABASE_URL` and auth set, you get sign-in and chat history in the UI.
+
+## CLI Quick Reference
+
+```bash
+# Chat without the UI
+uv run chainagents --prompt "Hello, agent!"
+
+# Terminal TUI
+uv run chainagents --tui
+
+# Check agent status
+uv run chainagents --status
+
+# List available commands
+uv run chainagents --list-commands
+
+# Delegate to a subagent
+uv run chainagents --command ask-researcher --prompt "Research this topic"
+```
+
+Run `uv run chainagents --help` for all options.
+
+## Troubleshooting
+
+### "Model not found" or connection errors
+
+- For Ollama: run `ollama list` to see installed models, and `ollama serve` to ensure it's running.
+- For LM Studio: verify the local server is running and update `base_url` in `deepagent.toml`.
+- For cloud providers: check that your API key is set and valid.
+
+### Chainlit history doesn't appear
+
+Make sure both `DATABASE_URL` and all three `CHAINLIT_AUTH_*` variables are set.
+
+### RAG says "not ready" on startup
+
+Make sure the embedding model is available. For Ollama: `ollama pull nomic-embed-text`.
+
+### The app crashes on startup
+
+Check that `deepagent.toml` exists and is valid TOML. If it's missing, the app falls back to built-in defaults but may not load any skills or MCP servers.
+
+## Where to Go Next
+
+- [README.md](README.md) — Full feature documentation
+- [deepagent.toml.example](deepagent.toml.example) — Complete config reference
+- [skills/](skills/) — Example skill definitions
+- [prompts/](prompts/) — Subagent prompt templates
+- [AGENTS.md](AGENTS.md) — Developer notes for this repo

--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ temperature = 0
 name = "claude-sonnet-4-6"
 models = ["claude-sonnet-4-6", "claude-opus-4-8", "claude-haiku-4-5-20251001"]
 reasoning_effort = "medium"
+thinking = "auto"
 # api_key = "optional-if-ANTHROPIC_API_KEY-or-DEEPAGENT_MODEL_API_KEY-is-set"
 # base_url = "https://api.anthropic.com"
 # endpoint_url = "https://claude-proxy.example/proxy/v1/messages"
@@ -280,6 +281,7 @@ Notes:
 - When switching from another provider to Anthropic through environment or CLI overrides, provide Anthropic credentials through `ANTHROPIC_API_KEY`, `DEEPAGENT_MODEL_API_KEY`, or `--api-key`; the runtime will not reuse an `api_key` from another provider's TOML config.
 - Legacy Ollama `endpoint` and `port` are still accepted when `provider = "ollama"` or omitted.
 - `reasoning_effort` sets the default Chainlit reasoning level for new chats. Ollama uses that level directly, Anthropic maps it to Claude `effort`, and OpenAI-compatible servers may ignore it.
+- `thinking` controls Anthropic adaptive thinking: `auto` enables it only for known supported Claude models, `adaptive` always sends `thinking = {"type": "adaptive"}`, and `disabled` never sends a thinking parameter.
 - `DEEPAGENT_MODEL_PROVIDER`, `DEEPAGENT_MODEL_BASE_URL`, `DEEPAGENT_MODEL_ENDPOINT_URL`, `DEEPAGENT_MODEL_NAME`, `DEEPAGENT_MODEL_API_KEY`, `DEEPAGENT_MODEL_REASONING`, `DEEPAGENT_MODEL_DISABLE_STREAMING`, and `DEEPAGENT_MODEL_DISABLE_STREAMING_FOR_TOOL_CALLS` override the TOML defaults when set.
 - `OLLAMA_BASE_URL`, `OLLAMA_MODEL`, and `OLLAMA_REASONING` still work as Ollama-only compatibility aliases.
 

--- a/deepagent.toml
+++ b/deepagent.toml
@@ -1,15 +1,15 @@
-[model]
-provider = "ollama"
-base_url = "http://10.0.1.152:11434"
-temperature = 0.3
-repeat_penalty = 1.1
+#[model]
+#provider = "ollama"
+#base_url = "http://10.0.1.152:11434"
+#temperature = 0.3
+#repeat_penalty = 1.1
 
-name = "qwen3.6:35b-a3b"
+#name = "qwen3.6:35b-a3b"
 #models = ["gpt-oss:20b", "gemma4:26b", "qwen3.6:27b"]
 
-reasoning_effort = "medium"
+#reasoning_effort = "medium"
 # Set true to bypass model streaming only for tool-calling requests.
-disable_streaming_for_tool_calls = false
+#disable_streaming_for_tool_calls = false
 
 # For LM Studio or another OpenAI-compatible server, switch to:
 #[model]
@@ -20,7 +20,14 @@ disable_streaming_for_tool_calls = false
 #reasoning_effort = "medium"
 #api_key = "optional"
 
-
+[model]
+provider = "anthropic"
+temperature = 1
+name = "claude-sonnet-4-6"
+models = ["claude-sonnet-4-6", "claude-opus-4-8", "claude-haiku-4-5-20251001"]
+reasoning_effort = "medium"
+thinking = "auto"
+base_url = "https://api.anthropic.com"
 
 [mcp]
 tool_name_prefix = false
@@ -52,10 +59,9 @@ chunk_overlap = 200
 top_k = 4
 
 [rag.embedding]
-provider = "auto"
-# For Ollama, the default embedding model is "nomic-embed-text".
-# model = "nomic-embed-text"
-# base_url = "http://127.0.0.1:11434"
+provider = "ollama"
+model = "nomic-embed-text"
+base_url = "http://10.0.1.152:11434"
 
 # Async subagent backed by the local LangGraph Agent Protocol server.
 [[async_subagents]]

--- a/deepagent.toml.example
+++ b/deepagent.toml.example
@@ -18,6 +18,7 @@ disable_streaming_for_tool_calls = false
 # provider = "anthropic"
 # name = "claude-sonnet-4-6"
 # models = ["claude-sonnet-4-6", "claude-opus-4-8", "claude-haiku-4-5-20251001"]
+# thinking = "auto"  # auto, adaptive, or disabled
 # endpoint_url = "https://claude-proxy.example/proxy/v1/messages"
 # api_key = ""  # optional when ANTHROPIC_API_KEY or DEEPAGENT_MODEL_API_KEY is set
 

--- a/deepagent_runtime.py
+++ b/deepagent_runtime.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import copy
 import inspect
 import json
 import logging
@@ -60,6 +61,7 @@ from rag_runtime import (
 ModelProvider = Literal["ollama", "openai_compatible", "anthropic"]
 ReasoningLevel = Literal["low", "medium", "high"]
 DisableStreaming = bool | Literal["tool_calling"]
+ModelThinking = Literal["auto", "adaptive", "disabled"]
 PersistenceMode = Literal["memory", "postgres"]
 DEFAULT_MODEL = "gpt-oss:20b"
 DEFAULT_MODEL_PROVIDER: ModelProvider = "ollama"
@@ -68,6 +70,7 @@ DEFAULT_OLLAMA_PORT = 11434
 DEFAULT_OLLAMA_BASE_URL = "http://127.0.0.1:11434"
 DEFAULT_ANTHROPIC_BASE_URL = "https://api.anthropic.com"
 DEFAULT_REASONING_LEVEL: ReasoningLevel = "medium"
+DEFAULT_MODEL_THINKING: ModelThinking = "auto"
 DEFAULT_TEMPERATURE = 0.0
 DEFAULT_EXTENSIONS_CONFIG = "deepagent.toml"
 DEFAULT_RECURSION_LIMIT = 100
@@ -162,6 +165,30 @@ def normalize_disable_streaming(value: Any | None) -> DisableStreaming:
     raise ValueError(
         "Model disable_streaming must be a boolean or 'tool_calling'."
     )
+
+
+def normalize_model_thinking(value: Any | None) -> ModelThinking:
+    """Normalize Anthropic model thinking configuration.
+
+    Args:
+        value: Value to normalize, convert, or serialize.
+
+    Returns:
+        The normalized thinking mode.
+
+    Raises:
+        ValueError: If the supplied value is invalid.
+    """
+    if value is None:
+        return DEFAULT_MODEL_THINKING
+    candidate = str(value).strip().lower().replace("-", "_")
+    if not candidate:
+        return DEFAULT_MODEL_THINKING
+    if candidate not in {"auto", "adaptive", "disabled"}:
+        raise ValueError(
+            "model.thinking must be one of 'auto', 'adaptive', or 'disabled'."
+        )
+    return candidate  # type: ignore[return-value]
 
 
 def normalize_disable_streaming_for_tool_calls(value: Any | None) -> bool:
@@ -1486,6 +1513,7 @@ class ModelDefaults:
         models: The models value.
         name_is_explicit: The name is explicit value.
         reasoning_effort: The reasoning effort value.
+        thinking: The Anthropic thinking mode.
         temperature: The temperature value.
         repeat_penalty: The repeat penalty value.
         disable_streaming: Whether to disable model streaming.
@@ -1499,6 +1527,7 @@ class ModelDefaults:
     models: tuple[str, ...] = ()
     name_is_explicit: bool = False
     reasoning_effort: ReasoningLevel = DEFAULT_REASONING_LEVEL
+    thinking: ModelThinking = DEFAULT_MODEL_THINKING
     temperature: float = DEFAULT_TEMPERATURE
     repeat_penalty: float | None = None
     disable_streaming: DisableStreaming = False
@@ -1604,6 +1633,7 @@ def parse_model_defaults(raw_config: dict[str, Any]) -> ModelDefaults:
             raw_model.get("reasoning_effort"),
             default=DEFAULT_REASONING_LEVEL,
         ),
+        thinking=normalize_model_thinking(raw_model.get("thinking")),
         temperature=normalize_model_temperature(
             raw_model.get("temperature", raw_model.get("tempreature"))
         ),
@@ -2120,6 +2150,7 @@ class RuntimeConfig:
         rag_error: The RAG error value.
         model_endpoint_query: The model endpoint query value.
         model_disable_streaming: Whether to disable model streaming.
+        model_thinking: Anthropic thinking mode.
     """
 
     database_url: str | None
@@ -2139,6 +2170,7 @@ class RuntimeConfig:
     rag_error: str | None = None
     model_endpoint_query: tuple[tuple[str, str], ...] = ()
     model_disable_streaming: DisableStreaming = False
+    model_thinking: ModelThinking = DEFAULT_MODEL_THINKING
 
     @classmethod
     def from_env(
@@ -2407,6 +2439,7 @@ class RuntimeConfig:
             rag_error=rag_error,
             model_endpoint_query=model_endpoint_query,
             model_disable_streaming=model_disable_streaming,
+            model_thinking=model_defaults.thinking,
         )
 
 
@@ -2447,6 +2480,11 @@ def build_model(
             "effort": reasoning_level,
             "disable_streaming": config.model_disable_streaming,
         }
+        if should_enable_anthropic_adaptive_thinking(
+            selected_model,
+            config.model_thinking,
+        ):
+            kwargs["thinking"] = {"type": "adaptive"}
         if config.model_api_key:
             kwargs["api_key"] = config.model_api_key
         default_query = model_endpoint_query_to_dict(config.model_endpoint_query)
@@ -2466,6 +2504,47 @@ def build_model(
     if default_query:
         kwargs["default_query"] = default_query
     return OpenAICompatibleChatOpenAI(**kwargs)
+
+
+def should_enable_anthropic_adaptive_thinking(
+    model_name: str,
+    thinking: ModelThinking,
+) -> bool:
+    """Return whether adaptive thinking should be enabled for Anthropic.
+
+    Args:
+        model_name: The model name value.
+        thinking: The configured thinking mode.
+
+    Returns:
+        Whether adaptive thinking should be enabled.
+    """
+    if thinking == "disabled":
+        return False
+    if thinking == "adaptive":
+        return True
+    return anthropic_model_supports_adaptive_thinking(model_name)
+
+
+def anthropic_model_supports_adaptive_thinking(model_name: str) -> bool:
+    """Return whether an Anthropic model supports adaptive thinking.
+
+    Args:
+        model_name: The model name value.
+
+    Returns:
+        Whether the model supports adaptive thinking.
+    """
+    normalized = model_name.lower()
+    return any(
+        marker in normalized
+        for marker in (
+            "claude-sonnet-4-6",
+            "claude-opus-4-6",
+            "claude-opus-4-7",
+            "claude-opus-4-8",
+        )
+    )
 
 
 def build_deepagent_backend(*, project_root: Path | None = None) -> CompositeBackend:
@@ -2695,6 +2774,9 @@ def sanitize_tools_for_model(
     Returns:
         The sanitized value.
     """
+    if model_provider == "anthropic":
+        return [normalize_anthropic_tool_schema(tool) for tool in tools]
+
     if model_provider != "openai_compatible":
         return list(tools)
 
@@ -2715,6 +2797,53 @@ def sanitize_tools_for_model(
         )
 
     return compatible_tools
+
+
+def normalize_anthropic_tool_schema(tool: Any) -> Any:
+    """Normalize tool schemas for Anthropic's stricter root object requirement.
+
+    Args:
+        tool: The tool value.
+
+    Returns:
+        The normalized tool value.
+    """
+    schema = getattr(tool, "args_schema", None)
+    if not isinstance(schema, dict):
+        return tool
+
+    normalized_schema = normalize_json_object_schema_root(schema)
+    if normalized_schema is schema:
+        return tool
+
+    if hasattr(tool, "model_copy"):
+        return tool.model_copy(update={"args_schema": normalized_schema})
+
+    try:
+        cloned = copy.copy(tool)
+        setattr(cloned, "args_schema", normalized_schema)
+        return cloned
+    except Exception:
+        setattr(tool, "args_schema", normalized_schema)
+        return tool
+
+
+def normalize_json_object_schema_root(schema: dict[str, Any]) -> dict[str, Any]:
+    """Ensure a JSON schema dict declares an object root when unspecified.
+
+    Args:
+        schema: The schema value.
+
+    Returns:
+        The normalized schema.
+    """
+    if schema.get("type") == "object":
+        return schema
+
+    if schema.get("type") is not None:
+        return schema
+
+    return {**schema, "type": "object"}
 
 
 def tool_supports_openai_compatible_schema(tool: Any) -> bool:

--- a/tests/test_deepagent_runtime_rag.py
+++ b/tests/test_deepagent_runtime_rag.py
@@ -8,8 +8,10 @@ from pathlib import Path
 from types import SimpleNamespace
 
 from langchain.agents.middleware.types import ToolCallRequest
+from langchain_anthropic.chat_models import convert_to_anthropic_tool
 from langchain_core.language_models.fake_chat_models import FakeListChatModel
 from langchain_core.messages import AIMessageChunk, ToolMessage
+from langchain_core.tools import StructuredTool
 from langgraph.checkpoint.memory import MemorySaver
 from langgraph.store.memory import InMemoryStore
 import pytest
@@ -114,6 +116,43 @@ def make_extensions_config(
         mcp_servers={"repo": {"transport": "stdio", "command": "npx", "args": []}},
         agent_mcp_servers=agent_mcp_servers,
     )
+
+
+def test_anthropic_tool_sanitization_adds_object_type_to_mcp_dict_schema() -> None:
+    """Verify Anthropic tool sanitization fixes MCP-style dict schemas."""
+    async def fake_mcp_tool(**kwargs):
+        """Return fake MCP tool arguments.
+
+        Args:
+            kwargs: Keyword arguments passed to the tool.
+
+        Returns:
+            The supplied keyword arguments.
+        """
+        return kwargs
+
+    tool = StructuredTool(
+        name="read_file",
+        description="Read a file.",
+        args_schema={
+            "properties": {"path": {"type": "string"}},
+            "required": ["path"],
+        },
+        coroutine=fake_mcp_tool,
+    )
+
+    sanitized = deepagent_runtime.sanitize_tools_for_model("anthropic", [tool])
+
+    assert sanitized[0] is not tool
+    assert tool.args_schema == {
+        "properties": {"path": {"type": "string"}},
+        "required": ["path"],
+    }
+    anthropic_tool = convert_to_anthropic_tool(sanitized[0])
+    assert anthropic_tool["input_schema"]["type"] == "object"
+    assert anthropic_tool["input_schema"]["properties"] == {
+        "path": {"type": "string"},
+    }
 
 
 def test_openai_compatible_model_preserves_vllm_reasoning_delta() -> None:
@@ -453,6 +492,115 @@ reasoning_effort = "low"
     assert model.anthropic_api_key.get_secret_value() == "toml-key"
     assert model.temperature == 0.2
     assert model.effort == "medium"
+    assert model.thinking == {"type": "adaptive"}
+
+
+def test_anthropic_adaptive_thinking_is_not_enabled_for_unsupported_models(
+    tmp_path: Path,
+) -> None:
+    """Verify unsupported Anthropic models do not receive adaptive thinking."""
+    from langchain_anthropic import ChatAnthropic
+
+    config = make_runtime_config(tmp_path)
+    config = RuntimeConfig(
+        database_url=config.database_url,
+        model_provider="anthropic",
+        model_name="claude-haiku-4-5-20251001",
+        model_choices=("claude-haiku-4-5-20251001",),
+        model_base_url="https://api.anthropic.com",
+        model_api_key="test-key",
+        model_temperature=config.model_temperature,
+        default_reasoning=config.default_reasoning,
+        persistence_mode=config.persistence_mode,
+        extensions=config.extensions,
+        rag_requested=config.rag_requested,
+        rag=config.rag,
+        rag_error=config.rag_error,
+    )
+
+    model = deepagent_runtime.build_model(config, "medium")
+
+    assert isinstance(model, ChatAnthropic)
+    assert model.effort == "medium"
+    assert model.thinking is None
+
+
+def test_runtime_config_disables_anthropic_thinking_from_toml(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Verify TOML can disable Anthropic thinking."""
+    from langchain_anthropic import ChatAnthropic
+
+    config_path = tmp_path / "deepagent.toml"
+    config_path.write_text(
+        """
+[model]
+provider = "anthropic"
+name = "claude-sonnet-4-6"
+api_key = "toml-key"
+thinking = "disabled"
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DEEPAGENT_CONFIG", str(config_path))
+
+    config = deepagent_runtime.RuntimeConfig.from_env()
+    model = deepagent_runtime.build_model(config, "medium")
+
+    assert config.model_thinking == "disabled"
+    assert isinstance(model, ChatAnthropic)
+    assert model.thinking is None
+
+
+def test_runtime_config_forces_anthropic_adaptive_thinking_from_toml(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Verify TOML can force Anthropic adaptive thinking."""
+    from langchain_anthropic import ChatAnthropic
+
+    config_path = tmp_path / "deepagent.toml"
+    config_path.write_text(
+        """
+[model]
+provider = "anthropic"
+name = "claude-haiku-4-5-20251001"
+api_key = "toml-key"
+thinking = "adaptive"
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DEEPAGENT_CONFIG", str(config_path))
+
+    config = deepagent_runtime.RuntimeConfig.from_env()
+    model = deepagent_runtime.build_model(config, "medium")
+
+    assert config.model_thinking == "adaptive"
+    assert isinstance(model, ChatAnthropic)
+    assert model.thinking == {"type": "adaptive"}
+
+
+def test_runtime_config_rejects_invalid_model_thinking(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Verify invalid model thinking config is rejected."""
+    config_path = tmp_path / "deepagent.toml"
+    config_path.write_text(
+        """
+[model]
+provider = "anthropic"
+name = "claude-sonnet-4-6"
+api_key = "toml-key"
+thinking = "manual"
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DEEPAGENT_CONFIG", str(config_path))
+
+    with pytest.raises(ValueError, match="model.thinking"):
+        deepagent_runtime.RuntimeConfig.from_env()
 
 
 def test_runtime_config_reads_anthropic_endpoint_url_from_toml(


### PR DESCRIPTION

# Add QUICKSTART.md: First-Time User Guide

## Summary

Adds a new `QUICKSTART.md` file aimed at first-time users who find the main README.md overwhelming due to its depth and breadth of configuration options.

## What it covers

- **What is this?** — One-paragraph project overview
- **Prerequisites** — Python, uv, optional Ollama/Docker
- **5-Minute Setup** — Linear, copy-pasteable steps to a working chat
- **Model provider comparison** — simple table (Ollama, LM Studio, OpenAI, Anthropic)
- **Common next steps** — RAG, skills, Postgres, auth (minimal examples)
- **CLI quick reference** — most-used commands
- **Troubleshooting** — common errors and fixes
- **Cross-references** — links back to README.md for deep dives

## Files changed

| File | Change |
|------|--------|
| `QUICKSTART.md` | +194 lines (new) |

## Related

- Complements (does not replace) the exis  --base mastmd  --head feat/qupl  --title "Add QUICKSTART.md: fid  --body 