### PR TITLE
Add interactive CLI config wizard

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -156,6 +156,9 @@ uv run chainagents --tui
 # Check agent status
 uv run chainagents --status
 
+# Configure deepagent.toml interactively
+uv run chainagents --configure
+
 # List available commands
 uv run chainagents --list-commands
 

--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ Useful CLI examples:
 
 ```bash
 uv run chainagents --status --no-rag
+uv run chainagents --configure
 uv run chainagents --tui --reasoning high
 uv run chainagents --list-commands
 uv run chainagents --command ask-researcher --prompt "Find the config entrypoints"

--- a/chainagents/interfaces/cli/app.py
+++ b/chainagents/interfaces/cli/app.py
@@ -449,14 +449,20 @@ def toml_scalar(value: Any) -> str:
 
 def toml_section_ranges(lines: list[str]) -> dict[str, tuple[int, int]]:
     """Return line ranges for non-array TOML sections."""
-    headers: list[tuple[str, int]] = []
+    headers: list[tuple[str | None, int]] = []
     for index, line in enumerate(lines):
-        match = re.match(r"^\s*\[([^\[\]]+)]\s*(?:#.*)?$", line)
-        if match:
-            headers.append((match.group(1).strip(), index))
+        array_match = re.match(r"^\s*\[\[([^\[\]]+)]]\s*(?:#.*)?$", line)
+        if array_match:
+            headers.append((None, index))
+            continue
+        table_match = re.match(r"^\s*\[([^\[\]]+)]\s*(?:#.*)?$", line)
+        if table_match:
+            headers.append((table_match.group(1).strip(), index))
 
     ranges: dict[str, tuple[int, int]] = {}
     for offset, (section, start) in enumerate(headers):
+        if section is None:
+            continue
         end = headers[offset + 1][1] if offset + 1 < len(headers) else len(lines)
         ranges[section] = (start, end)
     return ranges

--- a/chainagents/interfaces/cli/app.py
+++ b/chainagents/interfaces/cli/app.py
@@ -8,6 +8,7 @@ import asyncio
 import base64
 import json
 import mimetypes
+import os
 import re
 import sys
 import tomllib
@@ -33,6 +34,8 @@ from chainagents.commands.native import (
 from chainagents.runtime import (
     AgentRuntime,
     AppSettings,
+    DEFAULT_EXTENSIONS_CONFIG,
+    PROJECT_ROOT,
     ReasoningLevel,
     RuntimeConfig,
     RuntimeConfigOverrides,
@@ -40,6 +43,7 @@ from chainagents.runtime import (
     shutdown_langfuse_client,
     format_model_provider,
     normalize_reasoning_level,
+    resolve_local_path,
 )
 from chainagents.rag.runtime import RagStatus, RagUploadResult, UploadedRagFile
 
@@ -60,7 +64,6 @@ LANGGRAPH_STREAM_MODES = {
 CLI_PANEL_BOX = box.HEAVY
 CLI_TABLE_BOX = box.SIMPLE_HEAVY
 CLI_PANEL_PADDING = (0, 1)
-DEFAULT_CONFIG_PATH = "deepagent.toml"
 
 
 @dataclass(frozen=True)
@@ -506,6 +509,19 @@ def apply_toml_updates(
                 ranges = toml_section_ranges(lines)
 
     return "\n".join(lines).rstrip() + "\n"
+
+
+def resolve_configure_config_path(config_path: str | Path | None) -> Path:
+    """Resolve the config path that the interactive command should edit."""
+    config_name = (
+        str(config_path).strip()
+        if config_path is not None
+        else os.getenv("DEEPAGENT_CONFIG", DEFAULT_EXTENSIONS_CONFIG).strip()
+    )
+    return resolve_local_path(
+        config_name or DEFAULT_EXTENSIONS_CONFIG,
+        PROJECT_ROOT,
+    )
 
 
 def run_configure_command(
@@ -1753,7 +1769,7 @@ async def run_cli(
     """
     if args.configure:
         return run_configure_command(
-            config_path=Path(args.config or DEFAULT_CONFIG_PATH),
+            config_path=resolve_configure_config_path(args.config),
             stdin=stdin,
             stdout=stdout,
             stderr=stderr,
@@ -1889,7 +1905,7 @@ async def async_main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
     if args.configure:
         return run_configure_command(
-            config_path=Path(args.config or DEFAULT_CONFIG_PATH),
+            config_path=resolve_configure_config_path(args.config),
             stdin=sys.stdin,
             stdout=sys.stdout,
             stderr=sys.stderr,

--- a/chainagents/interfaces/cli/app.py
+++ b/chainagents/interfaces/cli/app.py
@@ -8,9 +8,12 @@ import asyncio
 import base64
 import json
 import mimetypes
+import re
 import sys
+import tomllib
 import traceback
 from contextlib import suppress
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, TextIO
 
@@ -57,6 +60,147 @@ LANGGRAPH_STREAM_MODES = {
 CLI_PANEL_BOX = box.HEAVY
 CLI_TABLE_BOX = box.SIMPLE_HEAVY
 CLI_PANEL_PADDING = (0, 1)
+DEFAULT_CONFIG_PATH = "deepagent.toml"
+
+
+@dataclass(frozen=True)
+class ConfigPrompt:
+    """Describe one interactive TOML configuration prompt."""
+
+    section: str
+    key: str
+    label: str
+    kind: str
+    default: Any | None = None
+    choices: tuple[str, ...] = ()
+    optional: bool = False
+
+
+CONFIGURE_PROMPTS = (
+    ConfigPrompt(
+        section="model",
+        key="provider",
+        label="Model provider",
+        kind="choice",
+        default="ollama",
+        choices=("ollama", "openai_compatible", "anthropic", "claude"),
+    ),
+    ConfigPrompt(
+        section="model",
+        key="base_url",
+        label="Model base URL",
+        kind="str",
+        default="http://127.0.0.1:11434",
+    ),
+    ConfigPrompt(
+        section="model",
+        key="name",
+        label="Model name",
+        kind="str",
+        default="gpt-oss:20b",
+    ),
+    ConfigPrompt(
+        section="model",
+        key="reasoning_effort",
+        label="Reasoning effort",
+        kind="choice",
+        default="medium",
+        choices=("low", "medium", "high"),
+    ),
+    ConfigPrompt(
+        section="model",
+        key="temperature",
+        label="Temperature",
+        kind="float",
+        default=0,
+    ),
+    ConfigPrompt(
+        section="agent",
+        key="state",
+        label="Agent state",
+        kind="choice",
+        default="stateful",
+        choices=("stateful", "stateless"),
+    ),
+    ConfigPrompt(
+        section="agent",
+        key="recursion_limit",
+        label="Recursion limit",
+        kind="int",
+        default=200,
+    ),
+    ConfigPrompt(
+        section="rag",
+        key="enabled",
+        label="Enable RAG",
+        kind="bool",
+        default=False,
+    ),
+    ConfigPrompt(
+        section="rag.embedding",
+        key="provider",
+        label="RAG embedding provider",
+        kind="choice",
+        default="auto",
+        choices=("auto", "ollama", "openai_compatible"),
+    ),
+    ConfigPrompt(
+        section="rag.embedding",
+        key="model",
+        label="RAG embedding model",
+        kind="str",
+        optional=True,
+    ),
+    ConfigPrompt(
+        section="rag.embedding",
+        key="base_url",
+        label="RAG embedding base URL",
+        kind="str",
+        optional=True,
+    ),
+    ConfigPrompt(
+        section="langfuse",
+        key="enabled",
+        label="Enable Langfuse",
+        kind="bool",
+        default=False,
+    ),
+    ConfigPrompt(
+        section="chainlit",
+        key="model_mode_enabled",
+        label="Show Chainlit model selector",
+        kind="bool",
+        default=True,
+    ),
+    ConfigPrompt(
+        section="chainlit",
+        key="reasoning_mode_enabled",
+        label="Show Chainlit reasoning modes",
+        kind="bool",
+        default=True,
+    ),
+    ConfigPrompt(
+        section="chainlit",
+        key="reasoning_steps_enabled",
+        label="Show Chainlit reasoning steps",
+        kind="bool",
+        default=True,
+    ),
+    ConfigPrompt(
+        section="chainlit",
+        key="tool_steps_enabled",
+        label="Show Chainlit tool steps",
+        kind="bool",
+        default=True,
+    ),
+    ConfigPrompt(
+        section="chainlit",
+        key="startup_status_enabled",
+        label="Show Chainlit startup status",
+        kind="bool",
+        default=True,
+    ),
+)
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -85,6 +229,11 @@ def build_parser() -> argparse.ArgumentParser:
     )
 
     parser.add_argument("--config", help="Path to deepagent.toml.")
+    parser.add_argument(
+        "--configure",
+        action="store_true",
+        help="Interactively configure deepagent.toml and exit.",
+    )
     parser.add_argument("--database-url", help="Postgres URL for durable state.")
     parser.add_argument(
         "--no-database",
@@ -205,6 +354,193 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         The parsed args.
     """
     return build_parser().parse_args(argv)
+
+
+def nested_config_value(config: dict[str, Any], *, section: str, key: str) -> Any | None:
+    """Return a value from a dotted TOML section path."""
+    current: Any = config
+    for part in section.split("."):
+        if not isinstance(current, dict) or part not in current:
+            return None
+        current = current[part]
+    if not isinstance(current, dict):
+        return None
+    return current.get(key)
+
+
+def prompt_default_text(value: Any | None, *, optional: bool) -> str:
+    """Format a current/default value for an interactive prompt."""
+    if value is None:
+        return "skip" if optional else ""
+    if isinstance(value, bool):
+        return "yes" if value else "no"
+    return str(value)
+
+
+def parse_config_prompt_value(raw_value: str, prompt: ConfigPrompt) -> Any:
+    """Parse and validate one interactive config answer."""
+    value = raw_value.strip()
+    if prompt.kind == "choice":
+        normalized = value.lower().replace("-", "_")
+        if normalized not in prompt.choices:
+            choices = ", ".join(prompt.choices)
+            raise ValueError(f"Choose one of: {choices}.")
+        return normalized
+    if prompt.kind == "bool":
+        normalized = value.lower()
+        if normalized in {"true", "yes", "y", "1", "on"}:
+            return True
+        if normalized in {"false", "no", "n", "0", "off"}:
+            return False
+        raise ValueError("Enter yes or no.")
+    if prompt.kind == "int":
+        try:
+            parsed_int = int(value)
+        except ValueError as exc:
+            raise ValueError("Enter a whole number.") from exc
+        if parsed_int < 1:
+            raise ValueError("Enter a number greater than zero.")
+        return parsed_int
+    if prompt.kind == "float":
+        try:
+            return float(value)
+        except ValueError as exc:
+            raise ValueError("Enter a number.") from exc
+    return value
+
+
+def read_config_prompt_value(
+    prompt: ConfigPrompt,
+    *,
+    current_value: Any | None,
+    stdin: TextIO,
+    stdout: TextIO,
+    stderr: TextIO,
+) -> tuple[Any | None, bool]:
+    """Read and validate one interactive config prompt value."""
+    fallback = current_value if current_value is not None else prompt.default
+    while True:
+        default_text = prompt_default_text(fallback, optional=prompt.optional)
+        print(f"{prompt.label} [{default_text}]: ", end="", file=stdout, flush=True)
+        raw_value = stdin.readline()
+        if raw_value == "":
+            raw_value = "\n"
+        candidate = raw_value.strip()
+        if not candidate:
+            if fallback is not None:
+                return fallback, True
+            return None, False
+        try:
+            return parse_config_prompt_value(candidate, prompt), True
+        except ValueError as exc:
+            print(f"{prompt.label}: {exc}", file=stderr)
+
+
+def toml_scalar(value: Any) -> str:
+    """Serialize a scalar value for the supported config fields."""
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, float):
+        return str(value)
+    return json.dumps(str(value), ensure_ascii=True)
+
+
+def toml_section_ranges(lines: list[str]) -> dict[str, tuple[int, int]]:
+    """Return line ranges for non-array TOML sections."""
+    headers: list[tuple[str, int]] = []
+    for index, line in enumerate(lines):
+        match = re.match(r"^\s*\[([^\[\]]+)]\s*(?:#.*)?$", line)
+        if match:
+            headers.append((match.group(1).strip(), index))
+
+    ranges: dict[str, tuple[int, int]] = {}
+    for offset, (section, start) in enumerate(headers):
+        end = headers[offset + 1][1] if offset + 1 < len(headers) else len(lines)
+        ranges[section] = (start, end)
+    return ranges
+
+
+def apply_toml_updates(
+    original: str,
+    updates: dict[tuple[str, str], Any],
+) -> str:
+    """Apply known TOML scalar updates while preserving unrelated text."""
+    lines = original.splitlines()
+    section_order = list(dict.fromkeys(section for section, _ in updates))
+    ranges = toml_section_ranges(lines)
+
+    for section in section_order:
+        section_updates = {
+            key: value
+            for (update_section, key), value in updates.items()
+            if update_section == section
+        }
+        if section not in ranges:
+            if lines and lines[-1] != "":
+                lines.append("")
+            lines.append(f"[{section}]")
+            for key, value in section_updates.items():
+                lines.append(f"{key} = {toml_scalar(value)}")
+            ranges = toml_section_ranges(lines)
+            continue
+
+        start, end = ranges[section]
+        for key, value in section_updates.items():
+            replacement = f"{key} = {toml_scalar(value)}"
+            key_pattern = re.compile(rf"^\s*{re.escape(key)}\s*=")
+            for index in range(start + 1, end):
+                if key_pattern.match(lines[index]):
+                    lines[index] = replacement
+                    break
+            else:
+                lines.insert(end, replacement)
+                end += 1
+                ranges = toml_section_ranges(lines)
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def run_configure_command(
+    *,
+    config_path: Path,
+    stdin: TextIO,
+    stdout: TextIO,
+    stderr: TextIO,
+) -> int:
+    """Interactively configure a deepagent.toml file."""
+    config_path = config_path.expanduser()
+    original = config_path.read_text(encoding="utf-8") if config_path.exists() else ""
+    try:
+        current_config = tomllib.loads(original) if original.strip() else {}
+    except tomllib.TOMLDecodeError as exc:
+        print(f"configure: could not parse {config_path}: {exc}", file=stderr)
+        return 1
+
+    print("Configure ChainAgents. Press Enter to keep the current value.", file=stdout)
+    updates: dict[tuple[str, str], Any] = {}
+    for prompt in CONFIGURE_PROMPTS:
+        current_value = nested_config_value(
+            current_config,
+            section=prompt.section,
+            key=prompt.key,
+        )
+        value, should_write = read_config_prompt_value(
+            prompt,
+            current_value=current_value,
+            stdin=stdin,
+            stdout=stdout,
+            stderr=stderr,
+        )
+        if should_write:
+            updates[(prompt.section, prompt.key)] = value
+
+    updated = apply_toml_updates(original, updates)
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(updated, encoding="utf-8")
+    print(f"Configuration written to {config_path}", file=stdout)
+    return 0
 
 
 def runtime_overrides_from_args(args: argparse.Namespace) -> RuntimeConfigOverrides:
@@ -1409,6 +1745,14 @@ async def run_cli(
     Returns:
         The command result.
     """
+    if args.configure:
+        return run_configure_command(
+            config_path=Path(args.config or DEFAULT_CONFIG_PATH),
+            stdin=stdin,
+            stdout=stdout,
+            stderr=stderr,
+        )
+
     if args.tui:
         if args.prompt or args.prompt_parts or args.stdin:
             print("tui: start the TUI without a one-shot prompt.", file=stderr)
@@ -1537,6 +1881,14 @@ async def async_main(argv: list[str] | None = None) -> int:
     """
     parser = build_parser()
     args = parser.parse_args(argv)
+    if args.configure:
+        return run_configure_command(
+            config_path=Path(args.config or DEFAULT_CONFIG_PATH),
+            stdin=sys.stdin,
+            stdout=sys.stdout,
+            stderr=sys.stderr,
+        )
+
     config = RuntimeConfig.from_env(runtime_overrides_from_args(args))
     runtime = await AgentRuntime.create(config)
     try:

--- a/tests/test_agent_cli.py
+++ b/tests/test_agent_cli.py
@@ -146,6 +146,71 @@ startup_status_enabled = false
     assert parsed["chainlit"]["startup_status_enabled"] is True
 
 
+def test_configure_command_stops_section_at_array_table(tmp_path: Path) -> None:
+    """Verify array-of-table headers bound scalar section updates."""
+    config_path = tmp_path / "deepagent.toml"
+    config_path.write_text(
+        """
+[rag.embedding]
+provider = "openai_compatible"
+# model = "text-embedding-3-small"
+# base_url = "http://127.0.0.1:11434"
+
+[[async_subagents]]
+name = "async-researcher"
+description = "Runs longer research jobs."
+graph_id = "async-researcher"
+url = "http://127.0.0.1:2024"
+
+[[subagents]]
+name = "repo-researcher"
+description = "Researches the current repository."
+system_prompt_file = "prompts/repo-researcher.md"
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    answers = "\n".join(
+        [
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "text-embedding-3-large",
+            "http://127.0.0.1:1234/v1",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+        ]
+    )
+
+    code = chainagents_cli.run_configure_command(
+        config_path=config_path,
+        stdin=io.StringIO(answers),
+        stdout=io.StringIO(),
+        stderr=io.StringIO(),
+    )
+
+    assert code == 0
+
+    import tomllib
+
+    written = config_path.read_text(encoding="utf-8")
+    parsed = tomllib.loads(written)
+    assert parsed["rag"]["embedding"]["model"] == "text-embedding-3-large"
+    assert parsed["rag"]["embedding"]["base_url"] == "http://127.0.0.1:1234/v1"
+    assert "model" not in parsed["async_subagents"][0]
+    assert "base_url" not in parsed["async_subagents"][0]
+
+
 def test_configure_command_appends_missing_sections(tmp_path: Path) -> None:
     """Verify the interactive config command appends missing TOML sections."""
     config_path = tmp_path / "deepagent.toml"

--- a/tests/test_agent_cli.py
+++ b/tests/test_agent_cli.py
@@ -255,6 +255,77 @@ def test_configure_command_reprompts_invalid_choice(tmp_path: Path) -> None:
     assert "Choose one of" in stderr.getvalue()
 
 
+@pytest.mark.anyio
+async def test_run_cli_configure_honors_deepagent_config_env(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify configure writes the runtime env config path."""
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    config_path = project_root / "prod.toml"
+    config_path.write_text("[model]\nname = \"prod-model\"\n", encoding="utf-8")
+    cwd = tmp_path / "workdir"
+    cwd.mkdir()
+    monkeypatch.chdir(cwd)
+    monkeypatch.setattr(chainagents_cli, "PROJECT_ROOT", project_root, raising=False)
+    monkeypatch.setenv("DEEPAGENT_CONFIG", "prod.toml")
+    args = chainagents_cli.parse_args(["--configure"])
+
+    code = await chainagents_cli.run_cli(
+        args,
+        runtime=object(),
+        stdin=io.StringIO("\n".join([""] * len(chainagents_cli.CONFIGURE_PROMPTS))),
+        stdout=io.StringIO(),
+        stderr=io.StringIO(),
+    )
+
+    assert code == 0
+    assert config_path.exists()
+    assert not (cwd / "deepagent.toml").exists()
+
+    import tomllib
+
+    parsed = tomllib.loads(config_path.read_text(encoding="utf-8"))
+    assert parsed["model"]["name"] == "prod-model"
+    assert parsed["agent"]["state"] == "stateful"
+
+
+@pytest.mark.anyio
+async def test_run_cli_configure_resolves_relative_config_against_project_root(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify relative --config paths use runtime path resolution."""
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    config_path = project_root / "custom.toml"
+    config_path.write_text("[model]\nname = \"custom-model\"\n", encoding="utf-8")
+    cwd = project_root / "subdir"
+    cwd.mkdir()
+    monkeypatch.chdir(cwd)
+    monkeypatch.setattr(chainagents_cli, "PROJECT_ROOT", project_root, raising=False)
+    args = chainagents_cli.parse_args(["--configure", "--config", "custom.toml"])
+
+    code = await chainagents_cli.run_cli(
+        args,
+        runtime=object(),
+        stdin=io.StringIO("\n".join([""] * len(chainagents_cli.CONFIGURE_PROMPTS))),
+        stdout=io.StringIO(),
+        stderr=io.StringIO(),
+    )
+
+    assert code == 0
+    assert config_path.exists()
+    assert not (cwd / "custom.toml").exists()
+
+    import tomllib
+
+    parsed = tomllib.loads(config_path.read_text(encoding="utf-8"))
+    assert parsed["model"]["name"] == "custom-model"
+    assert parsed["agent"]["state"] == "stateful"
+
+
 def test_runtime_overrides_from_cli_args_take_precedence(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_agent_cli.py
+++ b/tests/test_agent_cli.py
@@ -45,6 +45,151 @@ def test_cli_parses_prompt_and_runtime_flags() -> None:
     assert args.json_output is True
 
 
+def test_cli_parses_configure_flag() -> None:
+    """Verify that CLI parses the interactive configuration flag."""
+    args = chainagents_cli.parse_args(["--configure", "--config", "custom.toml"])
+
+    assert args.configure is True
+    assert args.config == "custom.toml"
+
+
+def test_configure_command_updates_known_toml_values(tmp_path: Path) -> None:
+    """Verify the interactive config command updates known TOML values."""
+    config_path = tmp_path / "deepagent.toml"
+    config_path.write_text(
+        """
+[model]
+# Keep this comment.
+provider = "ollama"
+base_url = "http://old.example:11434"
+name = "old-model"
+temperature = 0.1
+reasoning_effort = "low"
+
+[agent]
+state = "stateful"
+recursion_limit = 20
+
+[rag]
+enabled = false
+
+[rag.embedding]
+provider = "auto"
+
+[langfuse]
+enabled = false
+
+[chainlit]
+model_mode_enabled = false
+reasoning_mode_enabled = false
+reasoning_steps_enabled = false
+tool_steps_enabled = false
+startup_status_enabled = false
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    answers = "\n".join(
+        [
+            "openai_compatible",
+            "http://127.0.0.1:1234/v1",
+            "local-model",
+            "high",
+            "0.2",
+            "stateless",
+            "250",
+            "yes",
+            "openai_compatible",
+            "text-embedding-3-large",
+            "http://127.0.0.1:1234/v1",
+            "yes",
+            "yes",
+            "no",
+            "yes",
+            "no",
+            "yes",
+        ]
+    )
+    stdout = io.StringIO()
+
+    code = chainagents_cli.run_configure_command(
+        config_path=config_path,
+        stdin=io.StringIO(answers),
+        stdout=stdout,
+        stderr=io.StringIO(),
+    )
+
+    assert code == 0
+    written = config_path.read_text(encoding="utf-8")
+    assert "# Keep this comment." in written
+    assert 'provider = "openai_compatible"' in written
+    assert 'name = "local-model"' in written
+    assert "Configuration written" in stdout.getvalue()
+
+    import tomllib
+
+    parsed = tomllib.loads(written)
+    assert parsed["model"]["base_url"] == "http://127.0.0.1:1234/v1"
+    assert parsed["model"]["temperature"] == 0.2
+    assert parsed["model"]["reasoning_effort"] == "high"
+    assert parsed["agent"]["state"] == "stateless"
+    assert parsed["agent"]["recursion_limit"] == 250
+    assert parsed["rag"]["enabled"] is True
+    assert parsed["rag"]["embedding"]["provider"] == "openai_compatible"
+    assert parsed["rag"]["embedding"]["model"] == "text-embedding-3-large"
+    assert parsed["rag"]["embedding"]["base_url"] == "http://127.0.0.1:1234/v1"
+    assert parsed["langfuse"]["enabled"] is True
+    assert parsed["chainlit"]["model_mode_enabled"] is True
+    assert parsed["chainlit"]["reasoning_mode_enabled"] is False
+    assert parsed["chainlit"]["reasoning_steps_enabled"] is True
+    assert parsed["chainlit"]["tool_steps_enabled"] is False
+    assert parsed["chainlit"]["startup_status_enabled"] is True
+
+
+def test_configure_command_appends_missing_sections(tmp_path: Path) -> None:
+    """Verify the interactive config command appends missing TOML sections."""
+    config_path = tmp_path / "deepagent.toml"
+    config_path.write_text("[model]\nname = \"old-model\"\n", encoding="utf-8")
+    answers = "\n".join([""] * 17)
+
+    code = chainagents_cli.run_configure_command(
+        config_path=config_path,
+        stdin=io.StringIO(answers),
+        stdout=io.StringIO(),
+        stderr=io.StringIO(),
+    )
+
+    assert code == 0
+    import tomllib
+
+    parsed = tomllib.loads(config_path.read_text(encoding="utf-8"))
+    assert parsed["model"]["provider"] == "ollama"
+    assert parsed["model"]["name"] == "old-model"
+    assert parsed["agent"]["state"] == "stateful"
+    assert parsed["rag"]["enabled"] is False
+    assert parsed["rag"]["embedding"]["provider"] == "auto"
+    assert parsed["langfuse"]["enabled"] is False
+    assert parsed["chainlit"]["startup_status_enabled"] is True
+
+
+def test_configure_command_reprompts_invalid_choice(tmp_path: Path) -> None:
+    """Verify the interactive config command validates choices."""
+    config_path = tmp_path / "deepagent.toml"
+    config_path.write_text("", encoding="utf-8")
+    answers = "\n".join(["bad-provider", "ollama", *([""] * 16)])
+    stderr = io.StringIO()
+
+    code = chainagents_cli.run_configure_command(
+        config_path=config_path,
+        stdin=io.StringIO(answers),
+        stdout=io.StringIO(),
+        stderr=stderr,
+    )
+
+    assert code == 0
+    assert "Choose one of" in stderr.getvalue()
+
+
 def test_runtime_overrides_from_cli_args_take_precedence(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
- Add `chainagents --configure` for guided `deepagent.toml` setup before runtime startup.
- Update known model, agent, RAG, Langfuse, and Chainlit scalar fields while preserving unrelated TOML content where practical.
- Document the command in README and QUICKSTART and add CLI coverage.

## Validation
- `.venv/bin/python -m pytest` -> `214 passed, 1 warning`
- `git diff --check`