### PR TITLE
Add nested subagent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -554,6 +554,14 @@ description = "Researches the codebase and produces concise implementation guida
 system_prompt_file = "prompts/repo-researcher.md"
 skills = ["skills/research"]
 mcp_servers = ["repo"]
+nested_subagents = ["reviewer"]
+
+[[subagents.subagents]]
+name = "repo-planner"
+description = "Turns repository findings into an implementation plan."
+system_prompt = "Use repository context to produce a concise implementation plan."
+skills = ["skills/research"]
+mcp_servers = ["repo"]
 
 [[subagents]]
 name = "reviewer"
@@ -576,6 +584,14 @@ Supported subagent fields:
 - `skills`: optional list of skill source paths for that subagent
 - `mcp_servers`: optional list of MCP server names to attach to that subagent
 - `model`: optional model override
+- `nested_subagents`: optional list of top-level sync subagent names exposed as children of this subagent
+- `[[subagents.subagents]]`: optional inline private sync child subagents under a parent subagent
+
+Nested subagents are synchronous only. Use `[[subagents.subagents]]` for children
+that should only be available to the parent, or `nested_subagents = ["name"]` to
+reuse a top-level sync subagent as a child while keeping it visible to the main
+agent. Async Agent Protocol subagents remain top-level `[[async_subagents]]`
+entries.
 
 Main `[agent]` additions:
 
@@ -759,6 +775,7 @@ Notes:
 
 - `mcp_servers` on `[agent]` attaches those MCP tools to the main agent.
 - `mcp_servers` on `[[subagents]]` attaches those MCP tools only to that subagent.
+- `mcp_servers` on `[[subagents.subagents]]` attaches those MCP tools only to that nested child subagent.
 - Skills and MCP servers are independent. You can use neither, either, or both on any subagent.
 - Relative `cwd` values are resolved from the location of `deepagent.toml`.
 - `tool_name_prefix = true` is recommended when multiple MCP servers expose overlapping tool names.

--- a/chainagents/runtime/core.py
+++ b/chainagents/runtime/core.py
@@ -3403,12 +3403,14 @@ def build_static_sync_subagent_spec(
     *,
     registry: dict[str, SubagentConfig],
     backend: Any,
+    inherited_tools: list[Any],
     reasoning_level: ReasoningLevel,
     inherited_model_name: str,
     project_root: Path | None,
 ) -> dict[str, Any]:
     """Build a sync subagent spec for configured graph creation."""
     effective_model_name = subagent.model or inherited_model_name
+    effective_tools = list(inherited_tools)
     middleware = build_agent_middleware(
         config=config,
         reasoning_level=reasoning_level,
@@ -3425,6 +3427,7 @@ def build_static_sync_subagent_spec(
             child,
             registry=registry,
             backend=backend,
+            inherited_tools=effective_tools,
             reasoning_level=reasoning_level,
             inherited_model_name=effective_model_name,
             project_root=project_root,
@@ -3437,7 +3440,7 @@ def build_static_sync_subagent_spec(
             reasoning_level,
             model_name=effective_model_name,
         ),
-        "tools": None,
+        "tools": effective_tools or None,
         "system_prompt": subagent.system_prompt,
         "middleware": middleware,
         "backend": backend,
@@ -3461,6 +3464,7 @@ def build_graph_subagent_specs(
     include_async_subagents: bool,
     backend: Any | None = None,
     project_root: Path | None = None,
+    inherited_tools: list[Any] | None = None,
 ) -> list[Any]:
     """Build graph subagent specs.
 
@@ -3469,6 +3473,7 @@ def build_graph_subagent_specs(
         include_async_subagents: Whether to include async subagents.
         backend: DeepAgents backend shared with compiled nested subgraphs.
         project_root: Project root used to resolve runtime middleware context.
+        inherited_tools: Tools inherited from the graph that owns these subagents.
 
     Returns:
         The constructed graph subagent specs.
@@ -3485,6 +3490,7 @@ def build_graph_subagent_specs(
             subagent,
             registry=registry,
             backend=resolved_backend,
+            inherited_tools=list(inherited_tools or []),
             reasoning_level=config.default_reasoning,
             inherited_model_name=config.model_name,
             project_root=project_root,
@@ -3534,12 +3540,6 @@ def create_configured_graph(
         include_memories=config.agent_state == "stateful",
         memory_namespace=config.extensions.agent_memory_namespace,
     )
-    subagent_specs = build_graph_subagent_specs(
-        config,
-        include_async_subagents=include_async_subagents,
-        backend=backend,
-        project_root=PROJECT_ROOT,
-    )
     tools: list[Any] = []
     if config.rag is not None:
         tools.append(
@@ -3550,9 +3550,17 @@ def create_configured_graph(
     else:
         if config.rag_requested and config.rag_error:
             logger.warning("RAG is configured but unavailable: %s", config.rag_error)
+    main_tools = sanitize_tools_for_model(config.model_provider, tools)
+    subagent_specs = build_graph_subagent_specs(
+        config,
+        include_async_subagents=include_async_subagents,
+        backend=backend,
+        project_root=PROJECT_ROOT,
+        inherited_tools=main_tools,
+    )
     agent_kwargs: dict[str, Any] = {
         "model": build_model(config, config.default_reasoning),
-        "tools": sanitize_tools_for_model(config.model_provider, tools) or None,
+        "tools": main_tools or None,
         "system_prompt": compose_rag_system_prompt(
             compose_agent_system_prompt(
                 system_prompt_for_agent_state(system_prompt, config.agent_state),
@@ -3805,6 +3813,7 @@ class AgentRuntime:
         reasoning_level: ReasoningLevel,
         selected_model: str,
         backend: Any,
+        inherited_tools: list[Any],
         thread_id: str | None,
         mcp_session_id: str | None,
     ) -> list[Any]:
@@ -3819,6 +3828,7 @@ class AgentRuntime:
                 reasoning_level=reasoning_level,
                 inherited_model_name=selected_model,
                 backend=backend,
+                inherited_tools=inherited_tools,
                 thread_id=thread_id,
                 mcp_session_id=mcp_session_id,
             )
@@ -3833,12 +3843,13 @@ class AgentRuntime:
         reasoning_level: ReasoningLevel,
         inherited_model_name: str,
         backend: Any,
+        inherited_tools: list[Any],
         thread_id: str | None,
         mcp_session_id: str | None,
     ) -> dict[str, Any]:
         """Build one sync subagent spec, compiling it when it has children."""
         effective_model_name = subagent.model or inherited_model_name
-        tools = sanitize_tools_for_model(
+        own_tools = sanitize_tools_for_model(
             self.config.model_provider,
             await self._get_mcp_tools(
                 subagent.mcp_servers,
@@ -3846,6 +3857,7 @@ class AgentRuntime:
                 mcp_session_id=mcp_session_id,
             ),
         )
+        effective_tools = own_tools or list(inherited_tools)
         middleware = build_agent_middleware(
             config=self.config,
             reasoning_level=reasoning_level,
@@ -3855,7 +3867,7 @@ class AgentRuntime:
         )
         if not has_nested_child_subagents(subagent):
             return subagent.to_deepagents_spec(
-                tools=tools,
+                tools=own_tools,
                 middleware=middleware,
             )
 
@@ -3866,6 +3878,7 @@ class AgentRuntime:
                 reasoning_level=reasoning_level,
                 inherited_model_name=effective_model_name,
                 backend=backend,
+                inherited_tools=effective_tools,
                 thread_id=thread_id,
                 mcp_session_id=mcp_session_id,
             )
@@ -3876,7 +3889,7 @@ class AgentRuntime:
                 reasoning_level,
                 model_name=effective_model_name,
             ),
-            "tools": tools or None,
+            "tools": effective_tools or None,
             "system_prompt": subagent.system_prompt,
             "middleware": middleware,
             "backend": backend,
@@ -3960,6 +3973,7 @@ class AgentRuntime:
                     reasoning_level=reasoning_level,
                     selected_model=selected_model,
                     backend=backend,
+                    inherited_tools=main_tools,
                     thread_id=thread_id,
                     mcp_session_id=mcp_session_id,
                 )

--- a/chainagents/runtime/core.py
+++ b/chainagents/runtime/core.py
@@ -1394,6 +1394,8 @@ class SubagentConfig:
         skills: The skills value.
         mcp_servers: The MCP servers value.
         model: Model name or model object used by the runtime.
+        nested_subagent_names: Top-level sync subagent names exposed to this subagent.
+        subagents: Inline private sync subagents exposed to this subagent.
     """
 
     name: str
@@ -1402,6 +1404,8 @@ class SubagentConfig:
     skills: tuple[str, ...] = ()
     mcp_servers: tuple[str, ...] = ()
     model: str | None = None
+    nested_subagent_names: tuple[str, ...] = ()
+    subagents: tuple["SubagentConfig", ...] = ()
 
     def to_deepagents_spec(
         self,
@@ -1906,6 +1910,7 @@ def parse_sync_subagent_config(
     index: int,
     base_dir: Path,
     mcp_servers: dict[str, dict[str, Any]],
+    parent_name: str | None = None,
 ) -> SubagentConfig:
     """Parse sync subagent config.
 
@@ -1914,6 +1919,7 @@ def parse_sync_subagent_config(
         index: The index value.
         base_dir: The base dir value.
         mcp_servers: The MCP servers value.
+        parent_name: Parent subagent name for nested entries.
 
     Returns:
         The parsed sync subagent config.
@@ -1926,6 +1932,11 @@ def parse_sync_subagent_config(
     if not name or not description:
         raise ValueError(
             f"Subagent entry #{index} must include non-empty 'name' and 'description'."
+        )
+    if parent_name and "graph_id" in raw_subagent:
+        raise ValueError(
+            f"Subagent '{parent_name}' nested async subagents are not supported; "
+            f"nested subagent '{name or index}' defines 'graph_id'."
         )
 
     inline_prompt = raw_subagent.get("system_prompt")
@@ -1961,6 +1972,31 @@ def parse_sync_subagent_config(
                 f"Defined servers: {sorted(mcp_servers)}"
             )
 
+    nested_subagent_names = normalize_required_string_list(
+        raw_subagent.get("nested_subagents", []),
+        field_name=f"subagent '{name}' nested_subagents",
+    )
+    raw_nested_subagents = raw_subagent.get("subagents", [])
+    if not isinstance(raw_nested_subagents, list):
+        raise ValueError(
+            f"Subagent '{name}' nested 'subagents' config must be an array of tables."
+        )
+    nested_subagents: list[SubagentConfig] = []
+    for nested_index, raw_nested_subagent in enumerate(raw_nested_subagents, start=1):
+        if not isinstance(raw_nested_subagent, dict):
+            raise ValueError(
+                f"Subagent '{name}' nested subagent entry #{nested_index} must be a table/object."
+            )
+        nested_subagents.append(
+            parse_sync_subagent_config(
+                raw_nested_subagent,
+                index=nested_index,
+                base_dir=base_dir,
+                mcp_servers=mcp_servers,
+                parent_name=name,
+            )
+        )
+
     model = str(raw_subagent.get("model", "")).strip() or None
     return SubagentConfig(
         name=name,
@@ -1969,7 +2005,102 @@ def parse_sync_subagent_config(
         skills=subagent_skill_paths,
         mcp_servers=raw_subagent_mcp_servers,
         model=model,
+        nested_subagent_names=nested_subagent_names,
+        subagents=tuple(nested_subagents),
     )
+
+
+def normalize_required_string_list(
+    value: Any,
+    *,
+    field_name: str,
+) -> tuple[str, ...]:
+    """Normalize a config field that must be a list of non-empty strings."""
+    if not isinstance(value, list):
+        raise ValueError(f"'{field_name}' must be a list of strings.")
+
+    items: list[str] = []
+    for index, raw_item in enumerate(value, start=1):
+        item = str(raw_item).strip()
+        if not item:
+            raise ValueError(
+                f"'{field_name}' entry #{index} must be a non-empty string."
+            )
+        items.append(item)
+    return tuple(items)
+
+
+def validate_subagent_names(
+    subagents: tuple[SubagentConfig, ...],
+    async_subagents: tuple[AsyncSubagentConfig, ...],
+) -> None:
+    """Validate top-level subagent name uniqueness across sync and async specs."""
+    seen_names: set[str] = set()
+    for subagent in (*subagents, *async_subagents):
+        if subagent.name in seen_names:
+            raise ValueError(
+                f"Top-level subagent name '{subagent.name}' is defined more than once."
+            )
+        seen_names.add(subagent.name)
+
+
+def validate_nested_subagent_references(
+    subagents: tuple[SubagentConfig, ...],
+) -> None:
+    """Validate nested sync subagent references and cycles."""
+    registry = {subagent.name: subagent for subagent in subagents}
+    for subagent in subagents:
+        validate_nested_subagent_reference_tree(
+            subagent,
+            registry=registry,
+            path=(subagent.name,),
+        )
+
+
+def validate_nested_subagent_reference_tree(
+    subagent: SubagentConfig,
+    *,
+    registry: dict[str, SubagentConfig],
+    path: tuple[str, ...],
+) -> None:
+    """Validate one subagent's direct children and referenced descendants."""
+    direct_child_names: set[str] = set()
+    for child in subagent.subagents:
+        if child.name in direct_child_names:
+            raise ValueError(
+                f"Subagent '{subagent.name}' has duplicate nested child subagent "
+                f"'{child.name}'."
+            )
+        direct_child_names.add(child.name)
+
+    for referenced_name in subagent.nested_subagent_names:
+        if referenced_name not in registry:
+            raise ValueError(
+                f"Subagent '{subagent.name}' references unknown nested subagent "
+                f"'{referenced_name}'. Defined subagents: {sorted(registry)}"
+            )
+        if referenced_name in direct_child_names:
+            raise ValueError(
+                f"Subagent '{subagent.name}' has duplicate nested child subagent "
+                f"'{referenced_name}'."
+            )
+        if referenced_name in path:
+            cycle = " -> ".join((*path, referenced_name))
+            raise ValueError(f"nested subagent cycle detected: {cycle}")
+        direct_child_names.add(referenced_name)
+
+    for child in subagent.subagents:
+        validate_nested_subagent_reference_tree(
+            child,
+            registry=registry,
+            path=(*path, child.name),
+        )
+    for referenced_name in subagent.nested_subagent_names:
+        validate_nested_subagent_reference_tree(
+            registry[referenced_name],
+            registry=registry,
+            path=(*path, referenced_name),
+        )
 
 
 def parse_extensions_config(raw_config: dict[str, Any], config_path: Path) -> ExtensionsConfig:
@@ -2097,6 +2228,9 @@ def parse_extensions_config(raw_config: dict[str, Any], config_path: Path) -> Ex
                 source_name="Async subagent",
             )
         )
+
+    validate_subagent_names(tuple(subagents), tuple(async_subagents))
+    validate_nested_subagent_references(tuple(subagents))
 
     chainlit_section = raw_config.get("chainlit", {})
     if chainlit_section and not isinstance(chainlit_section, dict):
@@ -3247,28 +3381,113 @@ def tool_supports_openai_compatible_schema(tool: Any) -> bool:
     return isinstance(parameters, dict) and parameters.get("type") == "object"
 
 
+def nested_child_subagents(
+    subagent: SubagentConfig,
+    registry: dict[str, SubagentConfig],
+) -> tuple[SubagentConfig, ...]:
+    """Return inline and referenced nested child subagents in config order."""
+    return (
+        *subagent.subagents,
+        *(registry[name] for name in subagent.nested_subagent_names),
+    )
+
+
+def has_nested_child_subagents(subagent: SubagentConfig) -> bool:
+    """Return whether a sync subagent exposes child subagents."""
+    return bool(subagent.subagents or subagent.nested_subagent_names)
+
+
+def build_static_sync_subagent_spec(
+    config: RuntimeConfig,
+    subagent: SubagentConfig,
+    *,
+    registry: dict[str, SubagentConfig],
+    backend: Any,
+    reasoning_level: ReasoningLevel,
+    inherited_model_name: str,
+    project_root: Path | None,
+) -> dict[str, Any]:
+    """Build a sync subagent spec for configured graph creation."""
+    effective_model_name = subagent.model or inherited_model_name
+    middleware = build_agent_middleware(
+        config=config,
+        reasoning_level=reasoning_level,
+        model_name=effective_model_name,
+        source=subagent.name,
+        project_root=project_root,
+    )
+    if not has_nested_child_subagents(subagent):
+        return subagent.to_deepagents_spec(middleware=middleware)
+
+    child_specs = [
+        build_static_sync_subagent_spec(
+            config,
+            child,
+            registry=registry,
+            backend=backend,
+            reasoning_level=reasoning_level,
+            inherited_model_name=effective_model_name,
+            project_root=project_root,
+        )
+        for child in nested_child_subagents(subagent, registry)
+    ]
+    runnable_kwargs: dict[str, Any] = {
+        "model": build_model(
+            config,
+            reasoning_level,
+            model_name=effective_model_name,
+        ),
+        "tools": None,
+        "system_prompt": subagent.system_prompt,
+        "middleware": middleware,
+        "backend": backend,
+        "skills": list(subagent.skills) or None,
+        "subagents": child_specs or None,
+    }
+    runnable = create_deep_agent_with_configured_summarization(
+        config,
+        **runnable_kwargs,
+    )
+    return {
+        "name": subagent.name,
+        "description": subagent.description,
+        "runnable": runnable,
+    }
+
+
 def build_graph_subagent_specs(
     config: RuntimeConfig,
     *,
     include_async_subagents: bool,
+    backend: Any | None = None,
+    project_root: Path | None = None,
 ) -> list[Any]:
     """Build graph subagent specs.
 
     Args:
         config: Configuration object used by the operation.
         include_async_subagents: Whether to include async subagents.
+        backend: DeepAgents backend shared with compiled nested subgraphs.
+        project_root: Project root used to resolve runtime middleware context.
 
     Returns:
         The constructed graph subagent specs.
     """
+    registry = {subagent.name: subagent for subagent in config.extensions.subagents}
+    resolved_backend = backend or build_deepagent_backend(
+        project_root=project_root,
+        include_memories=config.agent_state == "stateful",
+        memory_namespace=config.extensions.agent_memory_namespace,
+    )
     subagent_specs: list[Any] = [
-        subagent.to_deepagents_spec(
-            middleware=build_agent_middleware(
-                config=config,
-                reasoning_level=config.default_reasoning,
-                model_name=subagent.model,
-                source=subagent.name,
-            )
+        build_static_sync_subagent_spec(
+            config,
+            subagent,
+            registry=registry,
+            backend=resolved_backend,
+            reasoning_level=config.default_reasoning,
+            inherited_model_name=config.model_name,
+            project_root=project_root,
         )
         for subagent in config.extensions.subagents
     ]
@@ -3311,9 +3530,15 @@ def create_configured_graph(
         The created configured graph.
     """
     config = RuntimeConfig.from_env()
+    backend = build_deepagent_backend(
+        include_memories=config.agent_state == "stateful",
+        memory_namespace=config.extensions.agent_memory_namespace,
+    )
     subagent_specs = build_graph_subagent_specs(
         config,
         include_async_subagents=include_async_subagents,
+        backend=backend,
+        project_root=PROJECT_ROOT,
     )
     tools: list[Any] = []
     if config.rag is not None:
@@ -3346,10 +3571,7 @@ def create_configured_graph(
             source="main-agent",
             project_root=PROJECT_ROOT,
         ),
-        "backend": build_deepagent_backend(
-            include_memories=config.agent_state == "stateful",
-            memory_namespace=config.extensions.agent_memory_namespace,
-        ),
+        "backend": backend,
         "skills": list(config.extensions.skills) or None,
         "subagents": subagent_specs or None,
     }
@@ -3577,6 +3799,103 @@ class AgentRuntime:
         elif self.config.rag_requested and self.config.rag_error:
             logger.warning("RAG is configured but unavailable: %s", self.config.rag_error)
 
+    async def _build_runtime_subagent_specs(
+        self,
+        *,
+        reasoning_level: ReasoningLevel,
+        selected_model: str,
+        backend: Any,
+        thread_id: str | None,
+        mcp_session_id: str | None,
+    ) -> list[Any]:
+        """Build top-level sync subagent specs for a runtime context."""
+        registry = {
+            subagent.name: subagent for subagent in self.config.extensions.subagents
+        }
+        return [
+            await self._build_runtime_sync_subagent_spec(
+                subagent,
+                registry=registry,
+                reasoning_level=reasoning_level,
+                inherited_model_name=selected_model,
+                backend=backend,
+                thread_id=thread_id,
+                mcp_session_id=mcp_session_id,
+            )
+            for subagent in self.config.extensions.subagents
+        ]
+
+    async def _build_runtime_sync_subagent_spec(
+        self,
+        subagent: SubagentConfig,
+        *,
+        registry: dict[str, SubagentConfig],
+        reasoning_level: ReasoningLevel,
+        inherited_model_name: str,
+        backend: Any,
+        thread_id: str | None,
+        mcp_session_id: str | None,
+    ) -> dict[str, Any]:
+        """Build one sync subagent spec, compiling it when it has children."""
+        effective_model_name = subagent.model or inherited_model_name
+        tools = sanitize_tools_for_model(
+            self.config.model_provider,
+            await self._get_mcp_tools(
+                subagent.mcp_servers,
+                thread_id=thread_id,
+                mcp_session_id=mcp_session_id,
+            ),
+        )
+        middleware = build_agent_middleware(
+            config=self.config,
+            reasoning_level=reasoning_level,
+            model_name=effective_model_name,
+            source=subagent.name,
+            project_root=self.project_root,
+        )
+        if not has_nested_child_subagents(subagent):
+            return subagent.to_deepagents_spec(
+                tools=tools,
+                middleware=middleware,
+            )
+
+        child_specs = [
+            await self._build_runtime_sync_subagent_spec(
+                child,
+                registry=registry,
+                reasoning_level=reasoning_level,
+                inherited_model_name=effective_model_name,
+                backend=backend,
+                thread_id=thread_id,
+                mcp_session_id=mcp_session_id,
+            )
+            for child in nested_child_subagents(subagent, registry)
+        ]
+        runnable_kwargs: dict[str, Any] = {
+            "model": self._build_model(
+                reasoning_level,
+                model_name=effective_model_name,
+            ),
+            "tools": tools or None,
+            "system_prompt": subagent.system_prompt,
+            "middleware": middleware,
+            "backend": backend,
+            "skills": list(subagent.skills) or None,
+            "subagents": child_specs or None,
+        }
+        if self.config.agent_state == "stateful":
+            runnable_kwargs["store"] = self.store
+            runnable_kwargs["checkpointer"] = self.checkpointer
+        runnable = create_deep_agent_with_configured_summarization(
+            self.config,
+            **runnable_kwargs,
+        )
+        return {
+            "name": subagent.name,
+            "description": subagent.description,
+            "runnable": runnable,
+        }
+
     async def get_agent(
         self,
         reasoning_level: ReasoningLevel,
@@ -3632,26 +3951,18 @@ class AgentRuntime:
                     source="main-agent",
                     project_root=self.project_root,
                 )
-                subagent_specs: list[Any] = [
-                    subagent.to_deepagents_spec(
-                        tools=sanitize_tools_for_model(
-                            self.config.model_provider,
-                            await self._get_mcp_tools(
-                                subagent.mcp_servers,
-                                thread_id=thread_id,
-                                mcp_session_id=mcp_session_id,
-                            ),
-                        ),
-                        middleware=build_agent_middleware(
-                            config=self.config,
-                            reasoning_level=reasoning_level,
-                            model_name=subagent.model or selected_model,
-                            source=subagent.name,
-                            project_root=self.project_root,
-                        ),
-                    )
-                    for subagent in self.config.extensions.subagents
-                ]
+                backend = build_deepagent_backend(
+                    project_root=self.project_root,
+                    include_memories=self.config.agent_state == "stateful",
+                    memory_namespace=self.config.extensions.agent_memory_namespace,
+                )
+                subagent_specs = await self._build_runtime_subagent_specs(
+                    reasoning_level=reasoning_level,
+                    selected_model=selected_model,
+                    backend=backend,
+                    thread_id=thread_id,
+                    mcp_session_id=mcp_session_id,
+                )
                 subagent_specs.extend(
                     subagent.to_deepagents_spec(
                         url_override=async_subagent_url_override,
@@ -3673,11 +3984,7 @@ class AgentRuntime:
                         rag_enabled=rag_tool_enabled,
                     ),
                     "middleware": middleware,
-                    "backend": build_deepagent_backend(
-                        project_root=self.project_root,
-                        include_memories=self.config.agent_state == "stateful",
-                        memory_namespace=self.config.extensions.agent_memory_namespace,
-                    ),
+                    "backend": backend,
                     "skills": list(self.config.extensions.skills) or None,
                     "subagents": subagent_specs or None,
                 }

--- a/deepagent.toml.example
+++ b/deepagent.toml.example
@@ -121,7 +121,15 @@ description = "Researches the codebase and produces concise implementation guida
 system_prompt_file = "prompts/repo-researcher.md"
 skills = ["skills/research"]
 mcp_servers = ["repo", "docs"]
+nested_subagents = ["reviewer"]
 # model = "gpt-oss:20b"
+
+[[subagents.subagents]]
+name = "repo-planner"
+description = "Turns repository findings into an implementation plan."
+system_prompt = "Use repository context to produce a concise implementation plan."
+skills = ["skills/research"]
+mcp_servers = ["repo"]
 
 [[subagents]]
 name = "reviewer"

--- a/tests/test_deepagent_runtime_rag.py
+++ b/tests/test_deepagent_runtime_rag.py
@@ -2115,6 +2115,111 @@ def test_get_agent_applies_configured_deepagents_summarization_thresholds(
     assert {item["keep"] for item in created_summarizers} == {("tokens", 2000)}
 
 
+def test_get_agent_builds_compiled_subagents_for_nested_sync_subagents(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Verify nested sync subagents are compiled into child DeepAgents graphs."""
+    created_graphs: list[SimpleNamespace] = []
+    mcp_tool_calls: list[tuple[str, ...]] = []
+
+    def fake_create_deep_agent(**kwargs):
+        """Capture every DeepAgents graph creation call."""
+        graph = SimpleNamespace(kwargs=kwargs)
+        created_graphs.append(graph)
+        return graph
+
+    def fake_build_model(config, reasoning_level, *, model_name=None):
+        """Return a visible model marker for graph-construction assertions."""
+        return f"model:{model_name or config.model_name}:{reasoning_level}"
+
+    monkeypatch.setattr(deepagent_runtime, "create_deep_agent", fake_create_deep_agent)
+    monkeypatch.setattr(deepagent_runtime, "build_model", fake_build_model)
+
+    runtime = AgentRuntime(
+        make_runtime_config(
+            tmp_path,
+            extensions=ExtensionsConfig(
+                config_path=None,
+                mcp_servers={
+                    "manager-mcp": {"transport": "stdio", "command": "npx", "args": []},
+                    "private-mcp": {"transport": "stdio", "command": "npx", "args": []},
+                    "reviewer-mcp": {"transport": "stdio", "command": "npx", "args": []},
+                },
+                subagents=(
+                    SubagentConfig(
+                        name="manager",
+                        description="Coordinates specialist agents.",
+                        system_prompt="Manage the work.",
+                        skills=("/workspace/manager-skills/",),
+                        mcp_servers=("manager-mcp",),
+                        model="manager-model",
+                        nested_subagent_names=("reviewer",),
+                        subagents=(
+                            SubagentConfig(
+                                name="private-reviewer",
+                                description="Reviews manager output.",
+                                system_prompt="Review privately.",
+                                skills=("/workspace/private-skills/",),
+                                mcp_servers=("private-mcp",),
+                            ),
+                        ),
+                    ),
+                    SubagentConfig(
+                        name="reviewer",
+                        description="Reviews output.",
+                        system_prompt="Review publicly.",
+                        mcp_servers=("reviewer-mcp",),
+                    ),
+                ),
+            ),
+        ),
+        project_root=tmp_path,
+    )
+    runtime._store = InMemoryStore()
+    runtime._checkpointer = MemorySaver()
+
+    async def fake_get_mcp_tools(
+        server_names,
+        *,
+        thread_id=None,
+        mcp_session_id=None,
+    ):
+        """Return visible fake MCP tools for each requested server tuple."""
+        mcp_tool_calls.append(tuple(server_names))
+        if not server_names:
+            return []
+        return [SimpleNamespace(name=f"tools:{','.join(server_names)}")]
+
+    runtime._get_mcp_tools = fake_get_mcp_tools  # type: ignore[assignment]
+
+    asyncio.run(runtime.get_agent("medium", thread_id="thread-1"))
+
+    assert len(created_graphs) == 2
+    manager_kwargs = created_graphs[0].kwargs
+    main_kwargs = created_graphs[1].kwargs
+
+    top_level_specs = main_kwargs["subagents"]
+    assert [spec["name"] for spec in top_level_specs] == ["manager", "reviewer"]
+    assert top_level_specs[0]["description"] == "Coordinates specialist agents."
+    assert top_level_specs[0]["runnable"] is created_graphs[0]
+    assert "runnable" not in top_level_specs[1]
+
+    assert manager_kwargs["model"] == "model:manager-model:medium"
+    assert manager_kwargs["system_prompt"] == "Manage the work."
+    assert manager_kwargs["skills"] == ["/workspace/manager-skills/"]
+    assert manager_kwargs["tools"][0].name == "tools:manager-mcp"
+
+    nested_specs = manager_kwargs["subagents"]
+    assert [spec["name"] for spec in nested_specs] == ["private-reviewer", "reviewer"]
+    assert nested_specs[0]["skills"] == ["/workspace/private-skills/"]
+    assert nested_specs[0]["tools"][0].name == "tools:private-mcp"
+    assert nested_specs[1]["tools"][0].name == "tools:reviewer-mcp"
+    assert ("manager-mcp",) in mcp_tool_calls
+    assert ("private-mcp",) in mcp_tool_calls
+    assert ("reviewer-mcp",) in mcp_tool_calls
+
+
 def test_summarization_status_middleware_emits_stream_events() -> None:
     """Verify that summarization status middleware emits stream events."""
     events: list[dict[str, str]] = []
@@ -2796,6 +2901,193 @@ model_mode_enabled = "no"
     monkeypatch.setenv("DEEPAGENT_CONFIG", str(config_path))
 
     with pytest.raises(ValueError, match="model_mode_enabled"):
+        deepagent_runtime.load_extensions_config()
+
+
+def test_load_extensions_config_parses_inline_nested_subagents(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Verify inline nested sync subagents are parsed under their parent."""
+    config_path = tmp_path / "deepagent.toml"
+    config_path.write_text(
+        """
+[mcp.servers.repo]
+transport = "stdio"
+command = "npx"
+args = ["server"]
+
+[[subagents]]
+name = "manager"
+description = "Coordinates specialist agents."
+system_prompt = "Manage the work."
+
+[[subagents.subagents]]
+name = "private-reviewer"
+description = "Reviews manager output."
+system_prompt = "Review the work."
+skills = ["/workspace/private-reviewer"]
+mcp_servers = ["repo"]
+model = "gpt-oss:120b"
+
+[[subagents]]
+name = "public-reviewer"
+description = "Reviews top-level output."
+system_prompt = "Review top-level work."
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DEEPAGENT_CONFIG", str(config_path))
+
+    extensions = deepagent_runtime.load_extensions_config()
+
+    manager = extensions.subagents[0]
+    assert manager.name == "manager"
+    assert manager.nested_subagent_names == ()
+    assert len(manager.subagents) == 1
+    private_reviewer = manager.subagents[0]
+    assert private_reviewer.name == "private-reviewer"
+    assert private_reviewer.skills == ("/workspace/private-reviewer/",)
+    assert private_reviewer.mcp_servers == ("repo",)
+    assert private_reviewer.model == "gpt-oss:120b"
+    assert extensions.subagents[1].name == "public-reviewer"
+
+
+def test_load_extensions_config_parses_nested_subagent_references(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Verify top-level sync subagents can be reused as nested children."""
+    config_path = tmp_path / "deepagent.toml"
+    config_path.write_text(
+        """
+[[subagents]]
+name = "manager"
+description = "Coordinates specialist agents."
+system_prompt = "Manage the work."
+nested_subagents = ["reviewer"]
+
+[[subagents]]
+name = "reviewer"
+description = "Reviews output."
+system_prompt = "Review the work."
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DEEPAGENT_CONFIG", str(config_path))
+
+    extensions = deepagent_runtime.load_extensions_config()
+
+    assert extensions.subagents[0].name == "manager"
+    assert extensions.subagents[0].nested_subagent_names == ("reviewer",)
+    assert extensions.subagents[0].subagents == ()
+
+
+def test_load_extensions_config_rejects_unknown_nested_subagent_reference(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Verify missing nested subagent references fail at config load."""
+    config_path = tmp_path / "deepagent.toml"
+    config_path.write_text(
+        """
+[[subagents]]
+name = "manager"
+description = "Coordinates specialist agents."
+system_prompt = "Manage the work."
+nested_subagents = ["missing-reviewer"]
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DEEPAGENT_CONFIG", str(config_path))
+
+    with pytest.raises(ValueError, match="unknown nested subagent 'missing-reviewer'"):
+        deepagent_runtime.load_extensions_config()
+
+
+def test_load_extensions_config_rejects_nested_subagent_reference_cycles(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Verify nested subagent references cannot create delegation cycles."""
+    config_path = tmp_path / "deepagent.toml"
+    config_path.write_text(
+        """
+[[subagents]]
+name = "manager"
+description = "Coordinates specialist agents."
+system_prompt = "Manage the work."
+nested_subagents = ["reviewer"]
+
+[[subagents]]
+name = "reviewer"
+description = "Reviews output."
+system_prompt = "Review the work."
+nested_subagents = ["manager"]
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DEEPAGENT_CONFIG", str(config_path))
+
+    with pytest.raises(ValueError, match="nested subagent cycle"):
+        deepagent_runtime.load_extensions_config()
+
+
+def test_load_extensions_config_rejects_duplicate_nested_child_names(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Verify a parent cannot expose two direct children with the same name."""
+    config_path = tmp_path / "deepagent.toml"
+    config_path.write_text(
+        """
+[[subagents]]
+name = "manager"
+description = "Coordinates specialist agents."
+system_prompt = "Manage the work."
+nested_subagents = ["reviewer"]
+
+[[subagents.subagents]]
+name = "reviewer"
+description = "Private reviewer."
+system_prompt = "Review privately."
+
+[[subagents]]
+name = "reviewer"
+description = "Public reviewer."
+system_prompt = "Review publicly."
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DEEPAGENT_CONFIG", str(config_path))
+
+    with pytest.raises(ValueError, match="duplicate nested child subagent 'reviewer'"):
+        deepagent_runtime.load_extensions_config()
+
+
+def test_load_extensions_config_rejects_nested_async_subagents(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Verify nested subagents are limited to synchronous subagent configs."""
+    config_path = tmp_path / "deepagent.toml"
+    config_path.write_text(
+        """
+[[subagents]]
+name = "manager"
+description = "Coordinates specialist agents."
+system_prompt = "Manage the work."
+
+[[subagents.subagents]]
+name = "remote-reviewer"
+description = "Remote reviewer."
+graph_id = "reviewer"
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DEEPAGENT_CONFIG", str(config_path))
+
+    with pytest.raises(ValueError, match="nested async subagents are not supported"):
         deepagent_runtime.load_extensions_config()
 
 

--- a/tests/test_deepagent_runtime_rag.py
+++ b/tests/test_deepagent_runtime_rag.py
@@ -2220,6 +2220,125 @@ def test_get_agent_builds_compiled_subagents_for_nested_sync_subagents(
     assert ("reviewer-mcp",) in mcp_tool_calls
 
 
+def test_get_agent_preserves_inherited_tools_for_compiled_nested_subagents(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Verify compiled nested parents keep inherited main-agent tools."""
+    created_graphs: list[SimpleNamespace] = []
+
+    def fake_create_deep_agent(**kwargs):
+        """Capture every DeepAgents graph creation call."""
+        graph = SimpleNamespace(kwargs=kwargs)
+        created_graphs.append(graph)
+        return graph
+
+    monkeypatch.setattr(deepagent_runtime, "create_deep_agent", fake_create_deep_agent)
+    monkeypatch.setattr(
+        deepagent_runtime,
+        "build_model",
+        lambda config, reasoning_level, *, model_name=None: (
+            f"model:{model_name or config.model_name}:{reasoning_level}"
+        ),
+    )
+
+    runtime = AgentRuntime(
+        make_runtime_config(
+            tmp_path,
+            extensions=ExtensionsConfig(
+                config_path=None,
+                subagents=(
+                    SubagentConfig(
+                        name="manager",
+                        description="Coordinates specialist agents.",
+                        system_prompt="Manage the work.",
+                        subagents=(
+                            SubagentConfig(
+                                name="reviewer",
+                                description="Reviews manager output.",
+                                system_prompt="Review privately.",
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+        project_root=tmp_path,
+    )
+    runtime._store = InMemoryStore()
+    runtime._checkpointer = MemorySaver()
+
+    async def fake_build_main_tools(*, thread_id=None, mcp_session_id=None):
+        """Return a visible inherited main-agent tool."""
+        return [SimpleNamespace(name="main-tool")]
+
+    runtime._build_main_tools = fake_build_main_tools  # type: ignore[assignment]
+
+    asyncio.run(runtime.get_agent("medium", thread_id="thread-1"))
+
+    assert len(created_graphs) == 2
+    manager_kwargs = created_graphs[0].kwargs
+    assert manager_kwargs["tools"][0].name == "main-tool"
+    assert "tools" not in manager_kwargs["subagents"][0]
+
+
+def test_build_graph_subagent_specs_preserves_static_inherited_tools_for_compiled_subagents(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Verify static compiled parents keep inherited graph tools."""
+    created_graphs: list[SimpleNamespace] = []
+
+    def fake_create_deep_agent(**kwargs):
+        """Capture every DeepAgents graph creation call."""
+        graph = SimpleNamespace(kwargs=kwargs)
+        created_graphs.append(graph)
+        return graph
+
+    monkeypatch.setattr(deepagent_runtime, "create_deep_agent", fake_create_deep_agent)
+    monkeypatch.setattr(
+        deepagent_runtime,
+        "build_model",
+        lambda config, reasoning_level, *, model_name=None: (
+            f"model:{model_name or config.model_name}:{reasoning_level}"
+        ),
+    )
+
+    config = make_runtime_config(
+        tmp_path,
+        extensions=ExtensionsConfig(
+            config_path=None,
+            subagents=(
+                SubagentConfig(
+                    name="manager",
+                    description="Coordinates specialist agents.",
+                    system_prompt="Manage the work.",
+                    subagents=(
+                        SubagentConfig(
+                            name="reviewer",
+                            description="Reviews manager output.",
+                            system_prompt="Review privately.",
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    )
+
+    specs = deepagent_runtime.build_graph_subagent_specs(
+        config,
+        include_async_subagents=False,
+        backend=object(),
+        project_root=tmp_path,
+        inherited_tools=[SimpleNamespace(name="static-tool")],
+    )
+
+    assert specs[0]["runnable"] is created_graphs[0]
+    manager_kwargs = created_graphs[0].kwargs
+    assert manager_kwargs["tools"][0].name == "static-tool"
+    assert "tools" not in manager_kwargs["subagents"][0]
+
+
 def test_summarization_status_middleware_emits_stream_events() -> None:
     """Verify that summarization status middleware emits stream events."""
     events: list[dict[str, str]] = []


### PR DESCRIPTION
## Summary
- Add recursive sync subagent config parsing for inline private children and top-level child references.
- Compile sync subagents with children into nested DeepAgents runnable subgraphs while preserving child skills, MCP tools, model overrides, middleware, and state handles.
- Document nested subagent syntax in the README and example config.

## Test Plan
- `uv run pytest -q`
- `git diff --check`

## Notes
- Nested subagents are synchronous only in this version; async Agent Protocol subagents remain top-level `[[async_subagents]]` entries.