### PR TITLE
Add multi-user Chainlit auth support

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,7 @@ export DEEPAGENT_RECURSION_LIMIT="200"
 # export ANTHROPIC_API_KEY="required-for-provider-anthropic-unless-DEEPAGENT_MODEL_API_KEY-is-set"
 export DEEPAGENT_CONFIG="deepagent.toml"
 export CHAINLIT_AUTH_SECRET="replace-with-a-long-random-string"
-export CHAINLIT_AUTH_USERNAME="admin"
-export CHAINLIT_AUTH_PASSWORD="change-me"
+export CHAINLIT_AUTH_USERS='{"admin":"change-me","alice":"alice-password"}'
 # export LANGFUSE_PUBLIC_KEY="pk-lf-..."
 # export LANGFUSE_SECRET_KEY="sk-lf-..."
 # export LANGFUSE_BASE_URL="https://cloud.langfuse.com"
@@ -88,11 +87,13 @@ export CHAINLIT_AUTH_PASSWORD="change-me"
 - it controls the maximum LangGraph steps for a single agent run
 - raise it when long tool-heavy Deep Agent runs hit `GraphRecursionError`
 
-`CHAINLIT_AUTH_SECRET`, `CHAINLIT_AUTH_USERNAME`, and `CHAINLIT_AUTH_PASSWORD` are optional:
+`CHAINLIT_AUTH_SECRET` and Chainlit user credentials are optional:
 
-- when all three are set, the app enables Chainlit password authentication
+- when `CHAINLIT_AUTH_SECRET` and `CHAINLIT_AUTH_USERS` are set, the app enables Chainlit password authentication for each configured user
+- `CHAINLIT_AUTH_USERS` must be a JSON object mapping usernames to passwords, e.g. `{"admin":"change-me","alice":"alice-password"}`
+- the legacy `CHAINLIT_AUTH_USERNAME` and `CHAINLIT_AUTH_PASSWORD` pair still works for a single user when `CHAINLIT_AUTH_USERS` is unset
 - together with `DATABASE_URL`, that unlocks the native Chainlit history bar and chat resume UI
-- when they are unset, the app stays unauthenticated and the history bar remains unavailable
+- when auth credentials are unset, the app stays unauthenticated and the history bar remains unavailable
 
 ## Optional: Install Postgres
 
@@ -131,11 +132,18 @@ This app includes a simple password-based auth callback driven by environment va
 
 ```bash
 export CHAINLIT_AUTH_SECRET="replace-with-a-long-random-string"
+export CHAINLIT_AUTH_USERS='{"admin":"change-me","alice":"alice-password"}'
+```
+
+For compatibility, a single user can still be configured with:
+
+```bash
+export CHAINLIT_AUTH_SECRET="replace-with-a-long-random-string"
 export CHAINLIT_AUTH_USERNAME="admin"
 export CHAINLIT_AUTH_PASSWORD="change-me"
 ```
 
-With both `DATABASE_URL` and the `CHAINLIT_AUTH_*` variables set:
+With `DATABASE_URL`, `CHAINLIT_AUTH_SECRET`, and either `CHAINLIT_AUTH_USERS` or the legacy username/password pair set:
 
 - users can sign in through Chainlit's native auth screen
 - the history sidebar can list and reopen prior chats
@@ -703,7 +711,7 @@ See [deepagent.toml.example](deepagent.toml.example) for a complete example.
 
 ## Notes
 
-- Native Chainlit history is available when both `DATABASE_URL` and the `CHAINLIT_AUTH_*` variables are configured.
+- Native Chainlit history is available when `DATABASE_URL`, `CHAINLIT_AUTH_SECRET`, and either `CHAINLIT_AUTH_USERS` or the legacy username/password pair are configured.
 - If `DATABASE_URL` is set but authentication is not configured, Chainlit still persists thread records, but they are not browseable from the UI.
 - When `DATABASE_URL` is unset, thread IDs only persist while the process stays alive.
 - When `DATABASE_URL` is set, durable state is available through LangGraph thread IDs. You can reuse a thread ID from the chat settings panel to continue the same checkpointed thread.

--- a/main.py
+++ b/main.py
@@ -194,7 +194,10 @@ def authenticate_chainlit_user(
     configured_password = configured_users.get(username)
     if configured_password is None:
         return None
-    if not secrets.compare_digest(password, configured_password):
+    if not secrets.compare_digest(
+        password.encode("utf-8"),
+        configured_password.encode("utf-8"),
+    ):
         return None
     return cl.User(
         identifier=username,

--- a/main.py
+++ b/main.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import json
 import mimetypes
 import os
 import secrets
 import traceback
+from collections.abc import Mapping
 from contextlib import suppress
 from pathlib import Path
 from typing import Any
@@ -110,10 +112,100 @@ VISION_IMAGE_MIME_ALIASES = {
     "image/x-png": "image/png",
 }
 GENERIC_UPLOAD_MIME_TYPES = {"", "application/octet-stream"}
-AUTH_USERNAME = os.getenv("CHAINLIT_AUTH_USERNAME", "").strip()
-AUTH_PASSWORD = os.getenv("CHAINLIT_AUTH_PASSWORD", "").strip()
+
+
+def load_chainlit_auth_users(
+    *,
+    raw_users: str | None = None,
+    legacy_username: str | None = None,
+    legacy_password: str | None = None,
+) -> dict[str, str]:
+    """Load Chainlit password users from environment-compatible values.
+
+    Args:
+        raw_users: JSON object mapping usernames to passwords.
+        legacy_username: Single-user username fallback.
+        legacy_password: Single-user password fallback.
+
+    Returns:
+        A mapping of usernames to passwords.
+
+    Raises:
+        ValueError: If CHAINLIT_AUTH_USERS is set but invalid.
+    """
+    if raw_users is None:
+        raw_users = os.getenv("CHAINLIT_AUTH_USERS", "")
+    raw_users = raw_users.strip()
+    if raw_users:
+        try:
+            parsed_users = json.loads(raw_users)
+        except json.JSONDecodeError as exc:
+            raise ValueError("CHAINLIT_AUTH_USERS must contain valid JSON") from exc
+
+        if not isinstance(parsed_users, dict):
+            raise ValueError(
+                "CHAINLIT_AUTH_USERS must be a JSON object mapping usernames to passwords"
+            )
+
+        auth_users: dict[str, str] = {}
+        for username, password in parsed_users.items():
+            if not isinstance(username, str) or not username.strip():
+                raise ValueError(
+                    "CHAINLIT_AUTH_USERS usernames must be non-empty strings"
+                )
+            if not isinstance(password, str) or not password:
+                raise ValueError(
+                    "CHAINLIT_AUTH_USERS passwords must be non-empty strings"
+                )
+            auth_users[username] = password
+
+        if not auth_users:
+            raise ValueError("CHAINLIT_AUTH_USERS must define at least one user")
+        return auth_users
+
+    if legacy_username is None:
+        legacy_username = os.getenv("CHAINLIT_AUTH_USERNAME", "")
+    if legacy_password is None:
+        legacy_password = os.getenv("CHAINLIT_AUTH_PASSWORD", "")
+
+    legacy_username = legacy_username.strip()
+    legacy_password = legacy_password.strip()
+    if legacy_username and legacy_password:
+        return {legacy_username: legacy_password}
+    return {}
+
+
+def authenticate_chainlit_user(
+    username: str,
+    password: str,
+    auth_users: Mapping[str, str] | None = None,
+) -> cl.User | None:
+    """Authenticate a Chainlit user from configured password settings.
+
+    Args:
+        username: The username value.
+        password: The password value.
+        auth_users: Optional configured users mapping.
+
+    Returns:
+        A Chainlit user when credentials match, otherwise None.
+    """
+    configured_users = AUTH_USERS if auth_users is None else auth_users
+    configured_password = configured_users.get(username)
+    if configured_password is None:
+        return None
+    if not secrets.compare_digest(password, configured_password):
+        return None
+    return cl.User(
+        identifier=username,
+        display_name=username,
+        metadata={"provider": "credentials"},
+    )
+
+
+AUTH_USERS = load_chainlit_auth_users()
 AUTH_SECRET = os.getenv("CHAINLIT_AUTH_SECRET", "").strip()
-AUTH_ENABLED = bool(AUTH_SECRET and AUTH_USERNAME and AUTH_PASSWORD)
+AUTH_ENABLED = bool(AUTH_SECRET and AUTH_USERS)
 
 
 def current_chainlit_thread_id() -> str:
@@ -890,17 +982,7 @@ if AUTH_ENABLED:
         Returns:
             The password auth callback result.
         """
-        if not (
-            secrets.compare_digest(username, AUTH_USERNAME)
-            and secrets.compare_digest(password, AUTH_PASSWORD)
-        ):
-            return None
-
-        return cl.User(
-            identifier=AUTH_USERNAME,
-            display_name=AUTH_USERNAME,
-            metadata={"provider": "credentials"},
-        )
+        return authenticate_chainlit_user(username, password)
 
 
 async def get_runtime_or_notify() -> AgentRuntime | None:
@@ -1004,7 +1086,11 @@ async def on_chat_start() -> None:
     history_line = (
         "- History bar: enabled for authenticated users\n"
         if runtime.persistence_enabled and AUTH_ENABLED
-        else "- History bar: disabled; set `DATABASE_URL`, `CHAINLIT_AUTH_SECRET`, `CHAINLIT_AUTH_USERNAME`, and `CHAINLIT_AUTH_PASSWORD` to enable native Chainlit history\n"
+        else (
+            "- History bar: disabled; set `DATABASE_URL`, `CHAINLIT_AUTH_SECRET`, "
+            "and `CHAINLIT_AUTH_USERS` (or legacy `CHAINLIT_AUTH_USERNAME` / "
+            "`CHAINLIT_AUTH_PASSWORD`) to enable native Chainlit history\n"
+        )
     )
     extensions = runtime.config.extensions
     configured_command_count = len(extensions.chainlit_commands)

--- a/tests/test_main_native_commands.py
+++ b/tests/test_main_native_commands.py
@@ -9,6 +9,82 @@ import main
 import pytest
 
 
+def test_load_chainlit_auth_users_parses_json_map() -> None:
+    """Verify that Chainlit auth can load multiple users from JSON."""
+    users = main.load_chainlit_auth_users(
+        raw_users='{"admin":"change-me","alice":"alice-password"}',
+    )
+
+    assert users == {"admin": "change-me", "alice": "alice-password"}
+
+
+def test_load_chainlit_auth_users_uses_legacy_credentials() -> None:
+    """Verify that legacy single-user Chainlit auth settings still work."""
+    users = main.load_chainlit_auth_users(
+        raw_users="",
+        legacy_username="admin",
+        legacy_password="change-me",
+    )
+
+    assert users == {"admin": "change-me"}
+
+
+def test_load_chainlit_auth_users_prefers_json_over_legacy_credentials() -> None:
+    """Verify that CHAINLIT_AUTH_USERS takes precedence over legacy settings."""
+    users = main.load_chainlit_auth_users(
+        raw_users='{"alice":"alice-password"}',
+        legacy_username="admin",
+        legacy_password="change-me",
+    )
+
+    assert users == {"alice": "alice-password"}
+
+
+@pytest.mark.parametrize(
+    ("raw_users", "message"),
+    (
+        ("not-json", "must contain valid JSON"),
+        ('["admin"]', "must be a JSON object"),
+        ("{}", "must define at least one user"),
+        ('{"":"password"}', "usernames must be non-empty strings"),
+        ('{"admin":123}', "passwords must be non-empty strings"),
+        ('{"admin":""}', "passwords must be non-empty strings"),
+    ),
+)
+def test_load_chainlit_auth_users_rejects_invalid_json_map(
+    raw_users: str,
+    message: str,
+) -> None:
+    """Verify that invalid Chainlit auth user config fails clearly."""
+    with pytest.raises(ValueError, match=message):
+        main.load_chainlit_auth_users(raw_users=raw_users)
+
+
+def test_authenticate_chainlit_user_accepts_configured_users() -> None:
+    """Verify that Chainlit auth accepts any configured user."""
+    users = {"admin": "change-me", "alice": "alice-password"}
+
+    admin = main.authenticate_chainlit_user("admin", "change-me", users)
+    alice = main.authenticate_chainlit_user("alice", "alice-password", users)
+
+    assert admin is not None
+    assert admin.identifier == "admin"
+    assert admin.display_name == "admin"
+    assert admin.metadata == {"provider": "credentials"}
+    assert alice is not None
+    assert alice.identifier == "alice"
+    assert alice.display_name == "alice"
+    assert alice.metadata == {"provider": "credentials"}
+
+
+def test_authenticate_chainlit_user_rejects_invalid_credentials() -> None:
+    """Verify that Chainlit auth rejects unknown users and wrong passwords."""
+    users = {"admin": "change-me", "alice": "alice-password"}
+
+    assert main.authenticate_chainlit_user("admin", "wrong", users) is None
+    assert main.authenticate_chainlit_user("unknown", "change-me", users) is None
+
+
 def test_resolve_native_command_prefers_explicit_slash_text() -> None:
     """Verify that resolve native command prefers explicit slash text."""
     parsed = agent_commands.resolve_native_command(

--- a/tests/test_main_native_commands.py
+++ b/tests/test_main_native_commands.py
@@ -77,6 +77,16 @@ def test_authenticate_chainlit_user_accepts_configured_users() -> None:
     assert alice.metadata == {"provider": "credentials"}
 
 
+def test_authenticate_chainlit_user_accepts_non_ascii_password() -> None:
+    """Verify that Chainlit auth supports non-ASCII JSON passwords."""
+    users = {"alice": "påsswörd"}
+
+    user = main.authenticate_chainlit_user("alice", "påsswörd", users)
+
+    assert user is not None
+    assert user.identifier == "alice"
+
+
 def test_authenticate_chainlit_user_rejects_invalid_credentials() -> None:
     """Verify that Chainlit auth rejects unknown users and wrong passwords."""
     users = {"admin": "change-me", "alice": "alice-password"}


### PR DESCRIPTION
## Summary
- Add `CHAINLIT_AUTH_USERS` JSON support for multiple Chainlit users
- Keep the legacy single-user `CHAINLIT_AUTH_USERNAME` / `CHAINLIT_AUTH_PASSWORD` fallback
- Update the README to show the new multi-user auth example and history-bar requirements

## Testing
- Added unit coverage for JSON parsing, fallback behavior, invalid config handling, and credential checks
- `uv run pytest tests/test_main_native_commands.py -q`
- `uv run pytest`