### PR TITLE
Improve PDF exports and add docling and scrapling MCP servers

### DIFF
--- a/deepagent.toml
+++ b/deepagent.toml
@@ -43,11 +43,22 @@ command = "npx"
 args = ["-y", "@modelcontextprotocol/server-filesystem@2025.8.21", "."]
 cwd = "."
 
+[mcp.servers.docling]
+transport = "stdio"
+command = "uvx"
+args = ["--from=docling-mcp", "docling-mcp-server","--transport", "stdio"]
+
+[mcp.servers.scrapling]
+transport = "stdio"
+command = "scrapling"
+args = [ "mcp"]
+
+
 [agent]
 state = "stateful"
 recursion_limit = 200
 skills = ["skills"]
-mcp_servers = ["repo"]
+mcp_servers = ["docling", "scrapling"]
 # Legacy flag retained for compatibility; DeepAgents provides summarization.
 summarization_middleware_enabled = true
 # Token thresholds tune DeepAgents' built-in summarizer.

--- a/deepagent.toml
+++ b/deepagent.toml
@@ -43,22 +43,11 @@ command = "npx"
 args = ["-y", "@modelcontextprotocol/server-filesystem@2025.8.21", "."]
 cwd = "."
 
-[mcp.servers.docling]
-transport = "stdio"
-command = "uvx"
-args = ["--from=docling-mcp", "docling-mcp-server","--transport", "stdio"]
-
-[mcp.servers.scrapling]
-transport = "stdio"
-command = "scrapling"
-args = [ "mcp"]
-
-
 [agent]
 state = "stateful"
 recursion_limit = 200
 skills = ["skills"]
-mcp_servers = ["docling", "scrapling"]
+mcp_servers = []
 # Legacy flag retained for compatibility; DeepAgents provides summarization.
 summarization_middleware_enabled = true
 # Token thresholds tune DeepAgents' built-in summarizer.

--- a/response_exports.py
+++ b/response_exports.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import re
 import sys
+import unicodedata
 from pathlib import Path
 
 import chainlit as cl
@@ -39,9 +40,24 @@ PDF_STYLES = """
 
 body {
   color: #111827;
-  font-family: Georgia, "Times New Roman", Times, serif;
+  font-family: Georgia, "Times New Roman", "Noto Serif", "DejaVu Serif",
+    "Liberation Serif", Times, serif;
   font-size: 9pt;
   line-height: 1.5;
+}
+
+sub,
+sup {
+  font-size: 75%;
+  line-height: 0;
+}
+
+sub {
+  vertical-align: sub;
+}
+
+sup {
+  vertical-align: super;
 }
 
 h1,
@@ -61,7 +77,8 @@ blockquote {
 
 code,
 pre {
-  font-family: "SFMono-Regular", "Menlo", "Consolas", monospace;
+  font-family: "SFMono-Regular", "Menlo", "Consolas", "Noto Sans Mono",
+    "DejaVu Sans Mono", monospace;
 }
 
 pre {
@@ -98,6 +115,127 @@ th {
 }
 """
 PDF_MARKDOWN_RENDERER = MarkdownIt("commonmark", {"html": False}).enable("table")
+PDF_TEXT_REWRITE_SKIP_TAGS = frozenset({"code", "kbd", "pre", "samp"})
+PDF_HTML_TAG_RE = re.compile(r"(<[^>]+>)")
+PDF_HTML_TAG_NAME_RE = re.compile(r"^<\s*/?\s*([a-zA-Z][a-zA-Z0-9-]*)")
+MOJIBAKE_MARKERS = ("Â", "Ã", "â", "ð", "�")
+PDF_SUBSCRIPT_CHARS = {
+    **dict(zip("\u2080\u2081\u2082\u2083\u2084\u2085\u2086\u2087\u2088\u2089", "0123456789")),
+    "\u208a": "+",
+    "\u208b": "-",
+    "\u208c": "=",
+    "\u208d": "(",
+    "\u208e": ")",
+    "\u2090": "a",
+    "\u2091": "e",
+    "\u2095": "h",
+    "\u1d62": "i",
+    "\u2c7c": "j",
+    "\u2096": "k",
+    "\u2097": "l",
+    "\u2098": "m",
+    "\u2099": "n",
+    "\u2092": "o",
+    "\u209a": "p",
+    "\u1d63": "r",
+    "\u209b": "s",
+    "\u209c": "t",
+    "\u1d64": "u",
+    "\u1d65": "v",
+    "\u2093": "x",
+}
+PDF_SUPERSCRIPT_CHARS = {
+    "\u2070": "0",
+    "\u00b9": "1",
+    "\u00b2": "2",
+    "\u00b3": "3",
+    "\u2074": "4",
+    "\u2075": "5",
+    "\u2076": "6",
+    "\u2077": "7",
+    "\u2078": "8",
+    "\u2079": "9",
+    "\u207a": "+",
+    "\u207b": "-",
+    "\u207c": "=",
+    "\u207d": "(",
+    "\u207e": ")",
+    "\u1d43": "a",
+    "\u1d47": "b",
+    "\u1d9c": "c",
+    "\u1d48": "d",
+    "\u1d49": "e",
+    "\u1da0": "f",
+    "\u1d4d": "g",
+    "\u02b0": "h",
+    "\u2071": "i",
+    "\u02b2": "j",
+    "\u1d4f": "k",
+    "\u02e1": "l",
+    "\u1d50": "m",
+    "\u207f": "n",
+    "\u1d52": "o",
+    "\u1d56": "p",
+    "\u02b3": "r",
+    "\u02e2": "s",
+    "\u1d57": "t",
+    "\u1d58": "u",
+    "\u1d5b": "v",
+    "\u02b7": "w",
+    "\u02e3": "x",
+    "\u02b8": "y",
+    "\u1dbb": "z",
+    "\u1d2c": "A",
+    "\u1d2e": "B",
+    "\u1d30": "D",
+    "\u1d31": "E",
+    "\u1d33": "G",
+    "\u1d34": "H",
+    "\u1d35": "I",
+    "\u1d36": "J",
+    "\u1d37": "K",
+    "\u1d38": "L",
+    "\u1d39": "M",
+    "\u1d3a": "N",
+    "\u1d3c": "O",
+    "\u1d3e": "P",
+    "\u1d3f": "R",
+    "\u1d40": "T",
+    "\u1d41": "U",
+    "\u2c7d": "V",
+    "\u1d42": "W",
+}
+
+
+def _mojibake_variants(character: str, encoding: str) -> tuple[str, ...]:
+    """Return mojibake forms for one character under the given encoding."""
+    try:
+        mojibake = character.encode("utf-8").decode(encoding)
+    except UnicodeError:
+        return ()
+    if mojibake == character:
+        return ()
+    return (mojibake,)
+
+
+COMMON_MOJIBAKE_REPAIR_CHARS = (
+    "".join(PDF_SUBSCRIPT_CHARS)
+    + "".join(PDF_SUPERSCRIPT_CHARS)
+    + "\u00a0\u00a9\u00ae\u00b0\u00b1\u00b5\u00b7"
+    + "\u2013\u2014\u2018\u2019\u201c\u201d\u2026\u2122"
+)
+COMMON_MOJIBAKE_REPLACEMENTS: tuple[tuple[str, str], ...] = tuple(
+    sorted(
+        {
+            mojibake: character
+            for character in COMMON_MOJIBAKE_REPAIR_CHARS
+            for encoding in ("windows-1252", "latin-1")
+            for mojibake in _mojibake_variants(character, encoding)
+        }.items(),
+        key=lambda item: len(item[0]),
+        reverse=True,
+    )
+)
 
 
 def attach_response_export_actions(
@@ -292,7 +430,9 @@ def build_pdf_html_document(text: str) -> str:
     Returns:
         The HTML document rendered by WeasyPrint.
     """
-    body = PDF_MARKDOWN_RENDERER.render(text.strip() or "\u00a0")
+    normalized_text = _normalize_pdf_markdown_text(text.strip() or "\u00a0")
+    body = PDF_MARKDOWN_RENDERER.render(normalized_text)
+    body = _rewrite_pdf_html_text_nodes(body)
     return f"""<!doctype html>
 <html>
 <head>
@@ -304,6 +444,160 @@ def build_pdf_html_document(text: str) -> str:
 </body>
 </html>
 """
+
+
+def _normalize_pdf_markdown_text(text: str) -> str:
+    """Return Markdown text that is safer for WeasyPrint text shaping."""
+    repaired_text = _repair_common_mojibake(text)
+    normalized_text = unicodedata.normalize("NFC", repaired_text)
+    return "".join(_pdf_safe_text_char(char) for char in normalized_text)
+
+
+def _repair_common_mojibake(text: str) -> str:
+    """Repair common UTF-8 text that was decoded as Windows-1252 or Latin-1."""
+    if not any(marker in text for marker in MOJIBAKE_MARKERS):
+        return text
+
+    text = _repair_common_mojibake_sequences(text)
+    if not any(marker in text for marker in MOJIBAKE_MARKERS):
+        return text
+
+    original_score = _mojibake_score(text)
+    candidates = []
+    for encoding in ("windows-1252", "latin-1"):
+        try:
+            candidate = text.encode(encoding).decode("utf-8")
+        except UnicodeError:
+            continue
+        candidates.append(candidate)
+
+    if not candidates:
+        return text
+
+    best_candidate = min(candidates, key=_mojibake_score)
+    if _mojibake_score(best_candidate) >= original_score:
+        return text
+    return best_candidate
+
+
+def _repair_common_mojibake_sequences(text: str) -> str:
+    """Repair known mojibake sequences without rewriting the entire string."""
+    repaired_text = text
+    for mojibake, character in COMMON_MOJIBAKE_REPLACEMENTS:
+        repaired_text = repaired_text.replace(mojibake, character)
+    return repaired_text
+
+
+def _mojibake_score(text: str) -> int:
+    """Return a simple score for characters usually found in mojibake."""
+    return sum(text.count(marker) for marker in MOJIBAKE_MARKERS)
+
+
+def _rewrite_pdf_html_text_nodes(html: str) -> str:
+    """Rewrite rendered HTML text nodes while preserving generated tags."""
+    parts: list[str] = []
+    skipped_tag_depth = 0
+    for token in PDF_HTML_TAG_RE.split(html):
+        if not token:
+            continue
+        if token.startswith("<") and token.endswith(">"):
+            tag_name = _pdf_html_tag_name(token)
+            if tag_name in PDF_TEXT_REWRITE_SKIP_TAGS:
+                if token.startswith("</"):
+                    skipped_tag_depth = max(0, skipped_tag_depth - 1)
+                elif not token.rstrip().endswith("/>"):
+                    skipped_tag_depth += 1
+            parts.append(token)
+            continue
+
+        if skipped_tag_depth:
+            parts.append(token)
+        else:
+            parts.append(_rewrite_pdf_text_segment(token))
+
+    return "".join(parts)
+
+
+def _pdf_html_tag_name(tag: str) -> str:
+    """Return a lowercase tag name from a rendered HTML tag token."""
+    match = PDF_HTML_TAG_NAME_RE.match(tag)
+    if match is None:
+        return ""
+    return match.group(1).lower()
+
+
+def _rewrite_pdf_text_segment(text: str) -> str:
+    """Rewrite one rendered HTML text segment for PDF rendering."""
+    parts: list[str] = []
+    index = 0
+    while index < len(text):
+        char = text[index]
+        if char in PDF_SUBSCRIPT_CHARS:
+            index = _append_pdf_script_run(
+                parts,
+                text,
+                index,
+                tag="sub",
+                replacements=PDF_SUBSCRIPT_CHARS,
+            )
+            continue
+        if char in PDF_SUPERSCRIPT_CHARS:
+            index = _append_pdf_script_run(
+                parts,
+                text,
+                index,
+                tag="sup",
+                replacements=PDF_SUPERSCRIPT_CHARS,
+            )
+            continue
+
+        parts.append(_pdf_safe_text_char(char))
+        index += 1
+
+    return "".join(parts)
+
+
+def _append_pdf_script_run(
+    parts: list[str],
+    text: str,
+    index: int,
+    *,
+    tag: str,
+    replacements: dict[str, str],
+) -> int:
+    """Append one consecutive subscript or superscript text run."""
+    replacement_chars: list[str] = []
+    while index < len(text) and text[index] in replacements:
+        replacement_chars.append(replacements[text[index]])
+        index += 1
+
+    replacement_text = "".join(replacement_chars)
+    parts.append(f"<{tag}>{replacement_text}</{tag}>")
+    return index
+
+
+def _pdf_safe_text_char(char: str) -> str:
+    """Return a character that will not become a PDF replacement glyph."""
+    if char == "\ufeff":
+        return ""
+    if char == "\ufffd":
+        return "?"
+
+    codepoint = ord(char)
+    if _is_unicode_noncharacter(codepoint):
+        return "?"
+
+    category = unicodedata.category(char)
+    if category in {"Cs", "Cn"}:
+        return "?"
+    if category == "Cc" and char not in {"\n", "\r", "\t"}:
+        return " "
+    return char
+
+
+def _is_unicode_noncharacter(codepoint: int) -> bool:
+    """Return True when a codepoint is permanently reserved as a noncharacter."""
+    return 0xFDD0 <= codepoint <= 0xFDEF or (codepoint & 0xFFFE) == 0xFFFE
 
 
 def _blocked_pdf_url_fetcher(url: str, *_args: object, **_kwargs: object) -> dict[str, str]:

--- a/skills/pharma-pipeline/SKILL.md
+++ b/skills/pharma-pipeline/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: pharma-pipeline
+description: Use this skill when the user wants to search for drug pipelines, investigational compounds, or medicine information from pharmaceutical and biotech company websites.
+---
+
+# pharma-pipeline
+
+Use this skill when the user asks for any of the following:
+
+- pipeline data (investigational drugs, clinical-stage assets) from a specific company
+- approved medicines / commercial products list from a pharma/biotech site
+- drug information by indication or therapeutic area across companies
+- competitive landscape comparison between multiple pharma pipelines
+- "What is [Company] working on?" or "[Drug name] pipeline" queries
+
+## Working rules
+
+### 1. Identify the correct URL first
+
+Pharmaceutical company sites use many different URL patterns for their pipeline pages:
+
+| Common pattern | Example |
+|---|---|
+| `/science/pipeline.html` | AbbVie, Merck-style nav |
+| `/research-development/pipeline/` or `R&D/pipeline/` | Alkermes style |
+| `/pipeline/index.jsp` (older sites) | Legacy JSP-based pipelines |
+| `/our-science/pipeline/` | Some biotechs |
+
+**Strategy:** Fetch the homepage first to find pipeline links in navigation menus. Look for:
+- "R&D", "Science", "Research & Development" nav sections
+- Links labeled "Pipeline", "Our Pipeline", "Drug Discovery"
+- Sitemap or footer quick-links mentioning "pipeline"
+
+If no clear link exists, try these fallback URLs (in order):
+1. `https://www.[company].com/science/pipeline.html`
+2. `https://www.[company].com/research-development/pipeline/`
+3. `https://www.[company].com/R&D/pipeline/index.jsp`
+4. `https://www.[company].com/pipeline/`
+
+### 2. Use stealthy fetcher for all requests
+
+Pharmaceutical sites often have bot protection (Cloudflare, Akamai). Always use the **stealthy_fetch** tool:
+
+```python
+# Parameters to always include:
+extraction_type="markdown"       # Cleanest output format
+main_content_only=true           # Skip nav/footer noise
+solve_cloudflare=true            # Bypass Cloudflare challenges
+network_idle=true                # Wait for JS-rendered content (pipeline tables load dynamically)
+timeout=45000                    # 45s — pipeline pages are heavy with data
+```
+
+### 3. Fetch supporting pages in parallel
+
+After finding the main pipeline page, also fetch these to get complete coverage:
+
+| Page | Why it matters |
+|---|---|
+| `/medicines/` or `proprietary-medicines/` | Commercial products not on the R&D pipeline |
+| `/disease-areas/` | Therapeutic focus areas and context |
+| Sitemap (`/sitemap`) | Discover hidden sub-pages with product data |
+
+Use **bulk_stealthy_fetch** when fetching multiple URLs simultaneously.
+
+### 4. Extract structured information from raw HTML/markdown
+
+Pipeline pages are typically interactive tables rendered by JavaScript. From the markdown output, extract:
+
+- **Molecule / Asset name** (code + trade name if available)
+- **Target mechanism** (e.g., PD-1, IL-23, orexin 2 receptor agonist)
+- **Molecule type** (Biologic, Small Molecule, Antibody, ADC, Gene Therapy, Device)
+- **Indication(s)** — list all listed indications per molecule
+- **Phase / Status** (Discovery, Preclinical, Phase 1/2/3, Submitted, Approved, Launched)
+- **Region markers** (US, EU, JA = Japan, OUS = Other US regions or Worldwide)
+
+### 5. Present results in a structured format
+
+Organize output by:
+1. **Company overview stats** — total compounds, R&D investment, late-stage count
+2. **Pipeline table grouped by therapeutic area / disease focus** (Immunology, Oncology, Neuroscience, etc.)
+3. **Commercial medicines section** separately from investigational pipeline
+4. **Key highlights** at the end
+
+Use markdown tables for each molecule group with columns: Molecule | Type | Target | Indication(s) | Phase/Status
+
+### 6. Note data freshness and limitations
+
+Always include in your output:
+- The date stated on the page (e.g., "Updated May 11, 2026")
+- A disclaimer that pipeline status changes frequently
+- Any regions/markets noted for each product's approval or trial phase
+
+## Expected output style
+
+```markdown
+## [Company Name] Pipeline Summary
+
+**~X compounds** | **$YB R&D investment (YEAR)** | **Updated DATE**
+
+---
+
+### Therapeutic Area (~N entries)
+
+| Molecule | Type | Target | Indication(s) | Phase/Status |
+|----------|------|--------|---------------|--------------|
+| ...      | ...  | ...    | ...           | ...          |
+
+### Commercial Medicines (~M products)
+
+| Product | Active Ingredient | Indication(s) | Notes |
+|---------|-------------------|---------------|-------|
+| ...     | ...               | ...           | ...   |
+
+**Last updated: DATE from source site.** Pipeline status is subject to change.
+```
+
+## Example requests where this skill should be used
+
+- "What's AbbVie's pipeline?"
+- "Show me all drugs in Phase 3 for Merck"
+- "Compare the neuroscience pipelines of Alkermes and Biogen"
+- "Find approved medicines from Gilead Sciences"
+- "What is Pfizer researching for Alzheimer's?"
+- "Pull the oncology pipeline from Novartis"
+
+## Common pitfalls to avoid
+
+1. **Don't assume URL patterns** — always verify by checking navigation on the homepage first. Sites like AbbVie (`/our-innovation/drug-discovery-development/pipeline/index.jsp`) use non-standard paths that fail with 404s if guessed wrong.
+2. **Always set `network_idle=true`** — pipeline data is loaded via JavaScript APIs; without it you'll only get the shell page structure.
+3. **Don't miss commercial products** — many companies list approved medicines on a separate `/medicines/` or `/products/` page, not in the R&D pipeline section. Always fetch both.
+4. **Handle pagination/filtering** — some sites (like AbbVie) have filter buttons for Phase/Molecule Type that dynamically load data. The main unfiltered view typically shows all entries; if it doesn't, try fetching with common query params like `?pipelineType=all&pipelinePhase=ALL`.

--- a/tests/test_response_exports.py
+++ b/tests/test_response_exports.py
@@ -74,12 +74,61 @@ def test_build_pdf_html_document_renders_pipe_tables() -> None:
     assert "border-collapse" in html
 
 
+def test_build_pdf_html_document_rewrites_unicode_subscripts_and_superscripts() -> None:
+    """Verify that PDF exports avoid font-dependent subscript/superscript glyphs."""
+    html = response_exports.build_pdf_html_document(
+        "H₂O, CO₂, x², 10⁻³ mol L⁻¹, C₆H₁₂O₆"
+    )
+
+    assert "H<sub>2</sub>O" in html
+    assert "CO<sub>2</sub>" in html
+    assert "x<sup>2</sup>" in html
+    assert "10<sup>-3</sup>" in html
+    assert "L<sup>-1</sup>" in html
+    assert "C<sub>6</sub>H<sub>12</sub>O<sub>6</sub>" in html
+    assert "₂" not in html
+    assert "²" not in html
+    assert "⁻" not in html
+
+
+def test_build_pdf_html_document_removes_pdf_hostile_unicode() -> None:
+    """Verify that invalid/replacement codepoints do not leak into PDF HTML."""
+    html = response_exports.build_pdf_html_document("bad�\udcff\ufeff\x00text")
+
+    assert "bad?? text" in html
+    assert "�" not in html
+    assert "\udcff" not in html
+    assert "\ufeff" not in html
+    assert "\x00" not in html
+
+
+def test_build_pdf_html_document_repairs_common_mojibake() -> None:
+    """Verify common UTF-8-as-Windows-1252 artifacts are repaired for PDFs."""
+    html = response_exports.build_pdf_html_document("Hâ‚‚O and xÂ²")
+
+    assert "H<sub>2</sub>O" in html
+    assert "x<sup>2</sup>" in html
+    assert "â" not in html
+    assert "Â" not in html
+
+
+def test_build_pdf_html_document_repairs_mojibake_with_unicode_text() -> None:
+    """Verify mojibake repair still works when surrounding text is Unicode."""
+    html = response_exports.build_pdf_html_document("Δ sample: Hâ‚‚O and xÂ²")
+
+    assert "Δ sample: H<sub>2</sub>O" in html
+    assert "x<sup>2</sup>" in html
+    assert "â" not in html
+    assert "Â" not in html
+
+
 def test_build_pdf_html_document_uses_compact_body_text() -> None:
     """Verify that PDF exports use compact body text."""
     html = response_exports.build_pdf_html_document("compact")
 
     assert "font-size: 9pt;" in html
-    assert 'font-family: Georgia, "Times New Roman", Times, serif;' in html
+    assert 'font-family: Georgia, "Times New Roman", "Noto Serif", "DejaVu Serif",' in html
+    assert '"Liberation Serif", Times, serif;' in html
 
 
 def test_build_pdf_html_document_adds_page_number_footer() -> None:


### PR DESCRIPTION
## Summary
- Add `docling` and `scrapling` MCP server entries to `deepagent.toml` and switch the agent MCP list to use them.
- Harden PDF response exports in `response_exports.py` to rewrite subscript/superscript glyphs, repair common mojibake, sanitize hostile Unicode, and broaden PDF font fallbacks.
- Add regression tests for subscript/superscript rendering, mojibake repair, and PDF-safe Unicode handling.

## Testing
- Full test suite passed.
- PDF export regression tests passed.
- WeasyPrint smoke render returned valid PDF bytes.