### PR TITLE
Add configurable agent memory namespace and startup memory files

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,7 +416,7 @@ Notes:
 - The built-in default is `100`; this repo's `deepagent.toml` sets it to `200`.
 - `DEEPAGENT_RECURSION_LIMIT` overrides this value when set.
 - Increase it for long tool-heavy runs that hit `GraphRecursionError`; lower it if you want runaway loops to stop sooner.
-- `memory_namespace` is the shared agent-scoped StoreBackend namespace for `/memories/`. The default is `filesystem` to preserve existing memory data from earlier configs.
+- `memory_namespace` is the shared agent-scoped StoreBackend namespace for `/memories/`. The default is `filesystem` to preserve existing memory data from earlier configs. Use only letters, numbers, hyphens, underscores, dots, `@`, `+`, colons, and tildes.
 - `memory_files` lists `/memories/` files DeepAgents loads into the startup memory prompt. The default is `["/memories/AGENTS.md"]`; set it to `[]` to keep the memory route without startup memory loading.
 
 ## Optional: Enable Workspace Docs RAG
@@ -574,7 +574,7 @@ Main `[agent]` additions:
 
 - `state`: optional agent state mode. Use `stateful` for checkpointed conversation state, or `stateless` to build the DeepAgents graph without a LangGraph store, checkpointer, or `/memories/` route. Defaults to `stateful`.
 - `recursion_limit`: optional positive integer LangGraph step limit for a single agent run. Defaults to `100` unless overridden by `DEEPAGENT_RECURSION_LIMIT`.
-- `memory_namespace`: optional non-empty namespace for agent-scoped `/memories/` storage. Defaults to `filesystem`.
+- `memory_namespace`: optional non-empty namespace for agent-scoped `/memories/` storage. Defaults to `filesystem`; allowed characters are letters, numbers, `-`, `_`, `.`, `@`, `+`, `:`, and `~`.
 - `memory_files`: optional list of absolute `/memories/` file paths loaded into the DeepAgents startup memory prompt. Defaults to `["/memories/AGENTS.md"]`; use `[]` to disable startup memory loading.
 - `AGENTS.md`: optional repo-root file that is automatically appended to the **main/supervisor** agent system prompt when present. It is not applied to separately configured async graph prompts.
 - `custom_instruction`: optional string appended to the **main/supervisor** agent system prompt. This setting does **not** get applied to separately configured prompts such as the `async_researcher` graph prompt.

--- a/README.md
+++ b/README.md
@@ -403,6 +403,8 @@ The `[agent]` table configures main-agent runtime behavior:
 [agent]
 state = "stateful"
 recursion_limit = 200
+memory_namespace = "filesystem"
+memory_files = ["/memories/AGENTS.md"]
 skills = ["skills"]
 mcp_servers = ["repo"]
 ```
@@ -414,6 +416,8 @@ Notes:
 - The built-in default is `100`; this repo's `deepagent.toml` sets it to `200`.
 - `DEEPAGENT_RECURSION_LIMIT` overrides this value when set.
 - Increase it for long tool-heavy runs that hit `GraphRecursionError`; lower it if you want runaway loops to stop sooner.
+- `memory_namespace` is the shared agent-scoped StoreBackend namespace for `/memories/`. The default is `filesystem` to preserve existing memory data from earlier configs.
+- `memory_files` lists `/memories/` files DeepAgents loads into the startup memory prompt. The default is `["/memories/AGENTS.md"]`; set it to `[]` to keep the memory route without startup memory loading.
 
 ## Optional: Enable Workspace Docs RAG
 
@@ -570,6 +574,8 @@ Main `[agent]` additions:
 
 - `state`: optional agent state mode. Use `stateful` for checkpointed conversation state, or `stateless` to build the DeepAgents graph without a LangGraph store, checkpointer, or `/memories/` route. Defaults to `stateful`.
 - `recursion_limit`: optional positive integer LangGraph step limit for a single agent run. Defaults to `100` unless overridden by `DEEPAGENT_RECURSION_LIMIT`.
+- `memory_namespace`: optional non-empty namespace for agent-scoped `/memories/` storage. Defaults to `filesystem`.
+- `memory_files`: optional list of absolute `/memories/` file paths loaded into the DeepAgents startup memory prompt. Defaults to `["/memories/AGENTS.md"]`; use `[]` to disable startup memory loading.
 - `AGENTS.md`: optional repo-root file that is automatically appended to the **main/supervisor** agent system prompt when present. It is not applied to separately configured async graph prompts.
 - `custom_instruction`: optional string appended to the **main/supervisor** agent system prompt. This setting does **not** get applied to separately configured prompts such as the `async_researcher` graph prompt.
 - DeepAgents provides its own summarization middleware in the main agent and sync subagents.
@@ -763,7 +769,7 @@ See [deepagent.toml.example](deepagent.toml.example) for a complete example.
 ## Workspace Contract
 
 - `/workspace/` maps to this repo on disk.
-- `/memories/` is available in stateful mode and durable across LangGraph threads only when `DATABASE_URL` is configured.
+- `/memories/` is available in stateful mode under the configured agent-scoped namespace and durable across LangGraph threads only when `DATABASE_URL` is configured.
 - any other absolute path is treated as ephemeral scratch space by the deep agent backend.
 
 ## Notes

--- a/chainagents/runtime/core.py
+++ b/chainagents/runtime/core.py
@@ -76,6 +76,8 @@ DEFAULT_AGENT_STATE: AgentStateMode = "stateful"
 DEFAULT_TEMPERATURE = 0.0
 DEFAULT_EXTENSIONS_CONFIG = "deepagent.toml"
 DEFAULT_RECURSION_LIMIT = 100
+DEFAULT_AGENT_MEMORY_NAMESPACE = "filesystem"
+DEFAULT_AGENT_MEMORY_FILES = ("/memories/AGENTS.md",)
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 DEEPAGENT_ARTIFACTS_DIRECTORY = Path(".files/deepagent")
 GENERATED_OUTPUTS_DIRECTORY = Path(".files/outputs")
@@ -167,6 +169,71 @@ def normalize_agent_state(value: Any | None) -> AgentStateMode:
     raise ValueError(
         "The top-level 'agent.state' config must be 'stateful' or 'stateless'."
     )
+
+
+def normalize_agent_memory_namespace(value: Any | None) -> str:
+    """Normalize the shared agent memory namespace.
+
+    Args:
+        value: Value to normalize, convert, or serialize.
+
+    Returns:
+        The normalized agent memory namespace.
+
+    Raises:
+        ValueError: If the supplied value is invalid.
+    """
+    if value is None:
+        return DEFAULT_AGENT_MEMORY_NAMESPACE
+    if not isinstance(value, str):
+        raise ValueError(
+            "The top-level 'agent.memory_namespace' config must be a non-empty string."
+        )
+    candidate = value.strip()
+    if not candidate:
+        raise ValueError(
+            "The top-level 'agent.memory_namespace' config must be a non-empty string."
+        )
+    if "*" in candidate:
+        raise ValueError(
+            "The top-level 'agent.memory_namespace' config cannot contain '*'."
+        )
+    return candidate
+
+
+def normalize_agent_memory_files(value: Any | None) -> tuple[str, ...]:
+    """Normalize startup memory files loaded by DeepAgents.
+
+    Args:
+        value: Value to normalize, convert, or serialize.
+
+    Returns:
+        The normalized memory file paths.
+
+    Raises:
+        ValueError: If the supplied value is invalid.
+    """
+    if value is None:
+        return DEFAULT_AGENT_MEMORY_FILES
+    if not isinstance(value, list):
+        raise ValueError(
+            "The top-level 'agent.memory_files' config must be an array of /memories/ paths."
+        )
+
+    memory_files: list[str] = []
+    for index, raw_path in enumerate(value, start=1):
+        if not isinstance(raw_path, str):
+            raise ValueError(
+                f"The top-level 'agent.memory_files' entry #{index} must be a string."
+            )
+        memory_path = raw_path.strip()
+        if not memory_path.startswith("/memories/") or memory_path == "/memories/":
+            raise ValueError(
+                "The top-level 'agent.memory_files' entries must be absolute "
+                "/memories/ file paths."
+            )
+        memory_files.append(memory_path)
+    return tuple(memory_files)
 
 
 def normalize_disable_streaming(value: Any | None) -> DisableStreaming:
@@ -1534,6 +1601,8 @@ class ExtensionsConfig:
         mcp_tool_name_prefix: The MCP tool name prefix value.
         mcp_stateful: The MCP stateful value.
         agent_state: Whether the DeepAgents graph is stateful or stateless.
+        agent_memory_namespace: Shared StoreBackend namespace for /memories/.
+        agent_memory_files: Startup memory files loaded into the agent prompt.
         recursion_limit: The recursion limit value.
         mcp_servers: The MCP servers value.
         skills: The skills value.
@@ -1558,6 +1627,8 @@ class ExtensionsConfig:
     mcp_tool_name_prefix: bool = True
     mcp_stateful: bool = False
     agent_state: AgentStateMode = DEFAULT_AGENT_STATE
+    agent_memory_namespace: str = DEFAULT_AGENT_MEMORY_NAMESPACE
+    agent_memory_files: tuple[str, ...] = DEFAULT_AGENT_MEMORY_FILES
     recursion_limit: int = DEFAULT_RECURSION_LIMIT
     mcp_servers: dict[str, dict[str, Any]] | None = None
     skills: tuple[str, ...] = ()
@@ -1918,6 +1989,10 @@ def parse_extensions_config(raw_config: dict[str, Any], config_path: Path) -> Ex
         field_name="The top-level 'agent.recursion_limit' config",
     )
     agent_state = normalize_agent_state(agent_section.get("state"))
+    agent_memory_namespace = normalize_agent_memory_namespace(
+        agent_section.get("memory_namespace")
+    )
+    agent_memory_files = normalize_agent_memory_files(agent_section.get("memory_files"))
     raw_mcp_servers = mcp_section.get("servers", {})
     mcp_servers: dict[str, dict[str, Any]] = {}
     for name, raw_server in raw_mcp_servers.items():
@@ -2133,6 +2208,8 @@ def parse_extensions_config(raw_config: dict[str, Any], config_path: Path) -> Ex
         mcp_tool_name_prefix=bool(mcp_section.get("tool_name_prefix", True)),
         mcp_stateful=bool(mcp_section.get("stateful", False)),
         agent_state=agent_state,
+        agent_memory_namespace=agent_memory_namespace,
+        agent_memory_files=agent_memory_files,
         recursion_limit=recursion_limit,
         mcp_servers=mcp_servers or None,
         skills=skill_paths,
@@ -2826,12 +2903,14 @@ def build_deepagent_backend(
     *,
     project_root: Path | None = None,
     include_memories: bool = True,
+    memory_namespace: str = DEFAULT_AGENT_MEMORY_NAMESPACE,
 ) -> CompositeBackend:
     """Build deepagent backend.
 
     Args:
         project_root: Project root used to resolve local paths.
         include_memories: Whether to expose the /memories/ store route.
+        memory_namespace: Shared StoreBackend namespace for /memories/.
 
     Returns:
         The constructed deepagent backend.
@@ -2854,7 +2933,9 @@ def build_deepagent_backend(
         ),
     }
     if include_memories:
-        routes["/memories/"] = StoreBackend()
+        routes["/memories/"] = StoreBackend(
+            namespace=lambda _runtime: (memory_namespace,)
+        )
     return CompositeBackend(
         default=StateBackend(),
         routes=routes,
@@ -3184,6 +3265,20 @@ def build_graph_subagent_specs(
     return subagent_specs
 
 
+def stateful_agent_memory_files(config: RuntimeConfig) -> list[str] | None:
+    """Return startup memory files for stateful agents.
+
+    Args:
+        config: Configuration object used by the operation.
+
+    Returns:
+        The configured memory file paths, or None when startup memory is disabled.
+    """
+    if config.agent_state != "stateful" or not config.extensions.agent_memory_files:
+        return None
+    return list(config.extensions.agent_memory_files)
+
+
 def create_configured_graph(
     *,
     include_async_subagents: bool,
@@ -3215,11 +3310,10 @@ def create_configured_graph(
     else:
         if config.rag_requested and config.rag_error:
             logger.warning("RAG is configured but unavailable: %s", config.rag_error)
-    return create_deep_agent_with_configured_summarization(
-        config,
-        model=build_model(config, config.default_reasoning),
-        tools=sanitize_tools_for_model(config.model_provider, tools) or None,
-        system_prompt=compose_rag_system_prompt(
+    agent_kwargs: dict[str, Any] = {
+        "model": build_model(config, config.default_reasoning),
+        "tools": sanitize_tools_for_model(config.model_provider, tools) or None,
+        "system_prompt": compose_rag_system_prompt(
             compose_agent_system_prompt(
                 system_prompt_for_agent_state(system_prompt, config.agent_state),
                 (
@@ -3231,18 +3325,23 @@ def create_configured_graph(
             ),
             rag_enabled=config.rag is not None,
         ),
-        middleware=build_agent_middleware(
+        "middleware": build_agent_middleware(
             config=config,
             reasoning_level=config.default_reasoning,
             source="main-agent",
             project_root=PROJECT_ROOT,
         ),
-        backend=build_deepagent_backend(
+        "backend": build_deepagent_backend(
             include_memories=config.agent_state == "stateful",
+            memory_namespace=config.extensions.agent_memory_namespace,
         ),
-        skills=list(config.extensions.skills) or None,
-        subagents=subagent_specs or None,
-    )
+        "skills": list(config.extensions.skills) or None,
+        "subagents": subagent_specs or None,
+    }
+    memory_files = stateful_agent_memory_files(config)
+    if memory_files is not None:
+        agent_kwargs["memory"] = memory_files
+    return create_deep_agent_with_configured_summarization(config, **agent_kwargs)
 
 
 @dataclass(frozen=True)
@@ -3562,10 +3661,14 @@ class AgentRuntime:
                     "backend": build_deepagent_backend(
                         project_root=self.project_root,
                         include_memories=self.config.agent_state == "stateful",
+                        memory_namespace=self.config.extensions.agent_memory_namespace,
                     ),
                     "skills": list(self.config.extensions.skills) or None,
                     "subagents": subagent_specs or None,
                 }
+                memory_files = stateful_agent_memory_files(self.config)
+                if memory_files is not None:
+                    agent_kwargs["memory"] = memory_files
                 if self.config.agent_state == "stateful":
                     agent_kwargs["store"] = self.store
                     agent_kwargs["checkpointer"] = self.checkpointer
@@ -3970,4 +4073,5 @@ class AgentRuntime:
         return build_deepagent_backend(
             project_root=self.project_root,
             include_memories=runtime.config.agent_state == "stateful",
+            memory_namespace=runtime.config.extensions.agent_memory_namespace,
         )

--- a/chainagents/runtime/core.py
+++ b/chainagents/runtime/core.py
@@ -9,6 +9,7 @@ import json
 import logging
 import math
 import os
+import re
 import threading
 import tomllib
 from collections.abc import Awaitable, Callable
@@ -78,6 +79,7 @@ DEFAULT_EXTENSIONS_CONFIG = "deepagent.toml"
 DEFAULT_RECURSION_LIMIT = 100
 DEFAULT_AGENT_MEMORY_NAMESPACE = "filesystem"
 DEFAULT_AGENT_MEMORY_FILES = ("/memories/AGENTS.md",)
+AGENT_MEMORY_NAMESPACE_RE = re.compile(r"^[A-Za-z0-9\-_.@+:~]+$")
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 DEEPAGENT_ARTIFACTS_DIRECTORY = Path(".files/deepagent")
 GENERATED_OUTPUTS_DIRECTORY = Path(".files/outputs")
@@ -194,9 +196,11 @@ def normalize_agent_memory_namespace(value: Any | None) -> str:
         raise ValueError(
             "The top-level 'agent.memory_namespace' config must be a non-empty string."
         )
-    if "*" in candidate:
+    if AGENT_MEMORY_NAMESPACE_RE.fullmatch(candidate) is None:
         raise ValueError(
-            "The top-level 'agent.memory_namespace' config cannot contain '*'."
+            "The top-level 'agent.memory_namespace' config may only contain "
+            "alphanumeric characters, hyphens, underscores, dots, @, +, colons, "
+            "and tildes."
         )
     return candidate
 

--- a/deepagent.toml
+++ b/deepagent.toml
@@ -49,6 +49,8 @@ cwd = "."
 [agent]
 state = "stateful"
 recursion_limit = 200
+memory_namespace = "filesystem"
+memory_files = ["/memories/AGENTS.md"]
 skills = ["skills"]
 mcp_servers = []
 # Legacy flag retained for compatibility; DeepAgents provides summarization.

--- a/deepagent.toml.example
+++ b/deepagent.toml.example
@@ -43,6 +43,12 @@ url = "http://localhost:8000/mcp"
 [agent]
 state = "stateful"
 # A repo-root AGENTS.md file is loaded automatically into the main agent prompt.
+# Agent-scoped DeepAgents memory is shared across all threads using this namespace.
+# The default preserves existing store-backed /memories/ data from older configs.
+memory_namespace = "filesystem"
+# These /memories/ files are loaded into the DeepAgents startup memory prompt.
+# Set memory_files = [] to keep the /memories/ route without startup memory loading.
+memory_files = ["/memories/AGENTS.md"]
 # Relative skill source paths are resolved from this file and mapped to /workspace/...
 # This directory should contain one or more skill folders, each with its own SKILL.md.
 skills = ["skills"]

--- a/tests/test_deepagent_runtime_rag.py
+++ b/tests/test_deepagent_runtime_rag.py
@@ -1153,6 +1153,102 @@ state = "stateless"
     assert config.extensions.agent_state == "stateless"
 
 
+def test_runtime_config_defaults_agent_scoped_memory(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Verify agent-scoped memory defaults preserve legacy namespace behavior."""
+    config_path = tmp_path / "deepagent.toml"
+    config_path.write_text(
+        """
+[agent]
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DEEPAGENT_CONFIG", str(config_path))
+
+    config = deepagent_runtime.RuntimeConfig.from_env()
+
+    assert config.extensions.agent_memory_namespace == "filesystem"
+    assert config.extensions.agent_memory_files == ("/memories/AGENTS.md",)
+
+
+def test_runtime_config_reads_agent_scoped_memory_from_toml(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Verify agent memory namespace and startup files are configurable."""
+    config_path = tmp_path / "deepagent.toml"
+    config_path.write_text(
+        """
+[agent]
+memory_namespace = "repo-agent"
+memory_files = ["/memories/AGENTS.md", "/memories/preferences.md"]
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DEEPAGENT_CONFIG", str(config_path))
+
+    config = deepagent_runtime.RuntimeConfig.from_env()
+
+    assert config.extensions.agent_memory_namespace == "repo-agent"
+    assert config.extensions.agent_memory_files == (
+        "/memories/AGENTS.md",
+        "/memories/preferences.md",
+    )
+
+
+def test_runtime_config_allows_empty_agent_memory_files(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Verify memory_files = [] disables startup memory loading."""
+    config_path = tmp_path / "deepagent.toml"
+    config_path.write_text(
+        """
+[agent]
+memory_files = []
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DEEPAGENT_CONFIG", str(config_path))
+
+    config = deepagent_runtime.RuntimeConfig.from_env()
+
+    assert config.extensions.agent_memory_files == ()
+
+
+@pytest.mark.parametrize(
+    ("agent_config", "message"),
+    (
+        ('memory_namespace = ""', "agent.memory_namespace"),
+        ('memory_namespace = "agent-*"', "agent.memory_namespace"),
+        ('memory_files = "/memories/AGENTS.md"', "agent.memory_files"),
+        ('memory_files = ["memories/AGENTS.md"]', "agent.memory_files"),
+        ('memory_files = ["/workspace/AGENTS.md"]', "agent.memory_files"),
+    ),
+)
+def test_runtime_config_rejects_invalid_agent_memory_config(
+    tmp_path: Path,
+    monkeypatch,
+    agent_config: str,
+    message: str,
+) -> None:
+    """Verify invalid agent memory config fails clearly."""
+    config_path = tmp_path / "deepagent.toml"
+    config_path.write_text(
+        f"""
+[agent]
+{agent_config}
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DEEPAGENT_CONFIG", str(config_path))
+
+    with pytest.raises(ValueError, match=message):
+        deepagent_runtime.RuntimeConfig.from_env()
+
+
 def test_runtime_config_rejects_invalid_agent_state(
     tmp_path: Path,
     monkeypatch,
@@ -1261,6 +1357,20 @@ def test_build_deepagent_backend_routes_generated_outputs_separately(
     assert read_result.error is None
     assert read_result.file_data is not None
     assert read_result.file_data["content"] == "downloadable output"
+
+
+def test_build_deepagent_backend_uses_explicit_agent_memory_namespace(
+    tmp_path: Path,
+) -> None:
+    """Verify /memories/ uses an explicit agent-scoped store namespace."""
+    backend = deepagent_runtime.build_deepagent_backend(
+        project_root=tmp_path,
+        memory_namespace="repo-agent",
+    )
+
+    memory_backend = backend.routes["/memories/"]
+
+    assert memory_backend._namespace(None) == ("repo-agent",)  # noqa: SLF001
 
 
 def test_tool_execution_resilience_middleware_returns_error_tool_message() -> None:
@@ -1571,6 +1681,72 @@ def test_get_agent_passes_deepagents_backend_instance(
     assert backend.routes["/workspace/"].cwd == tmp_path
 
 
+def test_get_agent_passes_agent_memory_files_when_stateful(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Verify stateful agents load configured long-term memory files."""
+    captured: dict[str, object] = {}
+
+    def fake_create_deep_agent(*, tools=None, **kwargs):
+        """Capture Deep Agent factory arguments for tests."""
+        captured["kwargs"] = kwargs
+        return object()
+
+    monkeypatch.setattr(deepagent_runtime, "create_deep_agent", fake_create_deep_agent)
+
+    extensions = ExtensionsConfig(
+        config_path=None,
+        agent_memory_namespace="repo-agent",
+        agent_memory_files=("/memories/AGENTS.md", "/memories/preferences.md"),
+    )
+    runtime = AgentRuntime(
+        make_runtime_config(tmp_path, extensions=extensions),
+        project_root=tmp_path,
+    )
+    runtime._store = InMemoryStore()
+    runtime._checkpointer = MemorySaver()
+
+    asyncio.run(runtime.get_agent("medium", thread_id="thread-1"))
+
+    assert captured["kwargs"]["memory"] == [
+        "/memories/AGENTS.md",
+        "/memories/preferences.md",
+    ]
+
+
+def test_get_agent_omits_memory_when_stateful_memory_files_empty(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Verify stateful agents can keep /memories/ without startup memory files."""
+    captured: dict[str, object] = {}
+
+    def fake_create_deep_agent(*, tools=None, **kwargs):
+        """Capture Deep Agent factory arguments for tests."""
+        captured["kwargs"] = kwargs
+        return object()
+
+    monkeypatch.setattr(deepagent_runtime, "create_deep_agent", fake_create_deep_agent)
+
+    extensions = ExtensionsConfig(
+        config_path=None,
+        agent_memory_namespace="repo-agent",
+        agent_memory_files=(),
+    )
+    runtime = AgentRuntime(
+        make_runtime_config(tmp_path, extensions=extensions),
+        project_root=tmp_path,
+    )
+    runtime._store = InMemoryStore()
+    runtime._checkpointer = MemorySaver()
+
+    asyncio.run(runtime.get_agent("medium", thread_id="thread-1"))
+
+    assert "memory" not in captured["kwargs"]
+    assert "/memories/" in captured["kwargs"]["backend"].routes
+
+
 def test_get_agent_omits_store_and_checkpointer_when_stateless(
     tmp_path: Path,
     monkeypatch,
@@ -1632,6 +1808,7 @@ def test_get_agent_disables_memories_backend_and_prompt_when_stateless(
     assert "/memories/" not in backend.routes
     assert "/memories/" not in system_prompt
     assert "Agent memory is disabled for this runtime." in system_prompt
+    assert "memory" not in captured["kwargs"]
 
 
 def test_get_agent_leaves_summarization_middleware_to_deepagents_when_enabled(

--- a/tests/test_deepagent_runtime_rag.py
+++ b/tests/test_deepagent_runtime_rag.py
@@ -1223,6 +1223,10 @@ memory_files = []
     (
         ('memory_namespace = ""', "agent.memory_namespace"),
         ('memory_namespace = "agent-*"', "agent.memory_namespace"),
+        ('memory_namespace = "agent namespace"', "agent.memory_namespace"),
+        ('memory_namespace = "agent/namespace"', "agent.memory_namespace"),
+        ('memory_namespace = "agent?namespace"', "agent.memory_namespace"),
+        ('memory_namespace = "agent[namespace]"', "agent.memory_namespace"),
         ('memory_files = "/memories/AGENTS.md"', "agent.memory_files"),
         ('memory_files = ["memories/AGENTS.md"]', "agent.memory_files"),
         ('memory_files = ["/workspace/AGENTS.md"]', "agent.memory_files"),


### PR DESCRIPTION
## Summary
- Add `agent.memory_namespace` to scope `/memories/` storage per agent runtime.
- Add `agent.memory_files` to load startup memory files into the main agent prompt.
- Document the new config in `README.md` and the example TOML file.
- Add tests for defaults, validation, backend routing, and agent wiring.

## Testing
- Unit tests added for config parsing, backend namespace selection, and agent factory arguments.