### PR TITLE
[codex] configure Chainlit final response placement

### DIFF
--- a/README.md
+++ b/README.md
@@ -553,6 +553,9 @@ reasoning_mode_enabled = true
 startup_status_enabled = true
 # Set false to keep legacy non-chronological streaming order in Chainlit.
 chronological_ui_enabled = true
+# top: render the answer as the Chainlit message body; bottom: render it after
+# reasoning/tool steps as a final Chainlit step.
+final_response_position = "top"
 commands = [
   { name = "ask-researcher", description = "Delegate to repo-researcher.", target = "subagent", value = "repo-researcher", template = "{input}" },
   { name = "repo-readme", description = "Run an MCP tool directly.", target = "mcp_tool", value = "repo_read_file", mcp_server = "repo", template = "{\"path\":\"README.md\"}" },
@@ -577,6 +580,7 @@ Notes:
 - `[chainlit].reasoning_mode_enabled = false` hides the Reasoning mode group and ignores per-message reasoning overrides from UI modes.
 - `[chainlit].startup_status_enabled = false` disables the initial startup status message that summarizes runtime configuration.
 - `[chainlit].chronological_ui_enabled = false` disables chronological UI ordering so response tokens stream immediately and reasoning steps are not force-rolled at tool boundaries.
+- `[chainlit].final_response_position = "bottom"` renders the final answer as the last Chainlit `llm` step, after reasoning and tool steps. Both positions attach Markdown and PDF download actions to the final answer.
 - Command `name` is invoked as `/<name>` and must be unique.
 - `template` is optional and may include `{input}`.
 - For `mcp_tool`, user command arguments must be valid JSON, e.g. `/repo-readme {"path":"README.md"}`.

--- a/chainlit.md
+++ b/chainlit.md
@@ -4,7 +4,9 @@ Local-first LangChain Deep Agent UI running on Ollama or any OpenAI-compatible s
 
 ## Available Surfaces
 
-- Final assistant response streams into the main chat message.
+- Final assistant response streams into the main chat message by default, or
+  renders after reasoning/tool steps when `[chainlit].final_response_position`
+  is set to `"bottom"`.
 - Raw model reasoning is shown in Chain of Thought steps.
 - Tool calls and tool outputs are rendered as native Chainlit tool steps.
 - Each completed assistant response includes Markdown and WeasyPrint-backed PDF download buttons.
@@ -33,6 +35,8 @@ Local-first LangChain Deep Agent UI running on Ollama or any OpenAI-compatible s
 
 - Use `deepagent.toml` to add skills, MCP servers, custom subagents, and async subagents.
 - Use `[chainlit].commands` in `deepagent.toml` to add slash commands that can rewrite prompts, delegate to configured subagents, or invoke MCP tools directly.
+- Use `[chainlit].final_response_position = "bottom"` to show the final answer
+  below Chainlit reasoning and tool-call steps.
 - Each sync subagent can have its own `skills` and `mcp_servers`.
 - Async subagents are Agent Protocol background jobs configured with `graph_id` and optional `url`/`headers`.
 - Omit async subagent `url` only when running the co-deployed graphs from `langgraph.json`; Chainlit-only runs need an HTTP `url`.

--- a/chainlit_bridge.py
+++ b/chainlit_bridge.py
@@ -9,13 +9,13 @@ import time
 import tomllib
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 import chainlit as cl
 from chainlit.utils import utc_now
 
 from agent_stream_events import AgentStreamEvent, AgentStreamEventAdapter
-from response_exports import attach_response_export_actions
+from response_exports import attach_response_export_actions, send_response_export_actions
 
 DEFAULT_AUTO_COLLAPSE_DELAY_SECONDS = 3.0
 RESPONSE_STREAM_FLUSH_INTERVAL_SECONDS = 0.05
@@ -31,6 +31,7 @@ LANGGRAPH_STREAM_MODES = {
     "tasks",
     "debug",
 }
+FinalResponsePosition = Literal["top", "bottom"]
 
 
 def load_auto_collapse_delay_seconds() -> float:
@@ -874,6 +875,7 @@ class ChainlitEventBridge:
         run_task_list: RunTaskList | None = None,
         *,
         chronological_ui_enabled: bool = True,
+        final_response_position: FinalResponsePosition = "top",
     ) -> None:
         """Initialize the chainlit event bridge instance.
 
@@ -881,10 +883,12 @@ class ChainlitEventBridge:
             prompt: The prompt value.
             run_task_list: The run task list value.
             chronological_ui_enabled: The chronological UI enabled value.
+            final_response_position: Where to render the final response.
         """
         self.prompt = prompt
         self.run_task_list = run_task_list
         self.response_message: cl.Message | None = None
+        self.response_step: cl.Step | None = None
         self.response_buffer = ""
         self.pending_response_stream = ""
         self.response_task_started = False
@@ -898,6 +902,7 @@ class ChainlitEventBridge:
         self.collapse_scheduled_step_ids: set[str] = set()
         self.pending_collapse_tasks: set[asyncio.Task[Any]] = set()
         self.chronological_ui_enabled = chronological_ui_enabled
+        self.final_response_position = final_response_position
 
     async def start(self) -> None:
         """Start the chainlit event bridge."""
@@ -1242,7 +1247,10 @@ class ChainlitEventBridge:
             self.response_task_started = True
         self.response_buffer += delta
         self.pending_response_stream += delta
-        if not self.chronological_ui_enabled:
+        if (
+            not self.chronological_ui_enabled
+            and self.final_response_position == "top"
+        ):
             if self.response_message is None:
                 self.response_message = await cl.Message(content="").send()
             await self._flush_response_stream()
@@ -1250,6 +1258,10 @@ class ChainlitEventBridge:
     async def _send_final_response_message(self) -> None:
         """Send the buffered final response as a Chainlit message."""
         if not self.response_buffer:
+            return
+
+        if self.final_response_position == "bottom":
+            await self._send_final_response_step()
             return
 
         if self.response_message is None:
@@ -1270,6 +1282,32 @@ class ChainlitEventBridge:
             response_text=self.response_buffer,
         )
         await self.response_message.update()
+
+    async def _send_final_response_step(self) -> None:
+        """Send the buffered final response as the last Chainlit step."""
+        if self.response_step is None:
+            self.response_step = cl.Step(
+                name="final response",
+                type="llm",
+                default_open=True,
+            )
+            self.response_step.start = utc_now()
+            await self.response_step.send()
+
+        self.response_step.output = self.response_buffer
+        self.response_step.end = utc_now()
+        await self.response_step.update()
+        await send_response_export_actions(
+            self.response_step,
+            prompt=self.prompt,
+            response_text=self.response_buffer,
+        )
+
+        if self.run_task_list is not None:
+            await self.run_task_list.mark_response_started(
+                for_id=getattr(self.response_step, "id", None)
+            )
+            self.response_task_started = True
 
     def _should_flush_response_stream(self) -> bool:
         """Return whether buffered response text should be flushed now.

--- a/deepagent.toml
+++ b/deepagent.toml
@@ -95,6 +95,9 @@ reasoning_mode_enabled = true
 # Set false to hide the initial startup status message ("Workspace agent ready...").
 startup_status_enabled = false
 chronological_ui_enabled = false
+# top: render the answer as the Chainlit message body; bottom: render it after
+# reasoning/tool steps as a final Chainlit step.
+final_response_position = "bottom"
 commands = [
   { name = "ask-researcher", description = "Delegate to repo-researcher.", target = "subagent", value = "repo-researcher", template = "{input}" },
   { name = "repo-readme", description = "Run an MCP tool directly.", target = "mcp_tool", value = "repo_read_file", mcp_server = "repo", template = "{\"path\":\"README.md\"}" },

--- a/deepagent.toml.example
+++ b/deepagent.toml.example
@@ -61,6 +61,9 @@ model_mode_enabled = true
 reasoning_mode_enabled = true
 # Set false to disable the initial startup status message in chat.
 startup_status_enabled = true
+# top: render the answer as the Chainlit message body; bottom: render it after
+# reasoning/tool steps as a final Chainlit step.
+final_response_position = "top"
 # Native slash commands available from the Chainlit composer.
 commands = [
   { name = "summarize-docs", description = "Summarize repository docs.", target = "prompt", value = "Summarize the repository documentation changes.", template = "Summarize docs for: {input}" },

--- a/deepagent_runtime.py
+++ b/deepagent_runtime.py
@@ -64,6 +64,7 @@ DisableStreaming = bool | Literal["tool_calling"]
 ModelThinking = Literal["auto", "adaptive", "disabled"]
 PersistenceMode = Literal["memory", "postgres"]
 AgentStateMode = Literal["stateful", "stateless"]
+ChainlitFinalResponsePosition = Literal["top", "bottom"]
 DEFAULT_MODEL = "gpt-oss:20b"
 DEFAULT_MODEL_PROVIDER: ModelProvider = "ollama"
 DEFAULT_OLLAMA_ENDPOINT = "http://127.0.0.1"
@@ -76,6 +77,7 @@ DEFAULT_AGENT_STATE: AgentStateMode = "stateful"
 DEFAULT_TEMPERATURE = 0.0
 DEFAULT_EXTENSIONS_CONFIG = "deepagent.toml"
 DEFAULT_RECURSION_LIMIT = 100
+DEFAULT_CHAINLIT_FINAL_RESPONSE_POSITION: ChainlitFinalResponsePosition = "top"
 PROJECT_ROOT = Path(__file__).resolve().parent
 DEEPAGENT_ARTIFACTS_DIRECTORY = Path(".files/deepagent")
 AGENTS_MD_FILENAME = "AGENTS.md"
@@ -164,6 +166,33 @@ def normalize_agent_state(value: Any | None) -> AgentStateMode:
         return "stateless"
     raise ValueError(
         "The top-level 'agent.state' config must be 'stateful' or 'stateless'."
+    )
+
+
+def normalize_chainlit_final_response_position(
+    value: Any | None,
+) -> ChainlitFinalResponsePosition:
+    """Normalize where Chainlit should render final responses.
+
+    Args:
+        value: Value to normalize, convert, or serialize.
+
+    Returns:
+        The normalized Chainlit final response position.
+
+    Raises:
+        ValueError: If the supplied value is invalid.
+    """
+    if value is None:
+        return DEFAULT_CHAINLIT_FINAL_RESPONSE_POSITION
+    candidate = str(value).strip().lower().replace("-", "_")
+    if not candidate:
+        return DEFAULT_CHAINLIT_FINAL_RESPONSE_POSITION
+    if candidate in {"top", "bottom"}:
+        return candidate  # type: ignore[return-value]
+    raise ValueError(
+        "The top-level 'chainlit.final_response_position' config must be "
+        "'top' or 'bottom'."
     )
 
 
@@ -1519,6 +1548,7 @@ class ExtensionsConfig:
         chainlit_reasoning_mode_enabled: The chainlit reasoning mode enabled value.
         chainlit_startup_status_enabled: The chainlit startup status enabled value.
         chainlit_chronological_ui_enabled: The chainlit chronological UI enabled value.
+        chainlit_final_response_position: The chainlit final response position value.
         summarization_middleware_enabled: The summarization middleware enabled value.
         summarization_trigger_tokens: The summarization trigger tokens value.
         summarization_keep_tokens: The summarization keep tokens value.
@@ -1541,6 +1571,9 @@ class ExtensionsConfig:
     chainlit_reasoning_mode_enabled: bool = True
     chainlit_startup_status_enabled: bool = True
     chainlit_chronological_ui_enabled: bool = True
+    chainlit_final_response_position: ChainlitFinalResponsePosition = (
+        DEFAULT_CHAINLIT_FINAL_RESPONSE_POSITION
+    )
     summarization_middleware_enabled: bool = False
     summarization_trigger_tokens: int | None = None
     summarization_keep_tokens: int | None = None
@@ -1992,6 +2025,9 @@ def parse_extensions_config(raw_config: dict[str, Any], config_path: Path) -> Ex
     raw_model_mode_enabled = chainlit_section.get("model_mode_enabled", True)
     raw_startup_status_enabled = chainlit_section.get("startup_status_enabled", True)
     raw_chronological_ui_enabled = chainlit_section.get("chronological_ui_enabled", True)
+    chainlit_final_response_position = normalize_chainlit_final_response_position(
+        chainlit_section.get("final_response_position")
+    )
     if not isinstance(raw_reasoning_mode_enabled, bool):
         raise ValueError(
             "The top-level 'chainlit.reasoning_mode_enabled' config must be a boolean."
@@ -2104,6 +2140,7 @@ def parse_extensions_config(raw_config: dict[str, Any], config_path: Path) -> Ex
         chainlit_reasoning_mode_enabled=raw_reasoning_mode_enabled,
         chainlit_startup_status_enabled=raw_startup_status_enabled,
         chainlit_chronological_ui_enabled=raw_chronological_ui_enabled,
+        chainlit_final_response_position=chainlit_final_response_position,
         summarization_middleware_enabled=raw_summarization_middleware_enabled,
         summarization_trigger_tokens=raw_summarization_trigger_tokens,
         summarization_keep_tokens=raw_summarization_keep_tokens,

--- a/main.py
+++ b/main.py
@@ -1490,6 +1490,7 @@ async def on_message(message: cl.Message) -> None:
         prompt=agent_prompt,
         run_task_list=run_task_list,
         chronological_ui_enabled=runtime.config.extensions.chainlit_chronological_ui_enabled,
+        final_response_position=runtime.config.extensions.chainlit_final_response_position,
     )
     await bridge.start()
 

--- a/response_exports.py
+++ b/response_exports.py
@@ -7,6 +7,7 @@ import re
 import sys
 import unicodedata
 from pathlib import Path
+from typing import Any
 
 import chainlit as cl
 from chainlit.element import Element, File, Pdf
@@ -251,29 +252,72 @@ def attach_response_export_actions(
         prompt: The prompt value.
         response_text: The response text value.
     """
-    message_id = str(getattr(message, "id", "") or "").strip()
-    if not message_id or not response_text.strip():
+    _, actions = _response_export_actions(
+        message,
+        prompt=prompt,
+        response_text=response_text,
+    )
+    if not actions:
         return
 
+    message.actions = actions
+
+
+async def send_response_export_actions(
+    target: Any,
+    *,
+    prompt: str,
+    response_text: str,
+) -> None:
+    """Send response export actions for a Chainlit target.
+
+    Args:
+        target: Chainlit object with an id to attach actions to.
+        prompt: The prompt value.
+        response_text: The response text value.
+    """
+    target_id, actions = _response_export_actions(
+        target,
+        prompt=prompt,
+        response_text=response_text,
+    )
+    if not target_id or not actions:
+        return
+
+    for action in actions:
+        await action.send(for_id=target_id)
+
+
+def _response_export_actions(
+    target: Any,
+    *,
+    prompt: str,
+    response_text: str,
+) -> tuple[str, list[cl.Action]]:
+    """Register response export data and build its action buttons."""
+    target_id = str(getattr(target, "id", "") or "").strip()
+    if not target_id or not response_text.strip():
+        return "", []
+
     exports = _get_response_exports()
-    exports[message_id] = {
+    exports[target_id] = {
         "prompt": prompt,
         "response_text": response_text,
-        "basename": suggested_export_basename(prompt, message_id),
+        "basename": suggested_export_basename(prompt, target_id),
     }
     cl.user_session.set(RESPONSE_EXPORTS_SESSION_KEY, exports)
 
-    message.actions = [
+    return target_id, [
         cl.Action(
             name=DOWNLOAD_MARKDOWN_ACTION,
-            payload={"response_id": message_id},
+            payload={"response_id": target_id},
             label="Markdown",
             tooltip="Download this response as Markdown.",
             icon="download",
         ),
         cl.Action(
             name=DOWNLOAD_PDF_ACTION,
-            payload={"response_id": message_id},
+            payload={"response_id": target_id},
             label="PDF",
             tooltip="Download this response as a PDF.",
             icon="download",

--- a/tests/test_chainlit_bridge_streaming.py
+++ b/tests/test_chainlit_bridge_streaming.py
@@ -214,6 +214,16 @@ class _Step:
         self.update_count += 1
 
 
+class _ToolMessage:
+    """Provide an internal helper for completed tool messages."""
+
+    type = "tool"
+    name = "read_file"
+    tool_call_id = "call-1"
+    status = "success"
+    content = '{"ok": true}'
+
+
 @pytest.fixture(autouse=True)
 def _patch_chainlit_tasks(monkeypatch) -> None:
     """Patch Chainlit task classes with local test doubles.
@@ -295,6 +305,60 @@ async def test_response_message_is_created_on_finish_after_reasoning_steps(monke
     ]
     assert task_list.tasks[-1].status == _TaskStatus.DONE
     assert task_list.tasks[-1].forId == _Message.instances[0].id
+
+
+@pytest.mark.anyio
+async def test_bottom_response_position_renders_final_response_after_steps(
+    monkeypatch,
+) -> None:
+    """Verify bottom response placement renders the final answer after run steps."""
+    task_list = _TaskList()
+    run_task_list = RunTaskList(task_list)  # type: ignore[arg-type]
+    export_calls: list[dict[str, Any]] = []
+    bridge = ChainlitEventBridge(
+        prompt="hello",
+        run_task_list=run_task_list,
+        final_response_position="bottom",
+    )
+
+    async def send_export_actions(*args: Any, **kwargs: Any) -> None:
+        """Capture bottom response export action requests."""
+        export_calls.append({"args": args, "kwargs": kwargs})
+
+    monkeypatch.setattr(
+        chainlit_bridge,
+        "send_response_export_actions",
+        send_export_actions,
+    )
+
+    await bridge.start()
+    await bridge._stream_reasoning("main-agent", "thinking")
+    await bridge._stream_tool_call(
+        "main-agent",
+        {"id": "call-1", "name": "read_file", "args": '{"path":"README.md"}'},
+    )
+    await bridge._complete_tool_step("main-agent", _ToolMessage())
+    await bridge._stream_response("Final answer")
+    await bridge.finish()
+
+    assert _Message.instances == []
+    assert [step.name for step in _Step.instances] == [
+        "main-agent reasoning",
+        "main-agent · read_file",
+        "final response",
+    ]
+    assert _Step.instances[-1].type == "llm"
+    assert _Step.instances[-1].output == "Final answer"
+    assert _Step.instances[-1].send_count == 1
+    assert _Step.instances[-1].update_count == 1
+    assert task_list.tasks[-1].status == _TaskStatus.DONE
+    assert task_list.tasks[-1].forId == _Step.instances[-1].id
+    assert export_calls == [
+        {
+            "args": (_Step.instances[-1],),
+            "kwargs": {"prompt": "hello", "response_text": "Final answer"},
+        }
+    ]
 
 
 @pytest.mark.anyio

--- a/tests/test_deepagent_runtime_rag.py
+++ b/tests/test_deepagent_runtime_rag.py
@@ -2156,6 +2156,7 @@ model_mode_enabled = false
 reasoning_mode_enabled = false
 startup_status_enabled = false
 chronological_ui_enabled = false
+final_response_position = "bottom"
 commands = [
   { name = "ask-researcher", description = "Delegate to subagent", target = "subagent", value = "repo-researcher" },
   { name = "run-tool", description = "Call MCP tool", target = "mcp_tool", value = "repo_read_file", mcp_server = "repo" },
@@ -2176,6 +2177,7 @@ commands = [
     assert extensions.chainlit_reasoning_mode_enabled is False
     assert extensions.chainlit_startup_status_enabled is False
     assert extensions.chainlit_chronological_ui_enabled is False
+    assert extensions.chainlit_final_response_position == "bottom"
 
 
 def test_load_extensions_config_parses_chainlit_starters(
@@ -2386,6 +2388,30 @@ chronological_ui_enabled = "sometimes"
     monkeypatch.setenv("DEEPAGENT_CONFIG", str(config_path))
 
     with pytest.raises(ValueError, match="chronological_ui_enabled"):
+        deepagent_runtime.load_extensions_config()
+
+
+def test_load_extensions_config_rejects_invalid_final_response_position(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Verify that load extensions config rejects invalid response position values.
+
+    Args:
+        tmp_path: Path to the tmp.
+        monkeypatch: The monkeypatch value.
+    """
+    config_path = tmp_path / "deepagent.toml"
+    config_path.write_text(
+        """
+[chainlit]
+final_response_position = "middle"
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DEEPAGENT_CONFIG", str(config_path))
+
+    with pytest.raises(ValueError, match="final_response_position"):
         deepagent_runtime.load_extensions_config()
 
 

--- a/tests/test_response_exports.py
+++ b/tests/test_response_exports.py
@@ -13,6 +13,22 @@ import pytest
 import response_exports
 
 
+class FakeUserSession:
+    """Provide a small Chainlit user session test double."""
+
+    def __init__(self, values: dict[str, Any] | None = None) -> None:
+        """Initialize the fake user session."""
+        self.values = values or {}
+
+    def get(self, key: str) -> Any:
+        """Return a stored session value."""
+        return self.values.get(key)
+
+    def set(self, key: str, value: Any) -> None:
+        """Store a session value."""
+        self.values[key] = value
+
+
 def test_build_pdf_bytes_uses_weasyprint_html_renderer(monkeypatch) -> None:
     """Verify that PDF exports are rendered through WeasyPrint."""
     html_calls: list[dict[str, Any]] = []
@@ -227,3 +243,62 @@ async def test_send_pdf_export_reports_generation_errors(monkeypatch) -> None:
     assert len(sent_messages) == 1
     assert sent_messages[0].author == "System"
     assert "PDF export requires WeasyPrint native libraries" in sent_messages[0].content
+
+
+@pytest.mark.anyio
+async def test_send_response_export_actions_attaches_downloads_to_step(
+    monkeypatch,
+) -> None:
+    """Verify export actions can be sent for a non-message Chainlit target."""
+    sent_actions: list[dict[str, Any]] = []
+    user_session = FakeUserSession()
+
+    class FakeAction:
+        def __init__(
+            self,
+            *,
+            name: str,
+            payload: dict[str, str],
+            label: str,
+            tooltip: str,
+            icon: str,
+        ) -> None:
+            self.name = name
+            self.payload = payload
+            self.label = label
+            self.tooltip = tooltip
+            self.icon = icon
+
+        async def send(self, for_id: str) -> None:
+            sent_actions.append(
+                {
+                    "for_id": for_id,
+                    "name": self.name,
+                    "payload": self.payload,
+                    "label": self.label,
+                    "tooltip": self.tooltip,
+                    "icon": self.icon,
+                }
+            )
+
+    monkeypatch.setattr(response_exports.cl, "user_session", user_session)
+    monkeypatch.setattr(response_exports.cl, "Action", FakeAction)
+
+    target = SimpleNamespace(id="step-1")
+
+    await response_exports.send_response_export_actions(
+        target,
+        prompt="hello",
+        response_text="Final answer",
+    )
+
+    exports = user_session.values[response_exports.RESPONSE_EXPORTS_SESSION_KEY]
+    assert exports["step-1"]["prompt"] == "hello"
+    assert exports["step-1"]["response_text"] == "Final answer"
+    assert len(sent_actions) == 2
+    assert {action["name"] for action in sent_actions} == {
+        response_exports.DOWNLOAD_MARKDOWN_ACTION,
+        response_exports.DOWNLOAD_PDF_ACTION,
+    }
+    assert {action["label"] for action in sent_actions} == {"Markdown", "PDF"}
+    assert {action["for_id"] for action in sent_actions} == {"step-1"}


### PR DESCRIPTION
## Summary

- Add `[chainlit].final_response_position` with `top` and `bottom` modes.
- Render bottom-position final answers as the last Chainlit `llm` step after reasoning and tool steps.
- Attach Markdown and PDF export actions to bottom-position final responses.
- Document the new Chainlit response placement option.

## Validation

- `/Users/amin/pythonProjects/ChainAgents/.venv/bin/python -m pytest tests/test_chainlit_bridge_streaming.py -k bottom_response_position`
- `/Users/amin/pythonProjects/ChainAgents/.venv/bin/python -m pytest tests/test_response_exports.py -k send_response_export_actions`
- `/Users/amin/pythonProjects/ChainAgents/.venv/bin/python -m pytest tests/test_deepagent_runtime_rag.py -k 'chainlit_commands or final_response_position'`
- `/Users/amin/pythonProjects/ChainAgents/.venv/bin/python -m pytest tests/test_chainlit_bridge_streaming.py tests/test_response_exports.py tests/test_deepagent_runtime_rag.py tests/test_main_native_commands.py`
- `/Users/amin/pythonProjects/ChainAgents/.venv/bin/python -m pytest`
- `git diff --check`