### PR TITLE
Add configurable reflection lesson proposals

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,6 +407,12 @@ memory_namespace = "filesystem"
 memory_files = ["/memories/AGENTS.md"]
 skills = ["skills"]
 mcp_servers = ["repo"]
+
+[agent.reflection]
+enabled = true
+memory_file = "/memories/AGENTS.md"
+max_lesson_chars = 700
+tool_failure_mode = "unrecovered"
 ```
 
 Notes:
@@ -418,6 +424,7 @@ Notes:
 - Increase it for long tool-heavy runs that hit `GraphRecursionError`; lower it if you want runaway loops to stop sooner.
 - `memory_namespace` is the shared agent-scoped StoreBackend namespace for `/memories/`. The default is `filesystem` to preserve existing memory data from earlier configs. Use only letters, numbers, hyphens, underscores, dots, `@`, `+`, colons, and tildes.
 - `memory_files` lists `/memories/` files DeepAgents loads into the startup memory prompt. The default is `["/memories/AGENTS.md"]`; set it to `[]` to keep the memory route without startup memory loading.
+- `[agent.reflection]` is opt-in. When enabled for stateful agents, ChainAgents proposes a compact lesson for `memory_file` after correction phrases such as "that was wrong" or after unrecovered tool failures. Chainlit asks with Save/Dismiss before writing through the agent; CLI, TUI, and API expose the proposal without mutating memory.
 
 ## Optional: Enable Workspace Docs RAG
 
@@ -576,6 +583,7 @@ Main `[agent]` additions:
 - `recursion_limit`: optional positive integer LangGraph step limit for a single agent run. Defaults to `100` unless overridden by `DEEPAGENT_RECURSION_LIMIT`.
 - `memory_namespace`: optional non-empty namespace for agent-scoped `/memories/` storage. Defaults to `filesystem`; allowed characters are letters, numbers, `-`, `_`, `.`, `@`, `+`, `:`, and `~`.
 - `memory_files`: optional list of absolute `/memories/` file paths loaded into the DeepAgents startup memory prompt. Defaults to `["/memories/AGENTS.md"]`; use `[]` to disable startup memory loading.
+- `[agent.reflection]`: optional correction-learning workflow. `enabled = true` requires `state = "stateful"` and a `memory_file` under `/memories/`; `max_lesson_chars` limits proposal size; `tool_failure_mode = "unrecovered"` only proposes lessons for failed tool calls that do not produce a later final response.
 - `AGENTS.md`: optional repo-root file that is automatically appended to the **main/supervisor** agent system prompt when present. It is not applied to separately configured async graph prompts.
 - `custom_instruction`: optional string appended to the **main/supervisor** agent system prompt. This setting does **not** get applied to separately configured prompts such as the `async_researcher` graph prompt.
 - DeepAgents provides its own summarization middleware in the main agent and sync subagents.

--- a/chainagents/interfaces/api/app.py
+++ b/chainagents/interfaces/api/app.py
@@ -22,6 +22,7 @@ from chainagents.runtime import (
     build_langgraph_run_config,
     normalize_reasoning_level,
 )
+from chainagents.runtime.reflection import ReflectionCollector
 
 
 AGENT_STREAM_MODES = ["messages", "updates", "custom"]
@@ -155,9 +156,28 @@ def create_app(runtime: Any | None = None) -> FastAPI:
         context = _run_context(active_runtime, payload)
 
         async def lines() -> AsyncIterator[str]:
+            reflection_collector = ReflectionCollector.from_runtime_config(
+                active_runtime.config,
+                prompt=context.prompt,
+            )
             try:
-                async for event in _iter_agent_events(active_runtime, context):
+                async for event in _iter_agent_events(
+                    active_runtime,
+                    context,
+                    reflection_collector=reflection_collector,
+                ):
                     yield _json_line(_event_payload(event, context))
+                proposal = reflection_collector.build_proposal()
+                if proposal is not None:
+                    yield _json_line(
+                        {
+                            "kind": "reflection_proposal",
+                            "proposal": proposal.to_payload(),
+                            "thread_id": context.thread_id,
+                            "model": context.model_name,
+                            "reasoning": context.reasoning_level,
+                        }
+                    )
                 yield _json_line(
                     {
                         "kind": "done",
@@ -169,6 +189,18 @@ def create_app(runtime: Any | None = None) -> FastAPI:
             except asyncio.CancelledError:
                 raise
             except Exception as exc:
+                reflection_collector.mark_run_failed(exc)
+                proposal = reflection_collector.build_proposal()
+                if proposal is not None:
+                    yield _json_line(
+                        {
+                            "kind": "reflection_proposal",
+                            "proposal": proposal.to_payload(),
+                            "thread_id": context.thread_id,
+                            "model": context.model_name,
+                            "reasoning": context.reasoning_level,
+                        }
+                    )
                 yield _json_line(
                     {
                         "kind": "error",
@@ -233,6 +265,8 @@ def _required_text(value: str, field_name: str) -> str:
 async def _iter_agent_events(
     runtime: Any,
     context: AgentRunContext,
+    *,
+    reflection_collector: ReflectionCollector | None = None,
 ) -> AsyncIterator[AgentStreamEvent]:
     agent = await runtime.get_agent(
         context.reasoning_level,
@@ -255,6 +289,8 @@ async def _iter_agent_events(
     try:
         async for raw_event in stream:
             for event in adapter.events_from_raw_event(raw_event):
+                if reflection_collector is not None:
+                    reflection_collector.record_event(event)
                 yield event
     finally:
         with suppress(Exception):

--- a/chainagents/interfaces/chainlit/app.py
+++ b/chainagents/interfaces/chainlit/app.py
@@ -38,10 +38,17 @@ from chainagents.runtime import (
     AgentRuntime,
     AppSettings,
     ChainlitStarterConfig,
+    ReasoningLevel,
     RuntimeConfig,
     build_langgraph_run_config,
     format_model_provider,
     normalize_reasoning_level,
+)
+from chainagents.runtime.reflection import (
+    ReflectionCollector,
+    ReflectionProposal,
+    format_reflection_proposal,
+    reflection_save_prompt,
 )
 from chainagents.rag.runtime import UploadedRagFile
 from chainagents.exports.response import (
@@ -58,6 +65,8 @@ SESSION_ASYNC_TASK_NOTIFIER_KEY = "async_task_notifier"
 SESSION_MCP_SESSION_ID_KEY = "mcp_session_id"
 REBUILD_RAG_INDEX_ACTION = "rebuild_knowledge_index"
 UPLOAD_RAG_FILE_ACTION = "upload_rag_file"
+REFLECTION_SAVE_ACTION = "save_reflection_lesson"
+REFLECTION_DISMISS_ACTION = "dismiss_reflection_lesson"
 RAG_UPLOAD_ACCEPT = {
     "text/plain": [
         ".csv",
@@ -405,6 +414,98 @@ def rag_actions() -> list[cl.Action]:
         Chainlit action buttons for RAG workflows.
     """
     return [build_rag_action(), build_upload_rag_action()]
+
+
+def reflection_actions() -> list[cl.Action]:
+    """Return Chainlit actions for reflection confirmation."""
+    return [
+        cl.Action(
+            name=REFLECTION_SAVE_ACTION,
+            payload={"value": "save"},
+            label="Save lesson",
+            tooltip="Ask the agent to save this lesson into long-term memory.",
+            icon="save",
+        ),
+        cl.Action(
+            name=REFLECTION_DISMISS_ACTION,
+            payload={"value": "dismiss"},
+            label="Dismiss",
+            tooltip="Do not save this reflection lesson.",
+            icon="x",
+        ),
+    ]
+
+
+async def ask_to_save_reflection_lesson(
+    *,
+    runtime: AgentRuntime,
+    settings: AppSettings,
+    proposal: ReflectionProposal,
+    reasoning_level: ReasoningLevel,
+    model_name: str,
+    async_url_override: str | None,
+    mcp_session_id: str | None,
+) -> None:
+    """Ask the Chainlit user whether to save a reflection lesson."""
+    response = await cl.AskActionMessage(
+        content=format_reflection_proposal(proposal),
+        actions=reflection_actions(),
+        author="System",
+        timeout=90,
+        raise_on_timeout=False,
+    ).send()
+    if not response:
+        return
+    payload = response.get("payload") if isinstance(response, dict) else None
+    if not isinstance(payload, dict) or payload.get("value") != "save":
+        return
+    await save_reflection_lesson(
+        runtime=runtime,
+        settings=settings,
+        proposal=proposal,
+        reasoning_level=reasoning_level,
+        model_name=model_name,
+        async_url_override=async_url_override,
+        mcp_session_id=mcp_session_id,
+    )
+
+
+async def save_reflection_lesson(
+    *,
+    runtime: AgentRuntime,
+    settings: AppSettings,
+    proposal: ReflectionProposal,
+    reasoning_level: ReasoningLevel,
+    model_name: str,
+    async_url_override: str | None,
+    mcp_session_id: str | None,
+) -> None:
+    """Ask the configured agent to save a confirmed reflection lesson."""
+    reflection_thread_id = f"{settings.thread_id}:reflection"
+    agent = await runtime.get_agent(
+        reasoning_level,
+        model_name=model_name,
+        thread_id=reflection_thread_id,
+        async_subagent_url_override=async_url_override,
+        mcp_session_id=mcp_session_id,
+    )
+    payload = {
+        "messages": [
+            {
+                "role": "user",
+                "content": reflection_save_prompt(proposal),
+            }
+        ]
+    }
+    config = build_langgraph_run_config(
+        runtime.config,
+        thread_id=reflection_thread_id,
+    )
+    await agent.ainvoke(payload, config=config)
+    await cl.Message(
+        content=f"Saved lesson to `{proposal.memory_file}`.",
+        author="System",
+    ).send()
 
 
 def build_native_command_specs(runtime: AgentRuntime) -> list[dict[str, Any]]:
@@ -1584,6 +1685,10 @@ async def on_message(message: cl.Message) -> None:
         chronological_ui_enabled=runtime.config.extensions.chainlit_chronological_ui_enabled,
         reasoning_steps_enabled=settings.show_reasoning_stream,
         tool_steps_enabled=settings.show_tool_calls,
+        reflection_collector=ReflectionCollector.from_runtime_config(
+            runtime.config,
+            prompt=agent_prompt,
+        ),
     )
     await bridge.start()
 
@@ -1628,12 +1733,35 @@ async def on_message(message: cl.Message) -> None:
         details = traceback.format_exc(limit=10)
         with suppress(Exception):
             await bridge.fail(exc, details)
+        proposal = bridge.reflection_proposal()
+        if proposal is not None:
+            with suppress(Exception):
+                await ask_to_save_reflection_lesson(
+                    runtime=runtime,
+                    settings=settings,
+                    proposal=proposal,
+                    reasoning_level=effective_reasoning_level,
+                    model_name=effective_model_name,
+                    async_url_override=async_url_override,
+                    mcp_session_id=mcp_session_id,
+                )
         return
     finally:
         with suppress(Exception):
             await stream.aclose()
 
     await bridge.finish()
+    proposal = bridge.reflection_proposal()
+    if proposal is not None:
+        await ask_to_save_reflection_lesson(
+            runtime=runtime,
+            settings=settings,
+            proposal=proposal,
+            reasoning_level=effective_reasoning_level,
+            model_name=effective_model_name,
+            async_url_override=async_url_override,
+            mcp_session_id=mcp_session_id,
+        )
     if async_task_notifier is not None:
         with suppress(Exception):
             await async_task_notifier.schedule_from_state(thread_id=settings.thread_id)

--- a/chainagents/interfaces/chainlit/bridge.py
+++ b/chainagents/interfaces/chainlit/bridge.py
@@ -15,6 +15,7 @@ import chainlit as cl
 from chainlit.utils import utc_now
 
 from chainagents.events.stream import AgentStreamEvent, AgentStreamEventAdapter
+from chainagents.runtime.reflection import ReflectionCollector, ReflectionProposal
 from chainagents.exports.response import attach_response_export_actions
 
 DEFAULT_AUTO_COLLAPSE_DELAY_SECONDS = 3.0
@@ -944,6 +945,7 @@ class ChainlitEventBridge:
         chronological_ui_enabled: bool = True,
         reasoning_steps_enabled: bool = True,
         tool_steps_enabled: bool = True,
+        reflection_collector: ReflectionCollector | None = None,
     ) -> None:
         """Initialize the chainlit event bridge instance.
 
@@ -953,6 +955,7 @@ class ChainlitEventBridge:
             chronological_ui_enabled: The chronological UI enabled value.
             reasoning_steps_enabled: Whether to show reasoning steps.
             tool_steps_enabled: Whether to show tool steps.
+            reflection_collector: Optional collector for post-run memory proposals.
         """
         self.prompt = prompt
         self.run_task_list = run_task_list
@@ -973,6 +976,7 @@ class ChainlitEventBridge:
         self.chronological_ui_enabled = chronological_ui_enabled
         self.reasoning_steps_enabled = reasoning_steps_enabled
         self.tool_steps_enabled = tool_steps_enabled
+        self.reflection_collector = reflection_collector
 
     async def start(self) -> None:
         """Start the chainlit event bridge."""
@@ -993,6 +997,8 @@ class ChainlitEventBridge:
 
     async def _handle_stream_event(self, event: AgentStreamEvent) -> None:
         """Render one normalized agent stream event."""
+        if self.reflection_collector is not None:
+            self.reflection_collector.record_event(event)
         if event.kind == "response_delta":
             await self._stream_response(event.text)
         elif event.kind == "reasoning_delta":
@@ -1049,6 +1055,8 @@ class ChainlitEventBridge:
             exc: The exc value.
             details: The details value.
         """
+        if self.reflection_collector is not None:
+            self.reflection_collector.mark_run_failed(exc)
         await self._close_all_open_steps()
         if self.run_task_list is not None:
             await self.run_task_list.fail()
@@ -1056,6 +1064,12 @@ class ChainlitEventBridge:
             step.input = self.prompt
             step.output = details
         await cl.Message(content=f"{type(exc).__name__}: {exc}", author="System").send()
+
+    def reflection_proposal(self) -> ReflectionProposal | None:
+        """Return the reflection proposal for the completed run, if any."""
+        if self.reflection_collector is None:
+            return None
+        return self.reflection_collector.build_proposal()
 
     async def _handle_message_chunk(self, part: dict[str, Any]) -> None:
         """Handle message chunk.

--- a/chainagents/interfaces/cli/app.py
+++ b/chainagents/interfaces/cli/app.py
@@ -25,6 +25,11 @@ from rich.table import Table
 from rich.text import Text
 
 from chainagents.events.stream import AgentStreamEvent, AgentStreamEventAdapter
+from chainagents.runtime.reflection import (
+    ReflectionCollector,
+    ReflectionProposal,
+    format_reflection_proposal,
+)
 from chainagents.commands.native import (
     dumps_tool_result,
     parse_native_command,
@@ -1012,6 +1017,7 @@ class CliEventRenderer:
         json_output: bool,
         show_reasoning: bool,
         show_tools: bool,
+        reflection_collector: ReflectionCollector | None = None,
     ) -> None:
         """Initialize the CLI event renderer instance.
 
@@ -1023,6 +1029,7 @@ class CliEventRenderer:
             json_output: The JSON output value.
             show_reasoning: The show reasoning value.
             show_tools: The show tools value.
+            reflection_collector: Optional collector for memory proposals.
         """
         self.prompt = prompt
         self.stdout = stdout
@@ -1033,6 +1040,7 @@ class CliEventRenderer:
         self.show_tools = show_tools
         self.response_buffer = ""
         self.stream_adapter = AgentStreamEventAdapter(prompt=prompt)
+        self.reflection_collector = reflection_collector
         self.reasoning_line_source: str | None = None
         self.stdout_console = cli_console(stdout)
         self.stderr_console = cli_console(stderr)
@@ -1048,6 +1056,8 @@ class CliEventRenderer:
 
     def _handle_stream_event(self, event: AgentStreamEvent) -> None:
         """Render one normalized agent stream event."""
+        if self.reflection_collector is not None:
+            self.reflection_collector.record_event(event)
         if event.kind == "response_delta":
             self._stream_response_delta(event.text)
         elif event.kind == "reasoning_delta":
@@ -1075,6 +1085,30 @@ class CliEventRenderer:
         if self.response_buffer:
             self.stdout_console.print(Text(self.response_buffer, style="bright_white"))
         return self.response_buffer
+
+    def mark_run_failed(self, exc: BaseException) -> None:
+        """Record that the streamed run failed."""
+        if self.reflection_collector is not None:
+            self.reflection_collector.mark_run_failed(exc)
+
+    def reflection_proposal(self) -> ReflectionProposal | None:
+        """Return a reflection proposal after the run completes."""
+        if self.reflection_collector is None:
+            return None
+        return self.reflection_collector.build_proposal()
+
+    def print_reflection_proposal(self, proposal: ReflectionProposal) -> None:
+        """Print a reflection proposal to stderr for human CLI users."""
+        if self.json_output:
+            return
+        self._close_reasoning_line()
+        self.stderr_console.print(
+            cli_panel(
+                Text(format_reflection_proposal(proposal), style="white"),
+                title="Reflection Proposal",
+                border_style="cyan",
+            )
+        )
 
     def _stream_summarization_status(self, event: AgentStreamEvent) -> None:
         """Render a summarization status update."""
@@ -1658,6 +1692,10 @@ async def run_agent_prompt(
         json_output=args.json_output,
         show_reasoning=args.show_reasoning,
         show_tools=args.show_tools,
+        reflection_collector=ReflectionCollector.from_runtime_config(
+            runtime.config,
+            prompt=prompt,
+        ),
     )
     stream = agent.astream_events(
         payload,
@@ -1681,6 +1719,10 @@ async def run_agent_prompt(
     except Exception as exc:
         with suppress(Exception):
             await stream.aclose()
+        renderer.mark_run_failed(exc)
+        proposal = renderer.reflection_proposal()
+        if proposal is not None:
+            renderer.print_reflection_proposal(proposal)
         print(f"{type(exc).__name__}: {exc}", file=stderr)
         if args.show_tools or args.show_reasoning:
             print(traceback.format_exc(limit=10), file=stderr)
@@ -1690,6 +1732,9 @@ async def run_agent_prompt(
             await stream.aclose()
 
     response = renderer.finish()
+    proposal = renderer.reflection_proposal()
+    if proposal is not None:
+        renderer.print_reflection_proposal(proposal)
     if args.json_output:
         payload = {
             "response": response,
@@ -1697,6 +1742,8 @@ async def run_agent_prompt(
             "model": settings.model_name,
             "reasoning": settings.reasoning_level,
         }
+        if proposal is not None:
+            payload["reflection_proposal"] = proposal.to_payload()
         if emit_json:
             print(json.dumps(payload, indent=2, sort_keys=True), file=stdout)
             return 0

--- a/chainagents/interfaces/tui/app.py
+++ b/chainagents/interfaces/tui/app.py
@@ -22,6 +22,10 @@ from chainagents.commands.native import (
     resolve_runtime_command,
 )
 from chainagents.events.stream import AgentStreamEvent, AgentStreamEventAdapter
+from chainagents.runtime.reflection import (
+    ReflectionCollector,
+    format_reflection_proposal,
+)
 from chainagents.runtime import (
     AgentRuntime,
     PROJECT_ROOT,
@@ -360,6 +364,10 @@ class ChainAgentsTuiApp(App[int]):
             thread_id=self.thread_id,
         )
         adapter = AgentStreamEventAdapter(prompt=prompt)
+        reflection_collector = ReflectionCollector.from_runtime_config(
+            self.runtime.config,
+            prompt=prompt,
+        )
         stream = agent.astream_events(
             payload,
             config=config,
@@ -368,6 +376,7 @@ class ChainAgentsTuiApp(App[int]):
             subgraphs=True,
         )
 
+        stream_error: Exception | None = None
         try:
             while True:
                 try:
@@ -375,10 +384,20 @@ class ChainAgentsTuiApp(App[int]):
                 except StopAsyncIteration:
                     break
                 for stream_event in adapter.events_from_raw_event(event):
+                    reflection_collector.record_event(stream_event)
                     await self._handle_stream_event(stream_event)
+        except Exception as exc:
+            stream_error = exc
+            reflection_collector.mark_run_failed(exc)
         finally:
             with suppress(Exception):
                 await stream.aclose()
+
+        proposal = reflection_collector.build_proposal()
+        if proposal is not None:
+            self._append_tool_entry(format_reflection_proposal(proposal))
+        if stream_error is not None:
+            raise stream_error
 
     async def _handle_stream_event(self, event: AgentStreamEvent) -> None:
         if event.kind == "response_delta":

--- a/chainagents/runtime/core.py
+++ b/chainagents/runtime/core.py
@@ -57,6 +57,10 @@ from chainagents.rag.runtime import (
     parse_rag_config,
     resolve_rag_config,
 )
+from chainagents.runtime.reflection import (
+    ReflectionConfig,
+    normalize_reflection_config,
+)
 
 
 ModelProvider = Literal["ollama", "openai_compatible", "anthropic"]
@@ -1607,6 +1611,7 @@ class ExtensionsConfig:
         agent_state: Whether the DeepAgents graph is stateful or stateless.
         agent_memory_namespace: Shared StoreBackend namespace for /memories/.
         agent_memory_files: Startup memory files loaded into the agent prompt.
+        agent_reflection: Correction reflection workflow configuration.
         recursion_limit: The recursion limit value.
         mcp_servers: The MCP servers value.
         skills: The skills value.
@@ -1633,6 +1638,7 @@ class ExtensionsConfig:
     agent_state: AgentStateMode = DEFAULT_AGENT_STATE
     agent_memory_namespace: str = DEFAULT_AGENT_MEMORY_NAMESPACE
     agent_memory_files: tuple[str, ...] = DEFAULT_AGENT_MEMORY_FILES
+    agent_reflection: ReflectionConfig = ReflectionConfig()
     recursion_limit: int = DEFAULT_RECURSION_LIMIT
     mcp_servers: dict[str, dict[str, Any]] | None = None
     skills: tuple[str, ...] = ()
@@ -1997,6 +2003,10 @@ def parse_extensions_config(raw_config: dict[str, Any], config_path: Path) -> Ex
         agent_section.get("memory_namespace")
     )
     agent_memory_files = normalize_agent_memory_files(agent_section.get("memory_files"))
+    agent_reflection = normalize_reflection_config(
+        agent_section.get("reflection"),
+        agent_state=agent_state,
+    )
     raw_mcp_servers = mcp_section.get("servers", {})
     mcp_servers: dict[str, dict[str, Any]] = {}
     for name, raw_server in raw_mcp_servers.items():
@@ -2214,6 +2224,7 @@ def parse_extensions_config(raw_config: dict[str, Any], config_path: Path) -> Ex
         agent_state=agent_state,
         agent_memory_namespace=agent_memory_namespace,
         agent_memory_files=agent_memory_files,
+        agent_reflection=agent_reflection,
         recursion_limit=recursion_limit,
         mcp_servers=mcp_servers or None,
         skills=skill_paths,

--- a/chainagents/runtime/reflection.py
+++ b/chainagents/runtime/reflection.py
@@ -1,0 +1,289 @@
+"""Shared correction reflection helpers for ChainAgents entrypoints."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any, Literal
+
+from chainagents.events.stream import AgentStreamEvent
+
+
+ReflectionReason = Literal["correction", "tool_failure"]
+ToolFailureReflectionMode = Literal["unrecovered"]
+DEFAULT_REFLECTION_MEMORY_FILE = "/memories/AGENTS.md"
+DEFAULT_REFLECTION_MAX_LESSON_CHARS = 700
+DEFAULT_REFLECTION_TOOL_FAILURE_MODE: ToolFailureReflectionMode = "unrecovered"
+CORRECTION_PHRASES = (
+    "that was wrong",
+    "i was wrong",
+    "you were wrong",
+    "this was wrong",
+    "that's wrong",
+    "incorrect",
+    "not correct",
+)
+
+
+@dataclass(frozen=True)
+class ReflectionConfig:
+    """Store correction reflection behavior parsed from configuration."""
+
+    enabled: bool = False
+    memory_file: str = DEFAULT_REFLECTION_MEMORY_FILE
+    max_lesson_chars: int = DEFAULT_REFLECTION_MAX_LESSON_CHARS
+    tool_failure_mode: ToolFailureReflectionMode = DEFAULT_REFLECTION_TOOL_FAILURE_MODE
+
+
+@dataclass(frozen=True)
+class ReflectionProposal:
+    """Describe a proposed lesson to save into agent-scoped memory."""
+
+    reason: ReflectionReason
+    memory_file: str
+    lesson: str
+    trigger: str
+    tool_name: str = ""
+    tool_result: str = ""
+
+    def to_payload(self) -> dict[str, Any]:
+        """Return a JSON-compatible representation of this proposal."""
+        return asdict(self)
+
+
+def normalize_reflection_config(
+    value: Any | None,
+    *,
+    agent_state: str,
+) -> ReflectionConfig:
+    """Normalize [agent.reflection] configuration.
+
+    Args:
+        value: Raw nested reflection config value.
+        agent_state: Resolved agent state mode.
+
+    Returns:
+        Normalized reflection configuration.
+
+    Raises:
+        ValueError: If reflection config is invalid.
+    """
+    if value is None:
+        return ReflectionConfig()
+    if not isinstance(value, dict):
+        raise ValueError(
+            "The top-level 'agent.reflection' config must be a table/object."
+        )
+
+    raw_enabled = value.get("enabled", False)
+    if not isinstance(raw_enabled, bool):
+        raise ValueError(
+            "The top-level 'agent.reflection.enabled' config must be a boolean."
+        )
+
+    raw_memory_file = value.get("memory_file", DEFAULT_REFLECTION_MEMORY_FILE)
+    if not isinstance(raw_memory_file, str):
+        raise ValueError(
+            "The top-level 'agent.reflection.memory_file' config must be a "
+            "/memories/ file path string."
+        )
+    memory_file = raw_memory_file.strip()
+    if not memory_file.startswith("/memories/") or memory_file == "/memories/":
+        raise ValueError(
+            "The top-level 'agent.reflection.memory_file' config must be an "
+            "absolute /memories/ file path."
+        )
+
+    raw_max_lesson_chars = value.get(
+        "max_lesson_chars",
+        DEFAULT_REFLECTION_MAX_LESSON_CHARS,
+    )
+    if (
+        not isinstance(raw_max_lesson_chars, int)
+        or isinstance(raw_max_lesson_chars, bool)
+        or raw_max_lesson_chars <= 0
+    ):
+        raise ValueError(
+            "The top-level 'agent.reflection.max_lesson_chars' config must be a "
+            "positive integer."
+        )
+
+    raw_tool_failure_mode = str(
+        value.get("tool_failure_mode", DEFAULT_REFLECTION_TOOL_FAILURE_MODE)
+    ).strip().lower()
+    if raw_tool_failure_mode != "unrecovered":
+        raise ValueError(
+            "The top-level 'agent.reflection.tool_failure_mode' config must be "
+            "'unrecovered'."
+        )
+
+    if raw_enabled and agent_state != "stateful":
+        raise ValueError(
+            "The top-level 'agent.reflection.enabled' config requires "
+            "agent.state = 'stateful'."
+        )
+
+    return ReflectionConfig(
+        enabled=raw_enabled,
+        memory_file=memory_file,
+        max_lesson_chars=raw_max_lesson_chars,
+        tool_failure_mode="unrecovered",
+    )
+
+
+class ReflectionCollector:
+    """Collect stream events and build a post-run memory lesson proposal."""
+
+    def __init__(self, config: ReflectionConfig, *, prompt: str) -> None:
+        """Initialize the collector."""
+        self.config = config
+        self.prompt = prompt
+        self._response_parts: list[str] = []
+        self._last_failed_tool: AgentStreamEvent | None = None
+        self._response_after_last_failure = False
+        self._run_error: str = ""
+
+    @classmethod
+    def from_runtime_config(
+        cls,
+        runtime_config: Any,
+        *,
+        prompt: str,
+    ) -> "ReflectionCollector":
+        """Build a collector from a runtime config object."""
+        extensions = getattr(runtime_config, "extensions", None)
+        config = getattr(extensions, "agent_reflection", ReflectionConfig())
+        if not isinstance(config, ReflectionConfig):
+            config = ReflectionConfig()
+        return cls(config, prompt=prompt)
+
+    def record_event(self, event: AgentStreamEvent) -> None:
+        """Record one normalized stream event."""
+        if not self.config.enabled:
+            return
+        if event.kind == "response_delta" and event.text:
+            self._response_parts.append(event.text)
+            if self._last_failed_tool is not None:
+                self._response_after_last_failure = True
+            return
+        if event.kind == "tool_result" and event.status.lower() == "error":
+            self._last_failed_tool = event
+            self._response_after_last_failure = False
+
+    def mark_run_failed(self, exc: BaseException) -> None:
+        """Record that the run failed after streaming began."""
+        if self.config.enabled:
+            self._run_error = f"{type(exc).__name__}: {exc}"
+
+    @property
+    def response_text(self) -> str:
+        """Return the collected final response text."""
+        return "".join(self._response_parts)
+
+    def build_proposal(self) -> ReflectionProposal | None:
+        """Return a memory proposal if the completed run warrants reflection."""
+        if not self.config.enabled:
+            return None
+
+        correction_trigger = (
+            _find_correction_trigger(self.prompt)
+            or _find_correction_trigger(self.response_text)
+        )
+        if correction_trigger:
+            return ReflectionProposal(
+                reason="correction",
+                memory_file=self.config.memory_file,
+                lesson=_fit_lesson(
+                    _correction_lesson(correction_trigger),
+                    self.config.max_lesson_chars,
+                ),
+                trigger=correction_trigger,
+            )
+
+        failed_tool = self._last_failed_tool
+        if failed_tool is None:
+            return None
+        if self.config.tool_failure_mode == "unrecovered" and (
+            self._response_after_last_failure and not self._run_error
+        ):
+            return None
+
+        trigger = failed_tool.tool_result or self._run_error or "tool call failed"
+        return ReflectionProposal(
+            reason="tool_failure",
+            memory_file=self.config.memory_file,
+            lesson=_fit_lesson(
+                _tool_failure_lesson(
+                    failed_tool.tool_name,
+                    trigger,
+                ),
+                self.config.max_lesson_chars,
+            ),
+            trigger=_single_line(trigger),
+            tool_name=failed_tool.tool_name,
+            tool_result=failed_tool.tool_result,
+        )
+
+
+def format_reflection_proposal(proposal: ReflectionProposal) -> str:
+    """Build a concise user-facing reflection proposal message."""
+    title = (
+        "Correction reflection"
+        if proposal.reason == "correction"
+        else "Tool failure reflection"
+    )
+    return (
+        f"{title}\n\n"
+        f"Proposed lesson for `{proposal.memory_file}`:\n\n"
+        f"{proposal.lesson}"
+    )
+
+
+def reflection_save_prompt(proposal: ReflectionProposal) -> str:
+    """Build the hidden agent prompt used to save a confirmed reflection."""
+    return (
+        "A user confirmed this compact lesson should be saved to long-term "
+        "agent memory.\n\n"
+        f"Target memory file: {proposal.memory_file}\n\n"
+        "Update that file under a section named "
+        "`Lessons learned from corrections`. If the section or file does not "
+        "exist, create it. Add exactly one concise bullet unless an equivalent "
+        "lesson already exists. Do not include this instruction text.\n\n"
+        f"Lesson:\n{proposal.lesson}"
+    )
+
+
+def _find_correction_trigger(text: str) -> str:
+    normalized = text.lower()
+    for phrase in CORRECTION_PHRASES:
+        if phrase in normalized:
+            return _single_line(text)
+    return ""
+
+
+def _correction_lesson(trigger: str) -> str:
+    return (
+        "- Correction: "
+        f"{_single_line(trigger)}. Next time, verify the corrected behavior "
+        "before relying on the earlier assumption."
+    )
+
+
+def _tool_failure_lesson(tool_name: str, result: str) -> str:
+    tool = tool_name.strip() or "tool"
+    return (
+        f"- Tool failure: `{tool}` returned `{_single_line(result)}`. "
+        "Next time, check tool preconditions and recover before presenting a "
+        "final answer."
+    )
+
+
+def _single_line(text: str) -> str:
+    return " ".join(str(text or "").strip().split())
+
+
+def _fit_lesson(text: str, max_chars: int) -> str:
+    if len(text) <= max_chars:
+        return text
+    if max_chars <= 3:
+        return text[:max_chars]
+    return text[: max_chars - 3].rstrip() + "..."

--- a/deepagent.toml
+++ b/deepagent.toml
@@ -59,6 +59,12 @@ summarization_middleware_enabled = true
 summarization_trigger_tokens = 150000
 summarization_keep_tokens = 10000
 
+[agent.reflection]
+enabled = true
+memory_file = "/memories/AGENTS.md"
+max_lesson_chars = 700
+tool_failure_mode = "unrecovered"
+
 [rag]
 enabled = true
 persist_directory = ".rag"

--- a/deepagent.toml.example
+++ b/deepagent.toml.example
@@ -60,6 +60,14 @@ mcp_servers = ["repo"]
 summarization_trigger_tokens = 6000
 summarization_keep_tokens = 2400
 
+[agent.reflection]
+# Set true to propose compact lessons after corrections or unrecovered tool failures.
+# Chainlit asks before saving; CLI, TUI, and API only surface proposals.
+enabled = false
+memory_file = "/memories/AGENTS.md"
+max_lesson_chars = 700
+tool_failure_mode = "unrecovered"
+
 [chainlit]
 # Set false to hide model selection in chat settings and Modes.
 model_mode_enabled = true

--- a/tests/test_deepagent_runtime_rag.py
+++ b/tests/test_deepagent_runtime_rag.py
@@ -1218,6 +1218,124 @@ memory_files = []
     assert config.extensions.agent_memory_files == ()
 
 
+def test_runtime_config_defaults_reflection_disabled(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Verify reflection is disabled unless explicitly configured."""
+    config_path = tmp_path / "deepagent.toml"
+    config_path.write_text(
+        """
+[agent]
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DEEPAGENT_CONFIG", str(config_path))
+
+    config = deepagent_runtime.RuntimeConfig.from_env()
+
+    assert config.extensions.agent_reflection.enabled is False
+    assert config.extensions.agent_reflection.memory_file == "/memories/AGENTS.md"
+    assert config.extensions.agent_reflection.max_lesson_chars == 700
+    assert config.extensions.agent_reflection.tool_failure_mode == "unrecovered"
+
+
+def test_runtime_config_reads_reflection_from_toml(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Verify reflection config is parsed from [agent.reflection]."""
+    config_path = tmp_path / "deepagent.toml"
+    config_path.write_text(
+        """
+[agent]
+state = "stateful"
+
+[agent.reflection]
+enabled = true
+memory_file = "/memories/AGENTS.md"
+max_lesson_chars = 512
+tool_failure_mode = "unrecovered"
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DEEPAGENT_CONFIG", str(config_path))
+
+    config = deepagent_runtime.RuntimeConfig.from_env()
+
+    assert config.extensions.agent_reflection.enabled is True
+    assert config.extensions.agent_reflection.memory_file == "/memories/AGENTS.md"
+    assert config.extensions.agent_reflection.max_lesson_chars == 512
+    assert config.extensions.agent_reflection.tool_failure_mode == "unrecovered"
+
+
+@pytest.mark.parametrize(
+    ("agent_config", "message"),
+    (
+        ('reflection = "yes"', "agent.reflection"),
+        (
+            '[agent.reflection]\nenabled = "yes"',
+            "agent.reflection.enabled",
+        ),
+        (
+            '[agent.reflection]\nenabled = true\nmemory_file = "memories/AGENTS.md"',
+            "agent.reflection.memory_file",
+        ),
+        (
+            '[agent.reflection]\nenabled = true\nmemory_file = "/workspace/AGENTS.md"',
+            "agent.reflection.memory_file",
+        ),
+        (
+            '[agent.reflection]\nenabled = true\nmax_lesson_chars = 0',
+            "agent.reflection.max_lesson_chars",
+        ),
+        (
+            '[agent.reflection]\nenabled = true\ntool_failure_mode = "all"',
+            "agent.reflection.tool_failure_mode",
+        ),
+    ),
+)
+def test_runtime_config_rejects_invalid_reflection_config(
+    tmp_path: Path,
+    monkeypatch,
+    agent_config: str,
+    message: str,
+) -> None:
+    """Verify invalid reflection config fails clearly."""
+    config_path = tmp_path / "deepagent.toml"
+    if agent_config.startswith("[agent.reflection]"):
+        toml = f"[agent]\nstate = \"stateful\"\n\n{agent_config}"
+    else:
+        toml = f"[agent]\n{agent_config}"
+    config_path.write_text(toml, encoding="utf-8")
+    monkeypatch.setenv("DEEPAGENT_CONFIG", str(config_path))
+
+    with pytest.raises(ValueError, match=message):
+        deepagent_runtime.RuntimeConfig.from_env()
+
+
+def test_runtime_config_rejects_reflection_when_stateless(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Verify reflection writes require stateful agent memory."""
+    config_path = tmp_path / "deepagent.toml"
+    config_path.write_text(
+        """
+[agent]
+state = "stateless"
+
+[agent.reflection]
+enabled = true
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DEEPAGENT_CONFIG", str(config_path))
+
+    with pytest.raises(ValueError, match="agent.reflection.enabled"):
+        deepagent_runtime.RuntimeConfig.from_env()
+
+
 @pytest.mark.parametrize(
     ("agent_config", "message"),
     (

--- a/tests/test_main_native_commands.py
+++ b/tests/test_main_native_commands.py
@@ -8,6 +8,7 @@ import agent_commands
 import main
 import pytest
 from deepagent_runtime import AppSettings, ChainlitStarterConfig
+from chainagents.runtime.reflection import ReflectionProposal
 
 
 def test_load_chainlit_auth_users_parses_json_map() -> None:
@@ -611,6 +612,175 @@ class _DummyMessage:
             The sent message or element.
         """
         return None
+
+
+@pytest.mark.anyio
+async def test_ask_to_save_reflection_lesson_uses_ask_action_message(
+    monkeypatch,
+) -> None:
+    """Verify Chainlit reflection confirmation uses AskActionMessage."""
+    captured: dict[str, object] = {}
+    saved: dict[str, object] = {}
+
+    class _AskActionMessage:
+        """Capture AskActionMessage construction and return Save."""
+
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+        async def send(self):
+            return {"payload": {"value": "save"}}
+
+    async def fake_save_reflection_lesson(**kwargs):
+        saved.update(kwargs)
+
+    monkeypatch.setattr(main.cl, "AskActionMessage", _AskActionMessage)
+    monkeypatch.setattr(main, "save_reflection_lesson", fake_save_reflection_lesson)
+
+    proposal = ReflectionProposal(
+        reason="correction",
+        memory_file="/memories/AGENTS.md",
+        lesson="- Correction: remember the generated output directory.",
+        trigger="That was wrong.",
+    )
+    settings = AppSettings(
+        model_name="fake-model",
+        reasoning_level="medium",
+        thread_id="thread-1",
+    )
+
+    await main.ask_to_save_reflection_lesson(
+        runtime=SimpleNamespace(),
+        settings=settings,
+        proposal=proposal,
+        reasoning_level="high",
+        model_name="other-model",
+        async_url_override="http://async.example",
+        mcp_session_id="mcp-session",
+    )
+
+    assert "Correction reflection" in str(captured["content"])
+    actions = captured["actions"]
+    assert [action.payload["value"] for action in actions] == ["save", "dismiss"]
+    assert saved["proposal"] == proposal
+    assert saved["settings"] == settings
+    assert saved["reasoning_level"] == "high"
+    assert saved["model_name"] == "other-model"
+    assert saved["async_url_override"] == "http://async.example"
+    assert saved["mcp_session_id"] == "mcp-session"
+
+
+@pytest.mark.anyio
+async def test_ask_to_save_reflection_lesson_dismiss_does_not_save(
+    monkeypatch,
+) -> None:
+    """Verify Chainlit reflection dismissal does not write memory."""
+    saved = False
+
+    class _AskActionMessage:
+        """Return Dismiss from AskActionMessage."""
+
+        def __init__(self, **kwargs):
+            pass
+
+        async def send(self):
+            return {"payload": {"value": "dismiss"}}
+
+    async def fake_save_reflection_lesson(**kwargs):
+        nonlocal saved
+        saved = True
+
+    monkeypatch.setattr(main.cl, "AskActionMessage", _AskActionMessage)
+    monkeypatch.setattr(main, "save_reflection_lesson", fake_save_reflection_lesson)
+
+    await main.ask_to_save_reflection_lesson(
+        runtime=SimpleNamespace(),
+        settings=AppSettings(
+            model_name="fake-model",
+            reasoning_level="medium",
+            thread_id="thread-1",
+        ),
+        proposal=ReflectionProposal(
+            reason="correction",
+            memory_file="/memories/AGENTS.md",
+            lesson="- Correction: remember the generated output directory.",
+            trigger="That was wrong.",
+        ),
+        reasoning_level="medium",
+        model_name="fake-model",
+        async_url_override=None,
+        mcp_session_id=None,
+    )
+
+    assert saved is False
+
+
+@pytest.mark.anyio
+async def test_save_reflection_lesson_invokes_agent_in_reflection_thread(
+    monkeypatch,
+) -> None:
+    """Verify confirmed reflections are saved by a hidden agent run."""
+    captured: dict[str, object] = {}
+
+    class _Agent:
+        async def ainvoke(self, payload, *, config):
+            captured["payload"] = payload
+            captured["config"] = config
+            return {"messages": []}
+
+    class _Runtime:
+        config = SimpleNamespace(recursion_limit=100)
+
+        async def get_agent(self, *args, **kwargs):
+            captured["agent_args"] = args
+            captured["agent_kwargs"] = kwargs
+            return _Agent()
+
+    messages: list[_DummyMessage] = []
+
+    class _Message(_DummyMessage):
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+            messages.append(self)
+
+    monkeypatch.setattr(main.cl, "Message", _Message)
+
+    proposal = ReflectionProposal(
+        reason="correction",
+        memory_file="/memories/AGENTS.md",
+        lesson="- Correction: remember the generated output directory.",
+        trigger="That was wrong.",
+    )
+
+    await main.save_reflection_lesson(
+        runtime=_Runtime(),
+        settings=AppSettings(
+            model_name="fake-model",
+            reasoning_level="medium",
+            thread_id="thread-1",
+        ),
+        proposal=proposal,
+        reasoning_level="high",
+        model_name="other-model",
+        async_url_override=None,
+        mcp_session_id="mcp-session",
+    )
+
+    assert captured["agent_args"] == ("high",)
+    assert captured["agent_kwargs"] == {
+        "model_name": "other-model",
+        "thread_id": "thread-1:reflection",
+        "async_subagent_url_override": None,
+        "mcp_session_id": "mcp-session",
+    }
+    assert captured["config"] == {
+        "configurable": {"thread_id": "thread-1:reflection"},
+        "recursion_limit": 100,
+    }
+    prompt = captured["payload"]["messages"][0]["content"]
+    assert "Target memory file: /memories/AGENTS.md" in prompt
+    assert "Lessons learned from corrections" in prompt
+    assert messages[-1].kwargs["content"] == "Saved lesson to `/memories/AGENTS.md`."
 
 
 @pytest.mark.anyio

--- a/tests/test_reflection_workflow.py
+++ b/tests/test_reflection_workflow.py
@@ -1,0 +1,212 @@
+"""Test correction reflection proposal behavior."""
+
+from __future__ import annotations
+
+import io
+import json
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+import chainagents_api
+import chainagents_cli
+from chainagents.events.stream import AgentStreamEvent
+from chainagents.runtime.reflection import ReflectionCollector, ReflectionConfig
+
+
+class _Token:
+    """Provide a minimal streamed AI token for reflection tests."""
+
+    type = "AIMessageChunk"
+    additional_kwargs: dict[str, str] = {}
+    tool_call_chunks: list[dict[str, str]] = []
+
+    def __init__(self, content: str = "") -> None:
+        """Initialize the token instance."""
+        self.content = content
+
+
+class _ToolMessage:
+    """Provide a minimal streamed tool message for reflection tests."""
+
+    type = "tool"
+    name = "read_file"
+    tool_call_id = "call-1"
+
+    def __init__(self, content: str, *, status: str = "error") -> None:
+        """Initialize the tool message."""
+        self.content = content
+        self.status = status
+
+
+def _raw_event(chunk: object) -> dict[str, object]:
+    """Build a raw LangGraph stream event."""
+    return {"event": "on_chain_stream", "data": {"chunk": chunk}}
+
+
+class _FakeAgent:
+    """Capture agent invocations and return configured stream events."""
+
+    def __init__(self, events: list[dict[str, object]]) -> None:
+        """Initialize the fake agent."""
+        self.events = events
+
+    def astream_events(self, payload, *, config, version, stream_mode, subgraphs):
+        """Return the configured async event stream."""
+
+        async def events():
+            for event in self.events:
+                yield event
+
+        return events()
+
+
+class _FakeRuntime:
+    """Provide the runtime surface required by CLI and API tests."""
+
+    def __init__(self, agent: _FakeAgent, *, reflection_enabled: bool = True) -> None:
+        """Initialize the fake runtime."""
+        self.agent = agent
+        self.config = SimpleNamespace(
+            default_reasoning="medium",
+            model_name="fake-model",
+            model_provider="ollama",
+            model_choices=("fake-model",),
+            agent_state="stateful",
+            recursion_limit=100,
+            persistence_mode="memory",
+            extensions=SimpleNamespace(
+                agent_reflection=ReflectionConfig(enabled=reflection_enabled)
+            ),
+        )
+
+    async def get_agent(self, *args, **kwargs):
+        """Return the fake agent."""
+        return self.agent
+
+
+def test_reflection_collector_detects_correction_phrase() -> None:
+    """Verify correction phrases create compact memory proposals."""
+    collector = ReflectionCollector(
+        ReflectionConfig(enabled=True),
+        prompt="That was wrong; the generated files belong under .files/outputs.",
+    )
+    proposal = collector.build_proposal()
+
+    assert proposal is not None
+    assert proposal.reason == "correction"
+    assert proposal.memory_file == "/memories/AGENTS.md"
+    assert "That was wrong" in proposal.lesson
+    assert len(proposal.lesson) <= 700
+
+
+def test_reflection_collector_ignores_recovered_tool_failure() -> None:
+    """Verify tool failures followed by a final response do not create proposals."""
+    collector = ReflectionCollector(ReflectionConfig(enabled=True), prompt="try it")
+    collector.record_event(
+        AgentStreamEvent(
+            kind="tool_result",
+            source="main-agent",
+            tool_name="read_file",
+            tool_result="missing file",
+            status="error",
+        )
+    )
+    collector.record_event(
+        AgentStreamEvent(kind="response_delta", source="main-agent", text="I recovered.")
+    )
+
+    assert collector.build_proposal() is None
+
+
+def test_reflection_collector_detects_unrecovered_tool_failure() -> None:
+    """Verify unrecovered failed tool calls create proposals."""
+    collector = ReflectionCollector(ReflectionConfig(enabled=True), prompt="try it")
+    collector.record_event(
+        AgentStreamEvent(
+            kind="tool_result",
+            source="main-agent",
+            tool_name="read_file",
+            tool_result="missing file",
+            status="error",
+        )
+    )
+
+    proposal = collector.build_proposal()
+
+    assert proposal is not None
+    assert proposal.reason == "tool_failure"
+    assert "read_file" in proposal.lesson
+
+
+def test_reflection_collector_ignores_disabled_config() -> None:
+    """Verify disabled reflection config is a no-op."""
+    collector = ReflectionCollector(
+        ReflectionConfig(enabled=False),
+        prompt="That was wrong.",
+    )
+
+    assert collector.build_proposal() is None
+
+
+def test_api_stream_emits_reflection_proposal_event() -> None:
+    """Verify API streaming exposes reflection proposals without writing memory."""
+    agent = _FakeAgent(
+        [
+            _raw_event(
+                (
+                    (),
+                    "messages",
+                    (_ToolMessage("file does not exist", status="error"), {}),
+                )
+            ),
+        ]
+    )
+    runtime = _FakeRuntime(agent)
+    app = chainagents_api.create_app(runtime=runtime)
+
+    from fastapi.testclient import TestClient
+
+    with TestClient(app) as client:
+        with client.stream(
+            "POST",
+            "/api/agent/stream",
+            json={"prompt": "try it", "thread_id": "thread-1"},
+        ) as response:
+            lines = [json.loads(line) for line in response.iter_lines()]
+
+    assert response.status_code == 200
+    assert [line["kind"] for line in lines] == [
+        "tool_result",
+        "reflection_proposal",
+        "done",
+    ]
+    assert lines[1]["proposal"]["reason"] == "tool_failure"
+    assert lines[1]["proposal"]["memory_file"] == "/memories/AGENTS.md"
+
+
+@pytest.mark.anyio
+async def test_cli_json_includes_reflection_proposal() -> None:
+    """Verify CLI JSON includes reflection proposals without writing memory."""
+    agent = _FakeAgent(
+        [
+            _raw_event(((), "messages", (_Token("That was wrong."), {}))),
+        ]
+    )
+    runtime = _FakeRuntime(agent)
+    args = chainagents_cli.parse_args(["--prompt", "hello", "--json"])
+    stdout = io.StringIO()
+
+    code = await chainagents_cli.run_agent_prompt(
+        runtime,  # type: ignore[arg-type]
+        args,
+        prompt="hello",
+        stdout=stdout,
+        stderr=io.StringIO(),
+    )
+
+    assert code == 0
+    payload = json.loads(stdout.getvalue())
+    assert payload["reflection_proposal"]["reason"] == "correction"
+    assert payload["reflection_proposal"]["memory_file"] == "/memories/AGENTS.md"


### PR DESCRIPTION
## Summary
- Add opt-in reflection collection and proposal generation from runtime config
- Surface reflection proposals in API, CLI, TUI, and Chainlit with a save/dismiss flow
- Document the new `[agent.reflection]` settings and defaults

## Testing
- Added unit tests for reflection config parsing and validation
- Added unit tests for Chainlit confirmation and reflection save flow