### PR TITLE
Add configurable Chainlit starter prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -557,6 +557,10 @@ commands = [
   { name = "repo-readme", description = "Run an MCP tool directly.", target = "mcp_tool", value = "repo_read_file", mcp_server = "repo", template = "{\"path\":\"README.md\"}" },
   { name = "summarize", description = "Apply a prompt template.", target = "prompt", value = "Summarize the input", template = "Summarize this:\n{input}" }
 ]
+starters = [
+  { label = "Explain this repo", message = "Explain the architecture of this repository and identify the most important files.", command = "ask-researcher", icon = "book-open" },
+  { label = "Review current changes", message = "Review the current working tree changes for bugs, regressions, and missing tests." }
+]
 ```
 
 `target` modes:
@@ -578,6 +582,8 @@ Notes:
 - Each discovered skill also becomes `/<skill-name>` automatically. For example, a skill with `name: reviewer` is available as `/reviewer`.
 - Skill-backed commands always force the main agent to read the selected `SKILL.md` first and use it for that turn.
 - If a configured `[chainlit].commands` entry and a skill share the same slash name, the configured command wins.
+- `starters` define starter prompts shown by Chainlit before the first message in a thread.
+- Starter `label` and `message` are required. Starter `command` and `icon` are optional.
 
 ## Add Async Subagents
 

--- a/deepagent.toml
+++ b/deepagent.toml
@@ -100,3 +100,7 @@ commands = [
   { name = "repo-readme", description = "Run an MCP tool directly.", target = "mcp_tool", value = "repo_read_file", mcp_server = "repo", template = "{\"path\":\"README.md\"}" },
   { name = "summarize", description = "Apply a prompt template.", target = "prompt", value = "Summarize the input", template = "Summarize this:\n{input}" }
 ]
+starters = [
+  { label = "Explain this repo", message = "Explain the architecture of this repository and identify the most important files.", command = "ask-researcher", icon = "book-open" },
+  { label = "Review current changes", message = "Review the current working tree changes for bugs, regressions, and missing tests." }
+]

--- a/deepagent.toml.example
+++ b/deepagent.toml.example
@@ -67,6 +67,11 @@ commands = [
   { name = "ask-researcher", description = "Delegate to repo-researcher subagent.", target = "subagent", value = "repo-researcher", template = "{input}" },
   { name = "repo-readme", description = "Call MCP filesystem read_file on README.md.", target = "mcp_tool", value = "repo_read_file", mcp_server = "repo", template = "{\"path\": \"README.md\"}" },
 ]
+# Starter prompts shown by Chainlit before a message is sent.
+starters = [
+  { label = "Explain this repo", message = "Explain the architecture of this repository and identify the most important files.", command = "ask-researcher", icon = "book-open" },
+  { label = "Review current changes", message = "Review the current working tree changes for bugs, regressions, and missing tests." },
+]
 
 [rag]
 enabled = true

--- a/deepagent_runtime.py
+++ b/deepagent_runtime.py
@@ -1400,6 +1400,23 @@ class ChainlitCommandConfig:
 
 
 @dataclass(frozen=True)
+class ChainlitStarterConfig:
+    """Describe a Chainlit starter prompt exposed at thread start.
+
+    Attributes:
+        label: Starter label shown in the Chainlit UI.
+        message: Message sent when the starter is selected.
+        command: Optional Chainlit command associated with the starter.
+        icon: Optional icon name shown by Chainlit.
+    """
+
+    label: str
+    message: str
+    command: str | None = None
+    icon: str | None = None
+
+
+@dataclass(frozen=True)
 class SkillCommandMetadata:
     """Track metadata required to expose a configured skill as a command.
 
@@ -1497,6 +1514,7 @@ class ExtensionsConfig:
         subagents: The subagents value.
         async_subagents: Async subagent configurations available for monitoring.
         chainlit_commands: The chainlit commands value.
+        chainlit_starters: The chainlit starters value.
         chainlit_model_mode_enabled: The chainlit model mode enabled value.
         chainlit_reasoning_mode_enabled: The chainlit reasoning mode enabled value.
         chainlit_startup_status_enabled: The chainlit startup status enabled value.
@@ -1518,6 +1536,7 @@ class ExtensionsConfig:
     subagents: tuple[SubagentConfig, ...] = ()
     async_subagents: tuple[AsyncSubagentConfig, ...] = ()
     chainlit_commands: tuple[ChainlitCommandConfig, ...] = ()
+    chainlit_starters: tuple[ChainlitStarterConfig, ...] = ()
     chainlit_model_mode_enabled: bool = True
     chainlit_reasoning_mode_enabled: bool = True
     chainlit_startup_status_enabled: bool = True
@@ -1540,6 +1559,7 @@ class ExtensionsConfig:
             or self.subagents
             or self.async_subagents
             or self.chainlit_commands
+            or self.chainlit_starters
         )
 
 
@@ -1965,6 +1985,9 @@ def parse_extensions_config(raw_config: dict[str, Any], config_path: Path) -> Ex
     raw_chainlit_commands = chainlit_section.get("commands", [])
     if not isinstance(raw_chainlit_commands, list):
         raise ValueError("The top-level 'chainlit.commands' config must be an array of tables.")
+    raw_chainlit_starters = chainlit_section.get("starters", [])
+    if not isinstance(raw_chainlit_starters, list):
+        raise ValueError("The top-level 'chainlit.starters' config must be an array of tables.")
     raw_reasoning_mode_enabled = chainlit_section.get("reasoning_mode_enabled", True)
     raw_model_mode_enabled = chainlit_section.get("model_mode_enabled", True)
     raw_startup_status_enabled = chainlit_section.get("startup_status_enabled", True)
@@ -2037,6 +2060,33 @@ def parse_extensions_config(raw_config: dict[str, Any], config_path: Path) -> Ex
         )
         seen_commands.add(name)
 
+    chainlit_starters: list[ChainlitStarterConfig] = []
+    for index, raw_chainlit_starter in enumerate(raw_chainlit_starters, start=1):
+        if not isinstance(raw_chainlit_starter, dict):
+            raise ValueError(
+                f"Chainlit starter entry #{index} must be a table/object."
+            )
+        label = str(raw_chainlit_starter.get("label", "")).strip()
+        message = str(raw_chainlit_starter.get("message", "")).strip()
+        command = normalize_optional_string(raw_chainlit_starter.get("command"))
+        icon = normalize_optional_string(raw_chainlit_starter.get("icon"))
+        if not label:
+            raise ValueError(
+                f"Chainlit starter entry #{index} must include a non-empty 'label'."
+            )
+        if not message:
+            raise ValueError(
+                f"Chainlit starter '{label}' must include a non-empty 'message'."
+            )
+        chainlit_starters.append(
+            ChainlitStarterConfig(
+                label=label,
+                message=message,
+                command=command,
+                icon=icon,
+            )
+        )
+
     return ExtensionsConfig(
         config_path=config_path,
         mcp_tool_name_prefix=bool(mcp_section.get("tool_name_prefix", True)),
@@ -2049,6 +2099,7 @@ def parse_extensions_config(raw_config: dict[str, Any], config_path: Path) -> Ex
         subagents=tuple(subagents),
         async_subagents=tuple(async_subagents),
         chainlit_commands=tuple(chainlit_commands),
+        chainlit_starters=tuple(chainlit_starters),
         chainlit_model_mode_enabled=raw_model_mode_enabled,
         chainlit_reasoning_mode_enabled=raw_reasoning_mode_enabled,
         chainlit_startup_status_enabled=raw_startup_status_enabled,

--- a/main.py
+++ b/main.py
@@ -9,7 +9,7 @@ import mimetypes
 import os
 import secrets
 import traceback
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 from contextlib import suppress
 from pathlib import Path
 from typing import Any
@@ -36,6 +36,7 @@ from deepagent_runtime import (
     DEFAULT_REASONING_LEVEL,
     AgentRuntime,
     AppSettings,
+    ChainlitStarterConfig,
     RuntimeConfig,
     build_langgraph_run_config,
     format_model_provider,
@@ -209,6 +210,52 @@ def authenticate_chainlit_user(
 AUTH_USERS = load_chainlit_auth_users()
 AUTH_SECRET = os.getenv("CHAINLIT_AUTH_SECRET", "").strip()
 AUTH_ENABLED = bool(AUTH_SECRET and AUTH_USERS)
+
+
+def build_chainlit_starters(
+    starter_configs: Iterable[ChainlitStarterConfig],
+) -> list[cl.Starter]:
+    """Build Chainlit starter objects from runtime config.
+
+    Args:
+        starter_configs: Configured starter definitions.
+
+    Returns:
+        Chainlit starter objects.
+    """
+    return [
+        cl.Starter(
+            label=starter.label,
+            message=starter.message,
+            command=starter.command,
+            icon=starter.icon,
+        )
+        for starter in starter_configs
+    ]
+
+
+@cl.set_starters
+async def configured_chainlit_starters(
+    user: cl.User | None = None,
+    language: str | None = None,
+) -> list[cl.Starter]:
+    """Return configured Chainlit starters.
+
+    Args:
+        user: Authenticated Chainlit user, if any.
+        language: Active UI language, if any.
+
+    Returns:
+        Configured Chainlit starter objects.
+    """
+    _ = (user, language)
+    runtime = AgentRuntime.current()
+    extensions = (
+        runtime.config.extensions
+        if runtime is not None
+        else RuntimeConfig.from_env().extensions
+    )
+    return build_chainlit_starters(extensions.chainlit_starters)
 
 
 def current_chainlit_thread_id() -> str:
@@ -1114,6 +1161,7 @@ async def on_chat_start() -> None:
         f"- Configured commands: `{configured_command_count}`\n"
         f"- Skill-backed commands: `{skill_command_count}`\n"
         f"- Native commands: `{len(runtime.chainlit_commands)}`\n"
+        f"- Starters: `{len(extensions.chainlit_starters)}`\n"
     )
     if runtime.chainlit_commands:
         command_lines = "\n".join(

--- a/tests/test_deepagent_runtime_rag.py
+++ b/tests/test_deepagent_runtime_rag.py
@@ -2178,6 +2178,67 @@ commands = [
     assert extensions.chainlit_chronological_ui_enabled is False
 
 
+def test_load_extensions_config_parses_chainlit_starters(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Verify that load extensions config parses chainlit starters.
+
+    Args:
+        tmp_path: Path to the tmp.
+        monkeypatch: The monkeypatch value.
+    """
+    config_path = tmp_path / "deepagent.toml"
+    config_path.write_text(
+        """
+[chainlit]
+starters = [
+  { label = "Explain repo", message = "Explain this repository.", icon = "book-open" },
+  { label = "Review diff", message = "Review the current changes.", command = "review" }
+]
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DEEPAGENT_CONFIG", str(config_path))
+
+    extensions = deepagent_runtime.load_extensions_config()
+
+    assert len(extensions.chainlit_starters) == 2
+    assert extensions.chainlit_starters[0].label == "Explain repo"
+    assert extensions.chainlit_starters[0].message == "Explain this repository."
+    assert extensions.chainlit_starters[0].icon == "book-open"
+    assert extensions.chainlit_starters[0].command is None
+    assert extensions.chainlit_starters[1].label == "Review diff"
+    assert extensions.chainlit_starters[1].command == "review"
+    assert extensions.chainlit_starters[1].icon is None
+
+
+def test_load_extensions_config_rejects_invalid_chainlit_starters(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Verify that load extensions config rejects invalid chainlit starters.
+
+    Args:
+        tmp_path: Path to the tmp.
+        monkeypatch: The monkeypatch value.
+    """
+    config_path = tmp_path / "deepagent.toml"
+    config_path.write_text(
+        """
+[chainlit]
+starters = [
+  { label = "Missing message" }
+]
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DEEPAGENT_CONFIG", str(config_path))
+
+    with pytest.raises(ValueError, match="must include a non-empty 'message'"):
+        deepagent_runtime.load_extensions_config()
+
+
 def test_load_extensions_config_parses_summarization_middleware_flag(
     tmp_path: Path,
     monkeypatch,

--- a/tests/test_main_native_commands.py
+++ b/tests/test_main_native_commands.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 import agent_commands
 import main
 import pytest
+from deepagent_runtime import ChainlitStarterConfig
 
 
 def test_load_chainlit_auth_users_parses_json_map() -> None:
@@ -106,6 +107,63 @@ def test_resolve_native_command_prefers_explicit_slash_text() -> None:
         command_name="summarize",
         raw_args="hello world",
     )
+
+
+def test_build_chainlit_starters_maps_config_to_chainlit_starters() -> None:
+    """Verify that starter config maps to Chainlit Starter objects."""
+    starters = main.build_chainlit_starters(
+        (
+            ChainlitStarterConfig(
+                label="Explain repo",
+                message="Explain this repository.",
+                icon="book-open",
+            ),
+            ChainlitStarterConfig(
+                label="Review diff",
+                message="Review the current changes.",
+                command="review",
+            ),
+        )
+    )
+
+    assert len(starters) == 2
+    assert starters[0].label == "Explain repo"
+    assert starters[0].message == "Explain this repository."
+    assert starters[0].icon == "book-open"
+    assert starters[0].command is None
+    assert starters[1].label == "Review diff"
+    assert starters[1].message == "Review the current changes."
+    assert starters[1].command == "review"
+    assert starters[1].icon is None
+
+
+@pytest.mark.anyio
+async def test_configured_chainlit_starters_reads_current_runtime(monkeypatch) -> None:
+    """Verify that the Chainlit starter callback reads current runtime config."""
+    runtime = SimpleNamespace(
+        config=SimpleNamespace(
+            extensions=SimpleNamespace(
+                chainlit_starters=(
+                    ChainlitStarterConfig(
+                        label="Explain repo",
+                        message="Explain this repository.",
+                    ),
+                )
+            )
+        )
+    )
+
+    async def fail_get_runtime():
+        raise AssertionError("starter callback should not initialize the runtime")
+
+    monkeypatch.setattr(main.AgentRuntime, "current", lambda: runtime)
+    monkeypatch.setattr(main.AgentRuntime, "get", fail_get_runtime)
+
+    starters = await main.configured_chainlit_starters()
+
+    assert len(starters) == 1
+    assert starters[0].label == "Explain repo"
+    assert starters[0].message == "Explain this repository."
 
 
 def test_resolve_native_command_uses_selected_command_input() -> None:


### PR DESCRIPTION
## Summary
- Add `chainlit.starters` support to the runtime config and parser
- Expose configured starters through Chainlit at chat start
- Document starter prompt fields in the README and example config
- Add unit tests for parsing, mapping, and runtime access

## Testing
- Added unit tests covering valid and invalid starter config parsing
- Added unit tests for starter object mapping and runtime callback behavior