### PR TITLE
Add FastAPI access to the agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,26 @@ Start the Chainlit app:
 chainlit run main.py -w
 ```
 
+Start the FastAPI server:
+
+```bash
+uv run chainagents-api --host 127.0.0.1 --port 8000
+```
+
+The API uses the same `deepagent.toml` and environment settings as the Chainlit
+and CLI entrypoints. Useful endpoints include:
+
+```bash
+curl http://127.0.0.1:8000/health
+curl http://127.0.0.1:8000/api/status
+curl -X POST http://127.0.0.1:8000/api/agent/invoke \
+  -H "Content-Type: application/json" \
+  -d '{"prompt":"Summarize this repository","thread_id":"api"}'
+curl -N -X POST http://127.0.0.1:8000/api/agent/stream \
+  -H "Content-Type: application/json" \
+  -d '{"prompt":"Summarize this repository","thread_id":"api"}'
+```
+
 Run the same underlying agent from a terminal without the Chainlit UI:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -186,12 +186,13 @@ and CLI entrypoints. Useful endpoints include:
 ```bash
 curl http://127.0.0.1:8000/health
 curl http://127.0.0.1:8000/api/status
+THREAD_ID="api-$(uuidgen)"
 curl -X POST http://127.0.0.1:8000/api/agent/invoke \
   -H "Content-Type: application/json" \
-  -d '{"prompt":"Summarize this repository","thread_id":"api"}'
+  -d "{\"prompt\":\"Summarize this repository\",\"thread_id\":\"$THREAD_ID\"}"
 curl -N -X POST http://127.0.0.1:8000/api/agent/stream \
   -H "Content-Type: application/json" \
-  -d '{"prompt":"Summarize this repository","thread_id":"api"}'
+  -d "{\"prompt\":\"Summarize this repository\",\"thread_id\":\"$THREAD_ID\"}"
 ```
 
 Run the same underlying agent from a terminal without the Chainlit UI:

--- a/chainagents_api.py
+++ b/chainagents_api.py
@@ -1,0 +1,311 @@
+#!/usr/bin/env python3
+"""Provide FastAPI access to the ChainAgents runtime."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager, suppress
+from dataclasses import asdict, dataclass
+from typing import Any
+
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel, Field
+
+from agent_stream_events import AgentStreamEvent, AgentStreamEventAdapter
+from deepagent_runtime import AgentRuntime, ReasoningLevel, normalize_reasoning_level
+
+
+DEFAULT_API_THREAD_ID = "api"
+AGENT_STREAM_MODES = ["messages", "updates", "custom"]
+NDJSON_MEDIA_TYPE = "application/x-ndjson"
+
+
+class AgentRunRequest(BaseModel):
+    """HTTP request body for running the agent."""
+
+    prompt: str = Field(..., min_length=1)
+    thread_id: str | None = None
+    model: str | None = None
+    reasoning: ReasoningLevel | None = None
+    async_subagent_url: str | None = None
+    mcp_session_id: str | None = None
+
+
+class AgentRunResponse(BaseModel):
+    """HTTP response body for a completed agent run."""
+
+    response: str
+    thread_id: str
+    model: str
+    reasoning: ReasoningLevel
+
+
+class RuntimeStatusResponse(BaseModel):
+    """Resolved runtime configuration exposed by the API."""
+
+    model: str
+    model_provider: str
+    model_choices: list[str]
+    default_reasoning: ReasoningLevel
+    recursion_limit: int
+    persistence_mode: str
+
+
+@dataclass(frozen=True)
+class AgentRunContext:
+    """Resolved request values used for one agent run."""
+
+    prompt: str
+    thread_id: str
+    model_name: str
+    reasoning_level: ReasoningLevel
+    async_subagent_url: str | None
+    mcp_session_id: str | None
+
+
+def create_app(runtime: Any | None = None) -> FastAPI:
+    """Create the FastAPI app.
+
+    Args:
+        runtime: Optional runtime test double or initialized AgentRuntime.
+
+    Returns:
+        The configured FastAPI app.
+    """
+    managed_runtime: AgentRuntime | None = None
+
+    @asynccontextmanager
+    async def lifespan(app: FastAPI):
+        nonlocal managed_runtime
+        if runtime is None:
+            managed_runtime = await AgentRuntime.create()
+            app.state.runtime = managed_runtime
+        else:
+            app.state.runtime = runtime
+
+        try:
+            yield
+        finally:
+            if managed_runtime is not None:
+                await managed_runtime.close()
+
+    app = FastAPI(
+        title="ChainAgents API",
+        version="1.1.0",
+        lifespan=lifespan,
+    )
+
+    @app.get("/health")
+    async def health() -> dict[str, str]:
+        return {"status": "ok"}
+
+    @app.get("/api/status", response_model=RuntimeStatusResponse)
+    async def status(request: Request) -> RuntimeStatusResponse:
+        active_runtime = _runtime_from_request(request)
+        config = active_runtime.config
+        return RuntimeStatusResponse(
+            model=config.model_name,
+            model_provider=config.model_provider,
+            model_choices=list(config.model_choices),
+            default_reasoning=config.default_reasoning,
+            recursion_limit=config.recursion_limit,
+            persistence_mode=config.persistence_mode,
+        )
+
+    @app.post("/api/agent/invoke", response_model=AgentRunResponse)
+    async def invoke_agent(
+        payload: AgentRunRequest,
+        request: Request,
+    ) -> AgentRunResponse:
+        active_runtime = _runtime_from_request(request)
+        context = _run_context(active_runtime, payload)
+        response_parts: list[str] = []
+        try:
+            async for event in _iter_agent_events(active_runtime, context):
+                if event.kind == "response_delta":
+                    response_parts.append(event.text)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            raise _agent_error(exc) from exc
+
+        return AgentRunResponse(
+            response="".join(response_parts),
+            thread_id=context.thread_id,
+            model=context.model_name,
+            reasoning=context.reasoning_level,
+        )
+
+    @app.post("/api/agent/stream")
+    async def stream_agent(
+        payload: AgentRunRequest,
+        request: Request,
+    ) -> StreamingResponse:
+        active_runtime = _runtime_from_request(request)
+        context = _run_context(active_runtime, payload)
+
+        async def lines() -> AsyncIterator[str]:
+            try:
+                async for event in _iter_agent_events(active_runtime, context):
+                    yield _json_line(_event_payload(event, context))
+                yield _json_line(
+                    {
+                        "kind": "done",
+                        "thread_id": context.thread_id,
+                        "model": context.model_name,
+                        "reasoning": context.reasoning_level,
+                    }
+                )
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                yield _json_line(
+                    {
+                        "kind": "error",
+                        "error": f"{type(exc).__name__}: {exc}",
+                        "thread_id": context.thread_id,
+                        "model": context.model_name,
+                        "reasoning": context.reasoning_level,
+                    }
+                )
+
+        return StreamingResponse(lines(), media_type=NDJSON_MEDIA_TYPE)
+
+    return app
+
+
+def _runtime_from_request(request: Request) -> Any:
+    runtime = getattr(request.app.state, "runtime", None)
+    if runtime is None:
+        raise HTTPException(status_code=503, detail="Agent runtime is not initialized.")
+    return runtime
+
+
+def _run_context(runtime: Any, request: AgentRunRequest) -> AgentRunContext:
+    prompt = request.prompt.strip()
+    if not prompt:
+        raise HTTPException(status_code=422, detail="prompt must not be blank.")
+
+    thread_id = _optional_text(request.thread_id) or DEFAULT_API_THREAD_ID
+    model_name = _optional_text(request.model) or runtime.config.model_name
+    try:
+        reasoning_level = normalize_reasoning_level(
+            request.reasoning,
+            default=runtime.config.default_reasoning,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+    return AgentRunContext(
+        prompt=prompt,
+        thread_id=thread_id,
+        model_name=model_name,
+        reasoning_level=reasoning_level,
+        async_subagent_url=_optional_text(request.async_subagent_url),
+        mcp_session_id=_optional_text(request.mcp_session_id),
+    )
+
+
+def _optional_text(value: str | None) -> str | None:
+    if value is None:
+        return None
+    text = value.strip()
+    return text or None
+
+
+async def _iter_agent_events(
+    runtime: Any,
+    context: AgentRunContext,
+) -> AsyncIterator[AgentStreamEvent]:
+    agent = await runtime.get_agent(
+        context.reasoning_level,
+        model_name=context.model_name,
+        thread_id=context.thread_id,
+        async_subagent_url_override=context.async_subagent_url,
+        mcp_session_id=context.mcp_session_id,
+    )
+    payload = {"messages": [{"role": "user", "content": context.prompt}]}
+    config = {
+        "configurable": {"thread_id": context.thread_id},
+        "recursion_limit": runtime.config.recursion_limit,
+    }
+    adapter = AgentStreamEventAdapter(prompt=context.prompt)
+    stream = agent.astream_events(
+        payload,
+        config=config,
+        version="v2",
+        stream_mode=AGENT_STREAM_MODES,
+        subgraphs=True,
+    )
+
+    try:
+        async for raw_event in stream:
+            for event in adapter.events_from_raw_event(raw_event):
+                yield event
+    finally:
+        with suppress(Exception):
+            await stream.aclose()
+
+
+def _event_payload(event: AgentStreamEvent, context: AgentRunContext) -> dict[str, Any]:
+    payload = asdict(event)
+    payload.update(
+        {
+            "thread_id": context.thread_id,
+            "model": context.model_name,
+            "reasoning": context.reasoning_level,
+        }
+    )
+    return payload
+
+
+def _json_line(payload: dict[str, Any]) -> str:
+    return json.dumps(payload, ensure_ascii=True, separators=(",", ":")) + "\n"
+
+
+def _agent_error(exc: Exception) -> HTTPException:
+    return HTTPException(
+        status_code=500,
+        detail=f"{type(exc).__name__}: {exc}",
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the ChainAgents API command-line parser."""
+    parser = argparse.ArgumentParser(
+        prog="chainagents-api",
+        description="Run the ChainAgents FastAPI server.",
+    )
+    parser.add_argument("--host", default="127.0.0.1", help="Host to bind.")
+    parser.add_argument("--port", default=8000, type=int, help="Port to bind.")
+    parser.add_argument(
+        "--reload",
+        action="store_true",
+        help="Enable Uvicorn reload for local development.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Run the API server from the console script."""
+    args = build_parser().parse_args(argv)
+
+    import uvicorn
+
+    uvicorn.run(
+        "chainagents_api:app",
+        host=args.host,
+        port=args.port,
+        reload=args.reload,
+    )
+
+
+app = create_app()
+
+
+if __name__ == "__main__":
+    main()

--- a/chainagents_api.py
+++ b/chainagents_api.py
@@ -19,7 +19,6 @@ from agent_stream_events import AgentStreamEvent, AgentStreamEventAdapter
 from deepagent_runtime import AgentRuntime, ReasoningLevel, normalize_reasoning_level
 
 
-DEFAULT_API_THREAD_ID = "api"
 AGENT_STREAM_MODES = ["messages", "updates", "custom"]
 NDJSON_MEDIA_TYPE = "application/x-ndjson"
 
@@ -28,7 +27,7 @@ class AgentRunRequest(BaseModel):
     """HTTP request body for running the agent."""
 
     prompt: str = Field(..., min_length=1)
-    thread_id: str | None = None
+    thread_id: str = Field(..., min_length=1)
     model: str | None = None
     reasoning: ReasoningLevel | None = None
     async_subagent_url: str | None = None
@@ -190,7 +189,7 @@ def _run_context(runtime: Any, request: AgentRunRequest) -> AgentRunContext:
     if not prompt:
         raise HTTPException(status_code=422, detail="prompt must not be blank.")
 
-    thread_id = _optional_text(request.thread_id) or DEFAULT_API_THREAD_ID
+    thread_id = _required_text(request.thread_id, "thread_id")
     model_name = _optional_text(request.model) or runtime.config.model_name
     try:
         reasoning_level = normalize_reasoning_level(
@@ -215,6 +214,13 @@ def _optional_text(value: str | None) -> str | None:
         return None
     text = value.strip()
     return text or None
+
+
+def _required_text(value: str, field_name: str) -> str:
+    text = value.strip()
+    if not text:
+        raise HTTPException(status_code=422, detail=f"{field_name} must not be blank.")
+    return text
 
 
 async def _iter_agent_events(

--- a/deepagent.toml
+++ b/deepagent.toml
@@ -1,13 +1,13 @@
-#[model]
-#provider = "ollama"
-#base_url = "http://10.0.1.152:11434"
-#temperature = 0.3
-#repeat_penalty = 1.1
+[model]
+provider = "ollama"
+base_url = "http://10.0.1.152:11434"
+temperature = 0.3
+repeat_penalty = 1.1
 
-#name = "qwen3.6:35b-a3b"
+name = "qwen3.6:35b-a3b-mtp-q4_K_M"
 #models = ["gpt-oss:20b", "gemma4:26b", "qwen3.6:27b"]
 
-#reasoning_effort = "medium"
+reasoning_effort = "high"
 # Set true to bypass model streaming only for tool-calling requests.
 #disable_streaming_for_tool_calls = false
 
@@ -20,14 +20,14 @@
 #reasoning_effort = "medium"
 #api_key = "optional"
 
-[model]
-provider = "anthropic"
-temperature = 1
-name = "claude-sonnet-4-6"
-models = ["claude-sonnet-4-6", "claude-opus-4-8", "claude-haiku-4-5-20251001"]
-reasoning_effort = "medium"
-thinking = "auto"
-base_url = "https://api.anthropic.com"
+#[model]
+#provider = "anthropic"
+#temperature = 1
+#name = "claude-sonnet-4-6"
+#models = ["claude-sonnet-4-6", "claude-opus-4-8", "claude-haiku-4-5-20251001"]
+#reasoning_effort = "medium"
+#thinking = "auto"
+#base_url = "https://api.anthropic.com"
 
 [mcp]
 tool_name_prefix = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "asyncpg>=0.30.0",
     "chainlit>=2.8.0",
     "deepagents>=0.6.7",
+    "fastapi>=0.135.0",
     "langchain-anthropic>=1.3.0",
     "langchain-chroma>=0.2.0",
     "langchain-mcp-adapters>=0.1.9",
@@ -20,10 +21,12 @@ dependencies = [
     "pytest>=8.3.0",
     "rich>=15.0.0",
     "textual>=6.1.0",
+    "uvicorn>=0.44.0",
 ]
 
 [project.scripts]
 chainagents = "chainagents_cli:main"
+chainagents-api = "chainagents_api:main"
 
 [build-system]
 requires = ["setuptools>=69"]
@@ -34,6 +37,7 @@ py-modules = [
     "agent_commands",
     "agent_stream_events",
     "async_task_notifications",
+    "chainagents_api",
     "chainagents_cli",
     "chainagents_tui",
     "chainlit_bridge",

--- a/tests/test_chainagents_api.py
+++ b/tests/test_chainagents_api.py
@@ -1,0 +1,208 @@
+"""Test the FastAPI access layer for ChainAgents."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from typing import Any
+
+from fastapi.testclient import TestClient
+
+import chainagents_api
+
+
+class _Token:
+    """Provide a minimal streamed AI token for API tests."""
+
+    type = "AIMessageChunk"
+    additional_kwargs: dict[str, str] = {}
+    tool_call_chunks: list[dict[str, str]] = []
+
+    def __init__(self, content: str = "") -> None:
+        """Initialize the token instance."""
+        self.content = content
+
+
+def _raw_event(chunk: object) -> dict[str, object]:
+    """Build a raw LangGraph stream event."""
+    return {"event": "on_chain_stream", "data": {"chunk": chunk}}
+
+
+class _FakeAgent:
+    """Capture agent invocations and return configured stream events."""
+
+    def __init__(self, events: list[dict[str, object]]) -> None:
+        """Initialize the fake agent."""
+        self.events = events
+        self.payload: dict[str, Any] | None = None
+        self.config: dict[str, Any] | None = None
+
+    def astream_events(self, payload, *, config, version, stream_mode, subgraphs):
+        """Return the configured async event stream."""
+        self.payload = payload
+        self.config = config
+
+        async def events():
+            for event in self.events:
+                yield event
+
+        return events()
+
+
+class _FakeRuntime:
+    """Provide the runtime surface required by the API module."""
+
+    def __init__(self, agent: _FakeAgent) -> None:
+        """Initialize the fake runtime."""
+        self.agent = agent
+        self.requests: list[dict[str, Any]] = []
+        self.config = SimpleNamespace(
+            default_reasoning="medium",
+            model_name="fake-model",
+            model_provider="ollama",
+            model_choices=("fake-model", "other-model"),
+            recursion_limit=100,
+            persistence_mode="memory",
+        )
+
+    async def get_agent(self, *args, **kwargs):
+        """Return the fake agent and capture selection arguments."""
+        self.requests.append({"args": args, "kwargs": kwargs})
+        return self.agent
+
+
+def test_health_reports_ok() -> None:
+    """Verify the health endpoint reports that the API process is alive."""
+    runtime = _FakeRuntime(_FakeAgent([]))
+    app = chainagents_api.create_app(runtime=runtime)
+
+    with TestClient(app) as client:
+        response = client.get("/health")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+def test_status_reports_runtime_configuration() -> None:
+    """Verify the status endpoint exposes resolved runtime configuration."""
+    runtime = _FakeRuntime(_FakeAgent([]))
+    app = chainagents_api.create_app(runtime=runtime)
+
+    with TestClient(app) as client:
+        response = client.get("/api/status")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "model": "fake-model",
+        "model_provider": "ollama",
+        "model_choices": ["fake-model", "other-model"],
+        "default_reasoning": "medium",
+        "recursion_limit": 100,
+        "persistence_mode": "memory",
+    }
+
+
+def test_invoke_runs_prompt_through_agent() -> None:
+    """Verify the invoke endpoint returns the final streamed response."""
+    agent = _FakeAgent(
+        [
+            _raw_event(((), "messages", (_Token("Hello"), {}))),
+            _raw_event(((), "messages", (_Token("Hello world"), {}))),
+        ]
+    )
+    runtime = _FakeRuntime(agent)
+    app = chainagents_api.create_app(runtime=runtime)
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/api/agent/invoke",
+            json={
+                "prompt": "hello",
+                "thread_id": "thread-1",
+                "model": "other-model",
+                "reasoning": "high",
+                "mcp_session_id": "session-1",
+            },
+        )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "response": "Hello world",
+        "thread_id": "thread-1",
+        "model": "other-model",
+        "reasoning": "high",
+    }
+    assert runtime.requests == [
+        {
+            "args": ("high",),
+            "kwargs": {
+                "model_name": "other-model",
+                "thread_id": "thread-1",
+                "async_subagent_url_override": None,
+                "mcp_session_id": "session-1",
+            },
+        }
+    ]
+    assert agent.payload == {"messages": [{"role": "user", "content": "hello"}]}
+    assert agent.config == {
+        "configurable": {"thread_id": "thread-1"},
+        "recursion_limit": 100,
+    }
+
+
+def test_stream_returns_ndjson_agent_events() -> None:
+    """Verify the stream endpoint returns normalized agent events as NDJSON."""
+    agent = _FakeAgent(
+        [
+            _raw_event(((), "messages", (_Token("Hello"), {}))),
+            _raw_event(((), "messages", (_Token("Hello world"), {}))),
+        ]
+    )
+    runtime = _FakeRuntime(agent)
+    app = chainagents_api.create_app(runtime=runtime)
+
+    with TestClient(app) as client:
+        with client.stream(
+            "POST",
+            "/api/agent/stream",
+            json={"prompt": "hello"},
+        ) as response:
+            lines = [json.loads(line) for line in response.iter_lines()]
+
+    assert response.status_code == 200
+    assert lines == [
+        {
+            "kind": "response_delta",
+            "source": "main-agent",
+            "text": "Hello",
+            "tool_call_id": "",
+            "tool_name": "",
+            "tool_args": "",
+            "tool_args_delta": "",
+            "tool_result": "",
+            "status": "",
+            "thread_id": "api",
+            "model": "fake-model",
+            "reasoning": "medium",
+        },
+        {
+            "kind": "response_delta",
+            "source": "main-agent",
+            "text": " world",
+            "tool_call_id": "",
+            "tool_name": "",
+            "tool_args": "",
+            "tool_args_delta": "",
+            "tool_result": "",
+            "status": "",
+            "thread_id": "api",
+            "model": "fake-model",
+            "reasoning": "medium",
+        },
+        {
+            "kind": "done",
+            "thread_id": "api",
+            "model": "fake-model",
+            "reasoning": "medium",
+        },
+    ]

--- a/tests/test_chainagents_api.py
+++ b/tests/test_chainagents_api.py
@@ -150,6 +150,21 @@ def test_invoke_runs_prompt_through_agent() -> None:
     }
 
 
+def test_invoke_requires_thread_id() -> None:
+    """Verify API callers must provide a thread ID for checkpoint isolation."""
+    runtime = _FakeRuntime(_FakeAgent([]))
+    app = chainagents_api.create_app(runtime=runtime)
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/api/agent/invoke",
+            json={"prompt": "hello"},
+        )
+
+    assert response.status_code == 422
+    assert runtime.requests == []
+
+
 def test_stream_returns_ndjson_agent_events() -> None:
     """Verify the stream endpoint returns normalized agent events as NDJSON."""
     agent = _FakeAgent(
@@ -165,7 +180,7 @@ def test_stream_returns_ndjson_agent_events() -> None:
         with client.stream(
             "POST",
             "/api/agent/stream",
-            json={"prompt": "hello"},
+            json={"prompt": "hello", "thread_id": "thread-1"},
         ) as response:
             lines = [json.loads(line) for line in response.iter_lines()]
 
@@ -181,7 +196,7 @@ def test_stream_returns_ndjson_agent_events() -> None:
             "tool_args_delta": "",
             "tool_result": "",
             "status": "",
-            "thread_id": "api",
+            "thread_id": "thread-1",
             "model": "fake-model",
             "reasoning": "medium",
         },
@@ -195,14 +210,29 @@ def test_stream_returns_ndjson_agent_events() -> None:
             "tool_args_delta": "",
             "tool_result": "",
             "status": "",
-            "thread_id": "api",
+            "thread_id": "thread-1",
             "model": "fake-model",
             "reasoning": "medium",
         },
         {
             "kind": "done",
-            "thread_id": "api",
+            "thread_id": "thread-1",
             "model": "fake-model",
             "reasoning": "medium",
         },
     ]
+
+
+def test_stream_requires_thread_id() -> None:
+    """Verify streamed API runs also require a caller-provided thread ID."""
+    runtime = _FakeRuntime(_FakeAgent([]))
+    app = chainagents_api.create_app(runtime=runtime)
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/api/agent/stream",
+            json={"prompt": "hello"},
+        )
+
+    assert response.status_code == 422
+    assert runtime.requests == []

--- a/uv.lock
+++ b/uv.lock
@@ -464,6 +464,7 @@ dependencies = [
     { name = "asyncpg" },
     { name = "chainlit" },
     { name = "deepagents" },
+    { name = "fastapi" },
     { name = "langchain-anthropic" },
     { name = "langchain-chroma" },
     { name = "langchain-mcp-adapters" },
@@ -476,6 +477,7 @@ dependencies = [
     { name = "pytest" },
     { name = "rich" },
     { name = "textual" },
+    { name = "uvicorn" },
 ]
 
 [package.metadata]
@@ -483,6 +485,7 @@ requires-dist = [
     { name = "asyncpg", specifier = ">=0.30.0" },
     { name = "chainlit", specifier = ">=2.8.0" },
     { name = "deepagents", specifier = ">=0.6.7" },
+    { name = "fastapi", specifier = ">=0.135.0" },
     { name = "langchain-anthropic", specifier = ">=1.3.0" },
     { name = "langchain-chroma", specifier = ">=0.2.0" },
     { name = "langchain-mcp-adapters", specifier = ">=0.1.9" },
@@ -495,6 +498,7 @@ requires-dist = [
     { name = "pytest", specifier = ">=8.3.0" },
     { name = "rich", specifier = ">=15.0.0" },
     { name = "textual", specifier = ">=6.1.0" },
+    { name = "uvicorn", specifier = ">=0.44.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add a FastAPI app with `/health`, `/api/status`, `/api/agent/invoke`, and `/api/agent/stream`.
- Reuse the existing agent runtime and stream event adapter for HTTP access.
- Add a `chainagents-api` console script and document the API usage in the README.

## Testing
- Added unit tests for health, status, invoke, and streaming responses.
- Ran the full pytest suite locally; all tests passed.