### PR TITLE
Make agent state configurable in deepagent.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ mcp_servers = ["repo"]
 
 Notes:
 
-- `state = "stateful"` passes the configured LangGraph store and checkpointer to DeepAgents so thread IDs can continue conversation state. `state = "stateless"` omits those state handles when building the agent graph.
+- `state = "stateful"` passes the configured LangGraph store and checkpointer to DeepAgents so thread IDs can continue conversation state. `state = "stateless"` omits those state handles and does not expose `/memories/` when building the agent graph.
 - `recursion_limit` is the LangGraph step limit for one agent run.
 - The built-in default is `100`; this repo's `deepagent.toml` sets it to `200`.
 - `DEEPAGENT_RECURSION_LIMIT` overrides this value when set.
@@ -480,7 +480,7 @@ Supported subagent fields:
 
 Main `[agent]` additions:
 
-- `state`: optional agent state mode. Use `stateful` for checkpointed conversation state, or `stateless` to build the DeepAgents graph without a LangGraph store or checkpointer. Defaults to `stateful`.
+- `state`: optional agent state mode. Use `stateful` for checkpointed conversation state, or `stateless` to build the DeepAgents graph without a LangGraph store, checkpointer, or `/memories/` route. Defaults to `stateful`.
 - `recursion_limit`: optional positive integer LangGraph step limit for a single agent run. Defaults to `100` unless overridden by `DEEPAGENT_RECURSION_LIMIT`.
 - `AGENTS.md`: optional repo-root file that is automatically appended to the **main/supervisor** agent system prompt when present. It is not applied to separately configured async graph prompts.
 - `custom_instruction`: optional string appended to the **main/supervisor** agent system prompt. This setting does **not** get applied to separately configured prompts such as the `async_researcher` graph prompt.
@@ -663,7 +663,7 @@ See [deepagent.toml.example](deepagent.toml.example) for a complete example.
 ## Workspace Contract
 
 - `/workspace/` maps to this repo on disk.
-- `/memories/` is durable across LangGraph threads only when `DATABASE_URL` is configured.
+- `/memories/` is available in stateful mode and durable across LangGraph threads only when `DATABASE_URL` is configured.
 - any other absolute path is treated as ephemeral scratch space by the deep agent backend.
 
 ## Notes
@@ -672,7 +672,7 @@ See [deepagent.toml.example](deepagent.toml.example) for a complete example.
 - If `DATABASE_URL` is set but authentication is not configured, Chainlit still persists thread records, but they are not browseable from the UI.
 - When `DATABASE_URL` is unset, thread IDs only persist while the process stays alive.
 - When `DATABASE_URL` is set, durable state is available through LangGraph thread IDs. You can reuse a thread ID from the chat settings panel to continue the same checkpointed thread.
-- When `[agent].state = "stateless"`, thread IDs still identify requests and MCP/RAG scopes, but the agent graph does not checkpoint conversation state or receive a LangGraph store.
+- When `[agent].state = "stateless"`, thread IDs still identify requests and MCP/RAG scopes, but the agent graph does not checkpoint conversation state, receive a LangGraph store, or expose `/memories/`.
 - MCP stateful sessions are process-local. They survive tool calls in the same thread, but not an app restart.
 - On startup, the UI shows how many skill sources, MCP servers, custom subagents, and async subagents were loaded from `deepagent.toml`.
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ export CHAINLIT_AUTH_PASSWORD="change-me"
 
 - when set, LangGraph checkpoints and `/memories/` are persisted in Postgres
 - when unset, the app falls back to in-memory persistence for the current process only
-- if `[agent].state = "stateless"`, the agent graph is built without LangGraph checkpoint or store handles even when `DATABASE_URL` is set
+- if `[agent].state = "stateless"`, LangGraph checkpoint and store handles are not opened or passed to the agent graph even when `DATABASE_URL` is set
 
 `DEEPAGENT_CONFIG` is optional:
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ export CHAINLIT_AUTH_PASSWORD="change-me"
 
 - when set, LangGraph checkpoints and `/memories/` are persisted in Postgres
 - when unset, the app falls back to in-memory persistence for the current process only
+- if `[agent].state = "stateless"`, the agent graph is built without LangGraph checkpoint or store handles even when `DATABASE_URL` is set
 
 `DEEPAGENT_CONFIG` is optional:
 
@@ -312,6 +313,7 @@ The `[agent]` table configures main-agent runtime behavior:
 
 ```toml
 [agent]
+state = "stateful"
 recursion_limit = 200
 skills = ["skills"]
 mcp_servers = ["repo"]
@@ -319,6 +321,7 @@ mcp_servers = ["repo"]
 
 Notes:
 
+- `state = "stateful"` passes the configured LangGraph store and checkpointer to DeepAgents so thread IDs can continue conversation state. `state = "stateless"` omits those state handles when building the agent graph.
 - `recursion_limit` is the LangGraph step limit for one agent run.
 - The built-in default is `100`; this repo's `deepagent.toml` sets it to `200`.
 - `DEEPAGENT_RECURSION_LIMIT` overrides this value when set.
@@ -439,6 +442,7 @@ args = ["-y", "@modelcontextprotocol/server-filesystem@2025.8.21", "."]
 cwd = "."
 
 [agent]
+state = "stateful"
 recursion_limit = 200
 skills = ["skills"]
 mcp_servers = ["repo"]
@@ -476,6 +480,7 @@ Supported subagent fields:
 
 Main `[agent]` additions:
 
+- `state`: optional agent state mode. Use `stateful` for checkpointed conversation state, or `stateless` to build the DeepAgents graph without a LangGraph store or checkpointer. Defaults to `stateful`.
 - `recursion_limit`: optional positive integer LangGraph step limit for a single agent run. Defaults to `100` unless overridden by `DEEPAGENT_RECURSION_LIMIT`.
 - `AGENTS.md`: optional repo-root file that is automatically appended to the **main/supervisor** agent system prompt when present. It is not applied to separately configured async graph prompts.
 - `custom_instruction`: optional string appended to the **main/supervisor** agent system prompt. This setting does **not** get applied to separately configured prompts such as the `async_researcher` graph prompt.
@@ -667,6 +672,7 @@ See [deepagent.toml.example](deepagent.toml.example) for a complete example.
 - If `DATABASE_URL` is set but authentication is not configured, Chainlit still persists thread records, but they are not browseable from the UI.
 - When `DATABASE_URL` is unset, thread IDs only persist while the process stays alive.
 - When `DATABASE_URL` is set, durable state is available through LangGraph thread IDs. You can reuse a thread ID from the chat settings panel to continue the same checkpointed thread.
+- When `[agent].state = "stateless"`, thread IDs still identify requests and MCP/RAG scopes, but the agent graph does not checkpoint conversation state or receive a LangGraph store.
 - MCP stateful sessions are process-local. They survive tool calls in the same thread, but not an app restart.
 - On startup, the UI shows how many skill sources, MCP servers, custom subagents, and async subagents were loaded from `deepagent.toml`.
 

--- a/chainagents_api.py
+++ b/chainagents_api.py
@@ -50,6 +50,7 @@ class RuntimeStatusResponse(BaseModel):
     model_provider: str
     model_choices: list[str]
     default_reasoning: ReasoningLevel
+    agent_state: str
     recursion_limit: int
     persistence_mode: str
 
@@ -111,6 +112,7 @@ def create_app(runtime: Any | None = None) -> FastAPI:
             model_provider=config.model_provider,
             model_choices=list(config.model_choices),
             default_reasoning=config.default_reasoning,
+            agent_state=config.agent_state,
             recursion_limit=config.recursion_limit,
             persistence_mode=config.persistence_mode,
         )

--- a/chainagents_cli.py
+++ b/chainagents_cli.py
@@ -915,6 +915,7 @@ def runtime_status_payload(runtime: AgentRuntime) -> dict[str, Any]:
         "model_base_url": runtime.config.model_base_url,
         "reasoning": runtime.config.default_reasoning,
         "model_disable_streaming": runtime.config.model_disable_streaming,
+        "agent_state": runtime.config.agent_state,
         "recursion_limit": runtime.config.recursion_limit,
         "persistence": runtime.config.persistence_mode,
         "rag": rag_status_payload(runtime.rag_status),
@@ -981,6 +982,7 @@ def print_runtime_status(
         "Disable streaming",
         Text(str(payload["model_disable_streaming"]), "white"),
     )
+    table.add_row("Agent state", Text(str(payload["agent_state"]), "white"))
     table.add_row("Recursion limit", Text(str(payload["recursion_limit"]), "white"))
     table.add_row("Persistence", Text(str(payload["persistence"]), "white"))
     table.add_row("RAG", rag_status_text(payload["rag"]))

--- a/deepagent.toml
+++ b/deepagent.toml
@@ -40,6 +40,7 @@ args = ["-y", "@modelcontextprotocol/server-filesystem@2025.8.21", "."]
 cwd = "."
 
 [agent]
+state = "stateful"
 recursion_limit = 200
 skills = ["skills"]
 mcp_servers = ["repo"]

--- a/deepagent.toml.example
+++ b/deepagent.toml.example
@@ -37,6 +37,7 @@ transport = "http"
 url = "http://localhost:8000/mcp"
 
 [agent]
+state = "stateful"
 # A repo-root AGENTS.md file is loaded automatically into the main agent prompt.
 # Relative skill source paths are resolved from this file and mapped to /workspace/...
 # This directory should contain one or more skill folders, each with its own SKILL.md.

--- a/deepagent_runtime.py
+++ b/deepagent_runtime.py
@@ -63,6 +63,7 @@ ReasoningLevel = Literal["low", "medium", "high"]
 DisableStreaming = bool | Literal["tool_calling"]
 ModelThinking = Literal["auto", "adaptive", "disabled"]
 PersistenceMode = Literal["memory", "postgres"]
+AgentStateMode = Literal["stateful", "stateless"]
 DEFAULT_MODEL = "gpt-oss:20b"
 DEFAULT_MODEL_PROVIDER: ModelProvider = "ollama"
 DEFAULT_OLLAMA_ENDPOINT = "http://127.0.0.1"
@@ -71,6 +72,7 @@ DEFAULT_OLLAMA_BASE_URL = "http://127.0.0.1:11434"
 DEFAULT_ANTHROPIC_BASE_URL = "https://api.anthropic.com"
 DEFAULT_REASONING_LEVEL: ReasoningLevel = "medium"
 DEFAULT_MODEL_THINKING: ModelThinking = "auto"
+DEFAULT_AGENT_STATE: AgentStateMode = "stateful"
 DEFAULT_TEMPERATURE = 0.0
 DEFAULT_EXTENSIONS_CONFIG = "deepagent.toml"
 DEFAULT_RECURSION_LIMIT = 100
@@ -135,6 +137,30 @@ def normalize_reasoning_level(
     if candidate not in {"low", "medium", "high"}:
         return default
     return candidate  # type: ignore[return-value]
+
+
+def normalize_agent_state(value: Any | None) -> AgentStateMode:
+    """Normalize agent state mode.
+
+    Args:
+        value: Value to normalize, convert, or serialize.
+
+    Returns:
+        The normalized agent state mode.
+
+    Raises:
+        ValueError: If the supplied value is invalid.
+    """
+    if value is None or str(value).strip() == "":
+        return DEFAULT_AGENT_STATE
+    candidate = str(value).strip().lower().replace("-", "_")
+    if candidate == "stateful":
+        return "stateful"
+    if candidate == "stateless":
+        return "stateless"
+    raise ValueError(
+        "The top-level 'agent.state' config must be 'stateful' or 'stateless'."
+    )
 
 
 def normalize_disable_streaming(value: Any | None) -> DisableStreaming:
@@ -1448,6 +1474,7 @@ class ExtensionsConfig:
         config_path: Path to the config.
         mcp_tool_name_prefix: The MCP tool name prefix value.
         mcp_stateful: The MCP stateful value.
+        agent_state: Whether the DeepAgents graph is stateful or stateless.
         recursion_limit: The recursion limit value.
         mcp_servers: The MCP servers value.
         skills: The skills value.
@@ -1468,6 +1495,7 @@ class ExtensionsConfig:
     config_path: Path | None
     mcp_tool_name_prefix: bool = True
     mcp_stateful: bool = False
+    agent_state: AgentStateMode = DEFAULT_AGENT_STATE
     recursion_limit: int = DEFAULT_RECURSION_LIMIT
     mcp_servers: dict[str, dict[str, Any]] | None = None
     skills: tuple[str, ...] = ()
@@ -1799,6 +1827,7 @@ def parse_extensions_config(raw_config: dict[str, Any], config_path: Path) -> Ex
         agent_section.get("recursion_limit"),
         field_name="The top-level 'agent.recursion_limit' config",
     )
+    agent_state = normalize_agent_state(agent_section.get("state"))
     raw_mcp_servers = mcp_section.get("servers", {})
     mcp_servers: dict[str, dict[str, Any]] = {}
     for name, raw_server in raw_mcp_servers.items():
@@ -1973,6 +2002,7 @@ def parse_extensions_config(raw_config: dict[str, Any], config_path: Path) -> Ex
         config_path=config_path,
         mcp_tool_name_prefix=bool(mcp_section.get("tool_name_prefix", True)),
         mcp_stateful=bool(mcp_section.get("stateful", False)),
+        agent_state=agent_state,
         recursion_limit=recursion_limit,
         mcp_servers=mcp_servers or None,
         skills=skill_paths,
@@ -2142,6 +2172,7 @@ class RuntimeConfig:
         model_temperature: The model temperature value.
         default_reasoning: The default reasoning value.
         persistence_mode: The persistence mode value.
+        agent_state: Whether the DeepAgents graph is stateful or stateless.
         extensions: The extensions value.
         model_repeat_penalty: The model repeat penalty value.
         recursion_limit: The recursion limit value.
@@ -2163,6 +2194,7 @@ class RuntimeConfig:
     default_reasoning: ReasoningLevel
     persistence_mode: PersistenceMode
     extensions: ExtensionsConfig
+    agent_state: AgentStateMode = DEFAULT_AGENT_STATE
     model_repeat_penalty: float | None = None
     recursion_limit: int = DEFAULT_RECURSION_LIMIT
     rag_requested: bool = False
@@ -2432,6 +2464,7 @@ class RuntimeConfig:
             model_repeat_penalty=model_repeat_penalty,
             default_reasoning=default_reasoning,
             persistence_mode="postgres" if database_url else "memory",
+            agent_state=file_config.extensions.agent_state,
             extensions=file_config.extensions,
             recursion_limit=recursion_limit,
             rag_requested=rag_requested,
@@ -3245,11 +3278,10 @@ class AgentRuntime:
                     )
                     for subagent in self.config.extensions.async_subagents
                 )
-                agent = create_deep_agent_with_configured_summarization(
-                    self.config,
-                    model=model,
-                    tools=main_tools or None,
-                    system_prompt=compose_rag_system_prompt(
+                agent_kwargs: dict[str, Any] = {
+                    "model": model,
+                    "tools": main_tools or None,
+                    "system_prompt": compose_rag_system_prompt(
                         compose_agent_system_prompt(
                             SYSTEM_PROMPT,
                             self.config.extensions.custom_instruction,
@@ -3257,12 +3289,17 @@ class AgentRuntime:
                         ),
                         rag_enabled=rag_tool_enabled,
                     ),
-                    middleware=middleware,
-                    backend=build_deepagent_backend(project_root=self.project_root),
-                    store=self.store,
-                    checkpointer=self.checkpointer,
-                    skills=list(self.config.extensions.skills) or None,
-                    subagents=subagent_specs or None,
+                    "middleware": middleware,
+                    "backend": build_deepagent_backend(project_root=self.project_root),
+                    "skills": list(self.config.extensions.skills) or None,
+                    "subagents": subagent_specs or None,
+                }
+                if self.config.agent_state == "stateful":
+                    agent_kwargs["store"] = self.store
+                    agent_kwargs["checkpointer"] = self.checkpointer
+                agent = create_deep_agent_with_configured_summarization(
+                    self.config,
+                    **agent_kwargs,
                 )
                 self._agents[cache_key] = agent
             return agent

--- a/deepagent_runtime.py
+++ b/deepagent_runtime.py
@@ -95,13 +95,17 @@ OPENAI_COMPATIBLE_REASONING_DELTA_KEYS = (
     "reasoning_details",
 )
 SUMMARIZATION_STATUS_EVENT_KIND = "summarization_status"
+SYSTEM_PROMPT_MEMORY_LINE = (
+    "- Use `/memories/` for agent memory. Persistence depends on runtime configuration."
+)
+STATELESS_SYSTEM_PROMPT_MEMORY_LINE = "- Agent memory is disabled for this runtime."
 
 SYSTEM_PROMPT = f"""
 You are a local workspace deep agent running inside a Chainlit UI.
 
 Workspace contract:
 - Use `/workspace/` for real project files. This route maps to `{PROJECT_ROOT}`.
-- Use `/memories/` for agent memory. Persistence depends on runtime configuration.
+{SYSTEM_PROMPT_MEMORY_LINE}
 - Use any other absolute path only for ephemeral scratch work.
 
 Operating constraints:
@@ -2075,6 +2079,27 @@ def compose_agent_system_prompt(
     return "\n\n".join(sections)
 
 
+def system_prompt_for_agent_state(
+    base_prompt: str,
+    agent_state: AgentStateMode,
+) -> str:
+    """Return the system prompt adjusted for configured agent state.
+
+    Args:
+        base_prompt: The base prompt value.
+        agent_state: Whether the DeepAgents graph is stateful or stateless.
+
+    Returns:
+        The adjusted system prompt.
+    """
+    if agent_state == "stateful":
+        return base_prompt
+    return base_prompt.replace(
+        SYSTEM_PROMPT_MEMORY_LINE,
+        STATELESS_SYSTEM_PROMPT_MEMORY_LINE,
+    )
+
+
 def load_file_config(config_path: str | Path | None = None) -> FileConfig:
     """Load file config.
 
@@ -2580,30 +2605,37 @@ def anthropic_model_supports_adaptive_thinking(model_name: str) -> bool:
     )
 
 
-def build_deepagent_backend(*, project_root: Path | None = None) -> CompositeBackend:
+def build_deepagent_backend(
+    *,
+    project_root: Path | None = None,
+    include_memories: bool = True,
+) -> CompositeBackend:
     """Build deepagent backend.
 
     Args:
         project_root: Project root used to resolve local paths.
+        include_memories: Whether to expose the /memories/ store route.
 
     Returns:
         The constructed deepagent backend.
     """
     resolved_project_root = project_root or PROJECT_ROOT
     artifacts_root = deepagent_artifacts_root(resolved_project_root)
+    routes = {
+        deepagent_artifacts_route_prefix(resolved_project_root): FilesystemBackend(
+            root_dir=str(artifacts_root),
+            virtual_mode=True,
+        ),
+        "/workspace/": FilesystemBackend(
+            root_dir=str(resolved_project_root),
+            virtual_mode=True,
+        ),
+    }
+    if include_memories:
+        routes["/memories/"] = StoreBackend()
     return CompositeBackend(
         default=StateBackend(),
-        routes={
-            deepagent_artifacts_route_prefix(resolved_project_root): FilesystemBackend(
-                root_dir=str(artifacts_root),
-                virtual_mode=True,
-            ),
-            "/workspace/": FilesystemBackend(
-                root_dir=str(resolved_project_root),
-                virtual_mode=True,
-            ),
-            "/memories/": StoreBackend(),
-        },
+        routes=routes,
         artifacts_root=str(artifacts_root),
     )
 
@@ -2967,7 +2999,7 @@ def create_configured_graph(
         tools=sanitize_tools_for_model(config.model_provider, tools) or None,
         system_prompt=compose_rag_system_prompt(
             compose_agent_system_prompt(
-                system_prompt,
+                system_prompt_for_agent_state(system_prompt, config.agent_state),
                 (
                     config.extensions.custom_instruction
                     if apply_custom_instruction
@@ -2983,7 +3015,9 @@ def create_configured_graph(
             source="main-agent",
             project_root=PROJECT_ROOT,
         ),
-        backend=build_deepagent_backend(),
+        backend=build_deepagent_backend(
+            include_memories=config.agent_state == "stateful",
+        ),
         skills=list(config.extensions.skills) or None,
         subagents=subagent_specs or None,
     )
@@ -3283,14 +3317,20 @@ class AgentRuntime:
                     "tools": main_tools or None,
                     "system_prompt": compose_rag_system_prompt(
                         compose_agent_system_prompt(
-                            SYSTEM_PROMPT,
+                            system_prompt_for_agent_state(
+                                SYSTEM_PROMPT,
+                                self.config.agent_state,
+                            ),
                             self.config.extensions.custom_instruction,
                             project_root=self.project_root,
                         ),
                         rag_enabled=rag_tool_enabled,
                     ),
                     "middleware": middleware,
-                    "backend": build_deepagent_backend(project_root=self.project_root),
+                    "backend": build_deepagent_backend(
+                        project_root=self.project_root,
+                        include_memories=self.config.agent_state == "stateful",
+                    ),
                     "skills": list(self.config.extensions.skills) or None,
                     "subagents": subagent_specs or None,
                 }
@@ -3695,4 +3735,7 @@ class AgentRuntime:
         Returns:
             The constructed the deep agent backend for the current runtime settings.
         """
-        return build_deepagent_backend(project_root=self.project_root)
+        return build_deepagent_backend(
+            project_root=self.project_root,
+            include_memories=runtime.config.agent_state == "stateful",
+        )

--- a/deepagent_runtime.py
+++ b/deepagent_runtime.py
@@ -3151,7 +3151,10 @@ class AgentRuntime:
         Returns:
             Whether durable persistence is configured.
         """
-        return self.config.persistence_mode == "postgres"
+        return (
+            self.config.agent_state == "stateful"
+            and self.config.persistence_mode == "postgres"
+        )
 
     @property
     def rag_enabled(self) -> bool:
@@ -3206,7 +3209,10 @@ class AgentRuntime:
                 tool_name_prefix=self.config.extensions.mcp_tool_name_prefix,
             )
 
-        if not self.config.database_url:
+        if self.config.agent_state == "stateless":
+            self._store = None
+            self._checkpointer = None
+        elif not self.config.database_url:
             self._store = InMemoryStore()
             self._checkpointer = MemorySaver()
         else:

--- a/tests/test_agent_cli.py
+++ b/tests/test_agent_cli.py
@@ -483,6 +483,7 @@ async def test_cli_json_combines_multiple_actions(tmp_path: Path) -> None:
         model_base_url=None,
         default_reasoning="medium",
         model_disable_streaming=False,
+        agent_state="stateful",
         recursion_limit=50,
         persistence_mode="memory",
         extensions=SimpleNamespace(

--- a/tests/test_chainagents_api.py
+++ b/tests/test_chainagents_api.py
@@ -61,6 +61,7 @@ class _FakeRuntime:
             model_name="fake-model",
             model_provider="ollama",
             model_choices=("fake-model", "other-model"),
+            agent_state="stateful",
             recursion_limit=100,
             persistence_mode="memory",
         )
@@ -97,6 +98,7 @@ def test_status_reports_runtime_configuration() -> None:
         "model_provider": "ollama",
         "model_choices": ["fake-model", "other-model"],
         "default_reasoning": "medium",
+        "agent_state": "stateful",
         "recursion_limit": 100,
         "persistence_mode": "memory",
     }

--- a/tests/test_deepagent_runtime_rag.py
+++ b/tests/test_deepagent_runtime_rag.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import dataclasses
 from contextlib import asynccontextmanager
 from pathlib import Path
 from types import SimpleNamespace
@@ -952,6 +953,46 @@ recursion_limit = 64
     assert config.extensions.recursion_limit == 64
 
 
+def test_runtime_config_reads_agent_state_from_toml(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Verify that runtime config reads agent state from TOML."""
+    config_path = tmp_path / "deepagent.toml"
+    config_path.write_text(
+        """
+[agent]
+state = "stateless"
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DEEPAGENT_CONFIG", str(config_path))
+
+    config = deepagent_runtime.RuntimeConfig.from_env()
+
+    assert config.agent_state == "stateless"
+    assert config.extensions.agent_state == "stateless"
+
+
+def test_runtime_config_rejects_invalid_agent_state(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Verify that invalid agent state config is rejected."""
+    config_path = tmp_path / "deepagent.toml"
+    config_path.write_text(
+        """
+[agent]
+state = "sometimes"
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DEEPAGENT_CONFIG", str(config_path))
+
+    with pytest.raises(ValueError, match="agent.state"):
+        deepagent_runtime.RuntimeConfig.from_env()
+
+
 def test_runtime_config_env_overrides_recursion_limit(
     tmp_path: Path,
     monkeypatch,
@@ -1264,6 +1305,36 @@ def test_get_agent_passes_deepagents_backend_instance(
     assert isinstance(backend, deepagent_runtime.CompositeBackend)
     assert not callable(backend)
     assert backend.routes["/workspace/"].cwd == tmp_path
+
+
+def test_get_agent_omits_store_and_checkpointer_when_stateless(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Verify stateless agents do not receive LangGraph state handles."""
+    captured: dict[str, object] = {}
+
+    def fake_create_deep_agent(*, tools=None, **kwargs):
+        """Capture Deep Agent factory arguments for tests."""
+        captured["kwargs"] = kwargs
+        return object()
+
+    monkeypatch.setattr(deepagent_runtime, "create_deep_agent", fake_create_deep_agent)
+
+    config = make_runtime_config(tmp_path)
+    config = dataclasses.replace(
+        config,
+        agent_state="stateless",
+        extensions=dataclasses.replace(config.extensions, agent_state="stateless"),
+    )
+    runtime = AgentRuntime(config, project_root=tmp_path)
+    runtime._store = InMemoryStore()
+    runtime._checkpointer = MemorySaver()
+
+    asyncio.run(runtime.get_agent("medium", thread_id="thread-1"))
+
+    assert "store" not in captured["kwargs"]
+    assert "checkpointer" not in captured["kwargs"]
 
 
 def test_get_agent_leaves_summarization_middleware_to_deepagents_when_enabled(

--- a/tests/test_deepagent_runtime_rag.py
+++ b/tests/test_deepagent_runtime_rag.py
@@ -1337,6 +1337,39 @@ def test_get_agent_omits_store_and_checkpointer_when_stateless(
     assert "checkpointer" not in captured["kwargs"]
 
 
+def test_get_agent_disables_memories_backend_and_prompt_when_stateless(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Verify stateless agents do not expose unusable memory routes."""
+    captured: dict[str, object] = {}
+
+    def fake_create_deep_agent(*, tools=None, **kwargs):
+        """Capture Deep Agent factory arguments for tests."""
+        captured["kwargs"] = kwargs
+        return object()
+
+    monkeypatch.setattr(deepagent_runtime, "create_deep_agent", fake_create_deep_agent)
+
+    config = make_runtime_config(tmp_path)
+    config = dataclasses.replace(
+        config,
+        agent_state="stateless",
+        extensions=dataclasses.replace(config.extensions, agent_state="stateless"),
+    )
+    runtime = AgentRuntime(config, project_root=tmp_path)
+    runtime._store = InMemoryStore()
+    runtime._checkpointer = MemorySaver()
+
+    asyncio.run(runtime.get_agent("medium", thread_id="thread-1"))
+
+    backend = captured["kwargs"]["backend"]
+    system_prompt = captured["kwargs"]["system_prompt"]
+    assert "/memories/" not in backend.routes
+    assert "/memories/" not in system_prompt
+    assert "Agent memory is disabled for this runtime." in system_prompt
+
+
 def test_get_agent_leaves_summarization_middleware_to_deepagents_when_enabled(
     tmp_path: Path,
     monkeypatch,

--- a/tests/test_deepagent_runtime_rag.py
+++ b/tests/test_deepagent_runtime_rag.py
@@ -1193,6 +1193,58 @@ def test_agent_runtime_initialize_runs_rag_startup_check(
     assert runtime.rag_status.ready is True
 
 
+def test_agent_runtime_initialize_skips_postgres_state_handles_when_stateless(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Verify stateless runtime does not open LangGraph Postgres state handles."""
+    config = make_runtime_config(tmp_path)
+    config = dataclasses.replace(
+        config,
+        database_url="postgresql://example.invalid/chainagents",
+        persistence_mode="postgres",
+        agent_state="stateless",
+        extensions=dataclasses.replace(config.extensions, agent_state="stateless"),
+        rag_requested=False,
+        rag=None,
+    )
+
+    def fail_from_conn_string(database_url: str):
+        raise AssertionError(f"Unexpected Postgres state init for {database_url}")
+
+    monkeypatch.setattr(
+        deepagent_runtime.AsyncPostgresStore,
+        "from_conn_string",
+        fail_from_conn_string,
+    )
+    monkeypatch.setattr(
+        deepagent_runtime.AsyncPostgresSaver,
+        "from_conn_string",
+        fail_from_conn_string,
+    )
+
+    runtime = AgentRuntime(config)
+    asyncio.run(runtime._initialize())
+
+    assert runtime._store is None
+    assert runtime._checkpointer is None
+
+
+def test_persistence_enabled_requires_stateful_agent_state(tmp_path: Path) -> None:
+    """Verify stateless mode is not reported as agent persistence enabled."""
+    config = make_runtime_config(tmp_path)
+    config = dataclasses.replace(
+        config,
+        database_url="postgresql://example.invalid/chainagents",
+        persistence_mode="postgres",
+        agent_state="stateless",
+        extensions=dataclasses.replace(config.extensions, agent_state="stateless"),
+    )
+    runtime = AgentRuntime(config)
+
+    assert runtime.persistence_enabled is False
+
+
 def test_get_agent_includes_rag_tool_when_ready(
     tmp_path: Path,
     monkeypatch,


### PR DESCRIPTION
## Summary
- add `[agent].state` with `stateful` and `stateless` modes
- omit LangGraph store and checkpointer when stateless is selected
- surface agent state in CLI and API status output and document the new config

## Testing
- `uv run pytest -q` passed