### PR TITLE
Auto-bootstrap Chainlit Postgres schema and register Postgres data layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,8 @@ Notes:
 
 - The Compose file lives at [compose.yaml](compose.yaml) and creates a persistent `postgres-data` volume.
 - If you already have Postgres installed locally, create an empty database and set `DATABASE_URL` to that instance instead.
-- No separate migration step is required for this app. On startup it calls the LangGraph Postgres store and checkpointer `setup()` routines automatically.
+- No separate migration step is required for this app. On startup it calls the LangGraph Postgres store/checkpointer `setup()` routines and creates any missing Chainlit persistence tables (`"User"`, `"Thread"`, `"Step"`, `"Feedback"`, and `"Element"`) automatically.
+- If you manage the Chainlit schema externally, set `CHAINLIT_SCHEMA_BOOTSTRAP=false` before launching the app to skip the automatic Chainlit table bootstrap.
 
 ## Optional: Enable Native Chainlit History
 

--- a/chainlit_persistence.py
+++ b/chainlit_persistence.py
@@ -1,0 +1,232 @@
+"""Chainlit data-layer helpers for local Postgres persistence."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from typing import Any
+
+from chainlit.data.chainlit_data_layer import ChainlitDataLayer
+from chainlit.data.storage_clients.base import BaseStorageClient
+from chainlit.logger import logger
+
+CHAINLIT_SCHEMA_BOOTSTRAP_ENV = "CHAINLIT_SCHEMA_BOOTSTRAP"
+
+CHAINLIT_SCHEMA_STATEMENTS: tuple[str, ...] = (
+    """
+    CREATE TABLE IF NOT EXISTS "User" (
+        id TEXT PRIMARY KEY,
+        identifier TEXT NOT NULL UNIQUE,
+        metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+        "createdAt" TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        "updatedAt" TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS "Thread" (
+        id TEXT PRIMARY KEY,
+        "createdAt" TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        "updatedAt" TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        "deletedAt" TIMESTAMPTZ,
+        name TEXT,
+        metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+        tags TEXT[] NOT NULL DEFAULT '{}'::text[],
+        "userId" TEXT REFERENCES "User"(id) ON DELETE SET NULL
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS "Step" (
+        id TEXT PRIMARY KEY,
+        "createdAt" TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        "updatedAt" TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        "parentId" TEXT REFERENCES "Step"(id) ON DELETE CASCADE,
+        "threadId" TEXT REFERENCES "Thread"(id) ON DELETE CASCADE,
+        input TEXT,
+        metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+        name TEXT,
+        output TEXT,
+        type TEXT NOT NULL DEFAULT 'undefined',
+        "showInput" TEXT DEFAULT 'json',
+        "isError" BOOLEAN DEFAULT FALSE,
+        "startTime" TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        "endTime" TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS "Feedback" (
+        id TEXT PRIMARY KEY,
+        "createdAt" TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        "updatedAt" TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        "stepId" TEXT REFERENCES "Step"(id) ON DELETE SET NULL,
+        name TEXT NOT NULL,
+        value DOUBLE PRECISION NOT NULL,
+        comment TEXT
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS "Element" (
+        id TEXT PRIMARY KEY,
+        "createdAt" TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        "updatedAt" TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        "threadId" TEXT REFERENCES "Thread"(id) ON DELETE CASCADE,
+        "stepId" TEXT NOT NULL REFERENCES "Step"(id) ON DELETE CASCADE,
+        metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+        mime TEXT,
+        name TEXT,
+        "objectKey" TEXT,
+        url TEXT,
+        "chainlitKey" TEXT,
+        display TEXT,
+        size TEXT,
+        language TEXT,
+        page INTEGER,
+        props JSONB
+    )
+    """,
+    'CREATE INDEX IF NOT EXISTS "User_identifier_idx" ON "User" (identifier)',
+    'CREATE INDEX IF NOT EXISTS "Thread_createdAt_idx" ON "Thread" ("createdAt")',
+    'CREATE INDEX IF NOT EXISTS "Thread_name_idx" ON "Thread" (name)',
+    'CREATE INDEX IF NOT EXISTS "Thread_userId_idx" ON "Thread" ("userId")',
+    'CREATE INDEX IF NOT EXISTS "Thread_updatedAt_idx" ON "Thread" ("updatedAt")',
+    'CREATE INDEX IF NOT EXISTS "Step_createdAt_idx" ON "Step" ("createdAt")',
+    'CREATE INDEX IF NOT EXISTS "Step_endTime_idx" ON "Step" ("endTime")',
+    'CREATE INDEX IF NOT EXISTS "Step_parentId_idx" ON "Step" ("parentId")',
+    'CREATE INDEX IF NOT EXISTS "Step_startTime_idx" ON "Step" ("startTime")',
+    'CREATE INDEX IF NOT EXISTS "Step_threadId_idx" ON "Step" ("threadId")',
+    'CREATE INDEX IF NOT EXISTS "Step_type_idx" ON "Step" (type)',
+    'CREATE INDEX IF NOT EXISTS "Step_name_idx" ON "Step" (name)',
+    'CREATE INDEX IF NOT EXISTS "Step_thread_start_end_idx" ON "Step" ("threadId", "startTime", "endTime")',
+    'CREATE INDEX IF NOT EXISTS "Feedback_createdAt_idx" ON "Feedback" ("createdAt")',
+    'CREATE INDEX IF NOT EXISTS "Feedback_name_idx" ON "Feedback" (name)',
+    'CREATE INDEX IF NOT EXISTS "Feedback_stepId_idx" ON "Feedback" ("stepId")',
+    'CREATE INDEX IF NOT EXISTS "Feedback_value_idx" ON "Feedback" (value)',
+    'CREATE INDEX IF NOT EXISTS "Feedback_name_value_idx" ON "Feedback" (name, value)',
+    'CREATE INDEX IF NOT EXISTS "Element_stepId_idx" ON "Element" ("stepId")',
+    'CREATE INDEX IF NOT EXISTS "Element_threadId_idx" ON "Element" ("threadId")',
+)
+
+
+def chainlit_schema_bootstrap_enabled() -> bool:
+    """Return whether this app should create missing Chainlit tables at startup."""
+    raw_value = os.getenv(CHAINLIT_SCHEMA_BOOTSTRAP_ENV, "true").strip().lower()
+    return raw_value not in {"0", "false", "no", "off"}
+
+
+class AutoMigratingChainlitDataLayer(ChainlitDataLayer):
+    """Chainlit official asyncpg data layer with idempotent schema setup."""
+
+    def __init__(
+        self,
+        database_url: str,
+        storage_client: BaseStorageClient | None = None,
+        show_logger: bool = False,
+        *,
+        bootstrap_schema: bool = True,
+    ) -> None:
+        super().__init__(
+            database_url=database_url,
+            storage_client=storage_client,
+            show_logger=show_logger,
+        )
+        self.bootstrap_schema = bootstrap_schema
+        self._schema_ready = False
+        self._schema_lock = asyncio.Lock()
+
+    async def connect(self) -> None:
+        """Open the connection pool and create Chainlit tables before first query."""
+        await super().connect()
+        if self.bootstrap_schema:
+            await self.setup_schema()
+
+    async def setup_schema(self) -> None:
+        """Create the official Chainlit Postgres tables and indexes if absent."""
+        if self._schema_ready:
+            return
+        async with self._schema_lock:
+            if self._schema_ready:
+                return
+            if not self.pool:
+                raise RuntimeError("Chainlit data layer pool is not initialized")
+            async with self.pool.acquire() as connection:  # type: ignore[union-attr]
+                async with connection.transaction():
+                    for statement in CHAINLIT_SCHEMA_STATEMENTS:
+                        await connection.execute(statement)
+            self._schema_ready = True
+            logger.info("Chainlit Postgres schema is ready")
+
+
+def create_chainlit_storage_client() -> BaseStorageClient | None:
+    """Build the optional Chainlit element storage client from environment variables."""
+    bucket_name = os.getenv("BUCKET_NAME")
+
+    aws_region = os.getenv("APP_AWS_REGION")
+    aws_access_key = os.getenv("APP_AWS_ACCESS_KEY")
+    aws_secret_key = os.getenv("APP_AWS_SECRET_KEY")
+    dev_aws_endpoint = os.getenv("DEV_AWS_ENDPOINT")
+    is_using_s3 = bool(aws_access_key and aws_secret_key and aws_region)
+
+    gcs_project_id = os.getenv("APP_GCS_PROJECT_ID")
+    gcs_client_email = os.getenv("APP_GCS_CLIENT_EMAIL")
+    gcs_private_key = os.getenv("APP_GCS_PRIVATE_KEY")
+    is_using_gcs = bool(gcs_project_id)
+
+    azure_storage_account = os.getenv("APP_AZURE_STORAGE_ACCOUNT")
+    azure_storage_key = os.getenv("APP_AZURE_STORAGE_ACCESS_KEY")
+    is_using_azure = bool(azure_storage_account and azure_storage_key)
+
+    configured_storage_count = sum([is_using_s3, is_using_gcs, is_using_azure])
+    if configured_storage_count > 1:
+        logger.warning("Multiple Chainlit storage configurations detected; ignoring all")
+        return None
+
+    if is_using_s3:
+        from chainlit.data.storage_clients.s3 import S3StorageClient
+
+        return S3StorageClient(
+            bucket=bucket_name,
+            region_name=aws_region,
+            aws_access_key_id=aws_access_key,
+            aws_secret_access_key=aws_secret_key,
+            endpoint_url=dev_aws_endpoint,
+        )
+
+    if is_using_gcs:
+        from chainlit.data.storage_clients.gcs import GCSStorageClient
+
+        return GCSStorageClient(
+            project_id=gcs_project_id,
+            client_email=gcs_client_email,
+            private_key=gcs_private_key,
+            bucket_name=bucket_name,
+        )
+
+    if is_using_azure:
+        from chainlit.data.storage_clients.azure_blob import AzureBlobStorageClient
+
+        return AzureBlobStorageClient(
+            container_name=bucket_name,
+            storage_account=azure_storage_account,
+            storage_key=azure_storage_key,
+        )
+
+    return None
+
+
+def create_chainlit_data_layer(
+    database_url: str | None = None,
+) -> AutoMigratingChainlitDataLayer:
+    """Create the app's Chainlit data layer for a configured database URL."""
+    resolved_database_url = (database_url or os.getenv("DATABASE_URL", "")).strip()
+    if not resolved_database_url:
+        raise ValueError("DATABASE_URL is required to create the Chainlit data layer")
+    return AutoMigratingChainlitDataLayer(
+        database_url=resolved_database_url,
+        storage_client=create_chainlit_storage_client(),
+        bootstrap_schema=chainlit_schema_bootstrap_enabled(),
+    )
+
+
+def chainlit_data_layer_enabled(environ: dict[str, Any] | None = None) -> bool:
+    """Return whether DATABASE_URL should enable the Chainlit data layer."""
+    source = os.environ if environ is None else environ
+    return bool(str(source.get("DATABASE_URL", "")).strip())

--- a/main.py
+++ b/main.py
@@ -32,6 +32,7 @@ from agent_commands import (
 )
 from async_task_notifications import AsyncTaskNotifier, async_subagent_url_override
 from chainlit_bridge import ChainlitEventBridge, RunTaskList
+from chainlit_persistence import chainlit_data_layer_enabled, create_chainlit_data_layer
 from deepagent_runtime import (
     DEFAULT_REASONING_LEVEL,
     AgentRuntime,
@@ -210,6 +211,14 @@ def authenticate_chainlit_user(
 AUTH_USERS = load_chainlit_auth_users()
 AUTH_SECRET = os.getenv("CHAINLIT_AUTH_SECRET", "").strip()
 AUTH_ENABLED = bool(AUTH_SECRET and AUTH_USERS)
+
+
+if chainlit_data_layer_enabled():
+
+    @cl.data_layer
+    def configured_chainlit_data_layer():
+        """Return the Postgres-backed Chainlit data layer with schema bootstrap."""
+        return create_chainlit_data_layer()
 
 
 def build_chainlit_starters(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ py-modules = [
     "chainagents_cli",
     "chainagents_tui",
     "chainlit_bridge",
+    "chainlit_persistence",
     "deepagent_runtime",
     "langgraph_app",
     "langchain_warning_filters",

--- a/tests/test_chainlit_persistence.py
+++ b/tests/test_chainlit_persistence.py
@@ -1,0 +1,102 @@
+"""Tests for Chainlit Postgres persistence bootstrap helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from chainlit_persistence import (
+    CHAINLIT_SCHEMA_STATEMENTS,
+    AutoMigratingChainlitDataLayer,
+    chainlit_data_layer_enabled,
+    chainlit_schema_bootstrap_enabled,
+)
+
+
+class _FakeTransaction:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class _FakeConnection:
+    def __init__(self) -> None:
+        self.executed: list[str] = []
+
+    def transaction(self) -> _FakeTransaction:
+        return _FakeTransaction()
+
+    async def execute(self, statement: str) -> None:
+        self.executed.append(statement)
+
+
+class _FakeAcquire:
+    def __init__(self, connection: _FakeConnection) -> None:
+        self.connection = connection
+
+    async def __aenter__(self) -> _FakeConnection:
+        return self.connection
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class _FakePool:
+    def __init__(self) -> None:
+        self.connection = _FakeConnection()
+
+    def acquire(self) -> _FakeAcquire:
+        return _FakeAcquire(self.connection)
+
+
+@pytest.mark.anyio
+async def test_auto_migrating_data_layer_bootstraps_schema_once() -> None:
+    """Verify schema bootstrap runs all DDL statements only once."""
+    pool = _FakePool()
+    data_layer = AutoMigratingChainlitDataLayer("postgresql://example/db")
+    data_layer.pool = pool  # type: ignore[assignment]
+
+    await data_layer.setup_schema()
+    await data_layer.setup_schema()
+
+    assert pool.connection.executed == list(CHAINLIT_SCHEMA_STATEMENTS)
+
+
+def test_chainlit_schema_statements_create_official_tables() -> None:
+    """Verify the bootstrap DDL includes the quoted tables used by Chainlit."""
+    schema_sql = "\n".join(CHAINLIT_SCHEMA_STATEMENTS)
+
+    for table_name in ('"User"', '"Thread"', '"Step"', '"Feedback"', '"Element"'):
+        assert f"CREATE TABLE IF NOT EXISTS {table_name}" in schema_sql
+
+    assert 'REFERENCES "User"(id)' in schema_sql
+    assert 'REFERENCES "Thread"(id)' in schema_sql
+    assert 'REFERENCES "Step"(id)' in schema_sql
+
+
+def test_chainlit_data_layer_enabled_requires_database_url() -> None:
+    """Verify Chainlit data layer registration follows DATABASE_URL."""
+    assert chainlit_data_layer_enabled({"DATABASE_URL": "postgresql://host/db"})
+    assert not chainlit_data_layer_enabled({"DATABASE_URL": ""})
+    assert not chainlit_data_layer_enabled({})
+
+
+@pytest.mark.parametrize("raw_value", ["0", "false", "False", "no", "off"])
+def test_chainlit_schema_bootstrap_enabled_can_be_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+    raw_value: str,
+) -> None:
+    """Verify operators can opt out when they run external Chainlit migrations."""
+    monkeypatch.setenv("CHAINLIT_SCHEMA_BOOTSTRAP", raw_value)
+
+    assert not chainlit_schema_bootstrap_enabled()
+
+
+def test_chainlit_schema_bootstrap_enabled_defaults_to_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify missing-table errors are prevented by default."""
+    monkeypatch.delenv("CHAINLIT_SCHEMA_BOOTSTRAP", raising=False)
+
+    assert chainlit_schema_bootstrap_enabled()


### PR DESCRIPTION
### Motivation

- Prevent `asyncpg.exceptions.UndefinedTableError: relation "User" does not exist` when `DATABASE_URL` is set and Chainlit attempts to persist users/threads/steps on a fresh DB. 
- Provide an idempotent, opt-out schema bootstrap so the app can run against an empty Postgres instance without requiring a separate migration step.

### Description

- Add `chainlit_persistence.py` which defines `CHAINLIT_SCHEMA_STATEMENTS`, `chainlit_schema_bootstrap_enabled()`, `AutoMigratingChainlitDataLayer` that runs an idempotent `setup_schema()` creating the quoted Chainlit tables (`"User"`, `"Thread"`, `"Step"`, `"Feedback"`, `"Element"`) and indexes, and helpers `create_chainlit_data_layer()` and `chainlit_data_layer_enabled()`.
- Register the Postgres-backed Chainlit data layer automatically in `main.py` when `DATABASE_URL` is present by calling `create_chainlit_data_layer()` under `@cl.data_layer`, preserving optional S3/GCS/Azure storage client behavior.
- Add tests in `tests/test_chainlit_persistence.py` to verify the DDL coverage, one-time bootstrap behavior, `DATABASE_URL` gating, and `CHAINLIT_SCHEMA_BOOTSTRAP` opt-out, and export the new module in `pyproject.toml` and docs update in `README.md`.

### Testing

- Ran unit tests for the new persistence helpers with `uv run pytest tests/test_chainlit_persistence.py tests/test_main_native_commands.py` and the targeted tests passed.
- Ran the full test suite with `uv run pytest` and observed `201 passed, 1 warning` across the repository.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a298108a30c8324aee7c6f89654e46b)