### PR TITLE
Add file-backed main-agent custom instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,6 +407,8 @@ memory_namespace = "filesystem"
 memory_files = ["/memories/AGENTS.md"]
 skills = ["skills"]
 mcp_servers = ["repo"]
+# custom_instruction = "Always ask clarifying questions before editing files."
+# custom_instruction_file = "prompts/main-agent.md"
 
 [agent.reflection]
 enabled = true
@@ -424,6 +426,8 @@ Notes:
 - Increase it for long tool-heavy runs that hit `GraphRecursionError`; lower it if you want runaway loops to stop sooner.
 - `memory_namespace` is the shared agent-scoped StoreBackend namespace for `/memories/`. The default is `filesystem` to preserve existing memory data from earlier configs. Use only letters, numbers, hyphens, underscores, dots, `@`, `+`, colons, and tildes.
 - `memory_files` lists `/memories/` files DeepAgents loads into the startup memory prompt. The default is `["/memories/AGENTS.md"]`; set it to `[]` to keep the memory route without startup memory loading.
+- `custom_instruction` appends an inline instruction to the **main/supervisor** agent system prompt.
+- `custom_instruction_file` loads that appended instruction from a UTF-8 text file. Relative paths are resolved from the active `deepagent.toml`; use either `custom_instruction` or `custom_instruction_file`, not both.
 - `[agent.reflection]` is opt-in. When enabled for stateful agents, ChainAgents proposes a compact lesson for `memory_file` after correction phrases such as "that was wrong" or after unrecovered tool failures. Chainlit asks with Save/Dismiss before writing through the agent; CLI, TUI, and API expose the proposal without mutating memory.
 
 ## Optional: Enable Workspace Docs RAG
@@ -602,6 +606,7 @@ Main `[agent]` additions:
 - `[agent.reflection]`: optional correction-learning workflow. `enabled = true` requires `state = "stateful"` and a `memory_file` under `/memories/`; `max_lesson_chars` limits proposal size; `tool_failure_mode = "unrecovered"` only proposes lessons for failed tool calls that do not produce a later final response.
 - `AGENTS.md`: optional repo-root file that is automatically appended to the **main/supervisor** agent system prompt when present. It is not applied to separately configured async graph prompts.
 - `custom_instruction`: optional string appended to the **main/supervisor** agent system prompt. This setting does **not** get applied to separately configured prompts such as the `async_researcher` graph prompt.
+- `custom_instruction_file`: optional UTF-8 text file loaded as the main-agent custom instruction. Relative paths resolve from the active `deepagent.toml`. This is mutually exclusive with `custom_instruction`.
 - DeepAgents provides its own summarization middleware in the main agent and sync subagents.
 - `summarization_trigger_tokens`: optional positive integer token threshold for DeepAgents' built-in summarization middleware.
 - `summarization_keep_tokens`: optional positive integer token budget to keep after DeepAgents summarizes conversation history.

--- a/chainagents/runtime/core.py
+++ b/chainagents/runtime/core.py
@@ -1633,7 +1633,7 @@ class ExtensionsConfig:
         summarization_middleware_enabled: The summarization middleware enabled value.
         summarization_trigger_tokens: The summarization trigger tokens value.
         summarization_keep_tokens: The summarization keep tokens value.
-        custom_instruction: The custom instruction value.
+        custom_instruction: Inline or file-loaded main-agent custom instruction.
     """
 
     config_path: Path | None
@@ -2103,6 +2103,28 @@ def validate_nested_subagent_reference_tree(
         )
 
 
+def parse_agent_custom_instruction(
+    agent_section: dict[str, Any],
+    base_dir: Path,
+) -> str | None:
+    """Parse inline or file-based main-agent custom instruction."""
+    custom_instruction = normalize_optional_string(
+        agent_section.get("custom_instruction")
+    )
+    custom_instruction_file = normalize_optional_string(
+        agent_section.get("custom_instruction_file")
+    )
+    if custom_instruction and custom_instruction_file:
+        raise ValueError(
+            "The top-level 'agent' config cannot define both "
+            "'custom_instruction' and 'custom_instruction_file'."
+        )
+    if not custom_instruction_file:
+        return custom_instruction
+    instruction_path = resolve_local_path(custom_instruction_file, base_dir)
+    return instruction_path.read_text(encoding="utf-8").strip() or None
+
+
 def parse_extensions_config(raw_config: dict[str, Any], config_path: Path) -> ExtensionsConfig:
     """Parse extensions config.
 
@@ -2146,7 +2168,7 @@ def parse_extensions_config(raw_config: dict[str, Any], config_path: Path) -> Ex
         mcp_servers[str(name)] = normalize_mcp_server_config(raw_server, base_dir)
 
     raw_skill_paths = agent_section.get("skills", [])
-    custom_instruction = normalize_optional_string(agent_section.get("custom_instruction"))
+    custom_instruction = parse_agent_custom_instruction(agent_section, base_dir)
     raw_summarization_middleware_enabled = agent_section.get(
         "summarization_middleware_enabled",
         False,
@@ -2428,7 +2450,7 @@ def compose_agent_system_prompt(
     if not instruction:
         return "\n\n".join(sections)
     sections.append(
-        "Custom user instruction from [agent].custom_instruction in deepagent.toml:\n"
+        "Custom user instruction from deepagent.toml:\n"
         f"{instruction}"
     )
     return "\n\n".join(sections)

--- a/deepagent.toml
+++ b/deepagent.toml
@@ -53,6 +53,10 @@ memory_namespace = "filesystem"
 memory_files = ["/memories/AGENTS.md"]
 skills = ["skills"]
 mcp_servers = []
+# Optional instruction appended to the main agent system prompt.
+# Use either custom_instruction or custom_instruction_file, not both.
+# custom_instruction = "Always ask clarifying questions before editing files."
+# custom_instruction_file = "prompts/main-agent.md"
 # Legacy flag retained for compatibility; DeepAgents provides summarization.
 summarization_middleware_enabled = true
 # Token thresholds tune DeepAgents' built-in summarizer.

--- a/deepagent.toml.example
+++ b/deepagent.toml.example
@@ -54,7 +54,9 @@ memory_files = ["/memories/AGENTS.md"]
 skills = ["skills"]
 mcp_servers = ["repo"]
 # Optional instruction appended to the main agent system prompt.
+# Use either custom_instruction or custom_instruction_file, not both.
 # custom_instruction = "Always ask clarifying questions before editing files."
+# custom_instruction_file = "prompts/main-agent.md"
 # DeepAgents 0.6.7 provides summarization middleware in its base agent stack.
 # These optional token thresholds tune DeepAgents' built-in summarizer.
 summarization_trigger_tokens = 6000

--- a/tests/test_deepagent_runtime_rag.py
+++ b/tests/test_deepagent_runtime_rag.py
@@ -2775,6 +2775,55 @@ starters = [
     assert extensions.chainlit_starters[1].icon is None
 
 
+def test_load_extensions_config_parses_agent_custom_instruction_file(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Verify main-agent custom instructions can be loaded from a file."""
+    prompts_dir = tmp_path / "prompts"
+    prompts_dir.mkdir()
+    instruction_path = prompts_dir / "main-agent.md"
+    instruction_path.write_text(
+        "\nPrefer precise answers from local code.\n",
+        encoding="utf-8",
+    )
+    config_path = tmp_path / "deepagent.toml"
+    config_path.write_text(
+        """
+[agent]
+custom_instruction_file = "prompts/main-agent.md"
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DEEPAGENT_CONFIG", str(config_path))
+
+    extensions = deepagent_runtime.load_extensions_config()
+
+    assert extensions.custom_instruction == "Prefer precise answers from local code."
+
+
+def test_load_extensions_config_rejects_ambiguous_agent_custom_instruction(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Verify inline and file-based main-agent instructions are mutually exclusive."""
+    instruction_path = tmp_path / "main-agent.md"
+    instruction_path.write_text("Prefer local code.", encoding="utf-8")
+    config_path = tmp_path / "deepagent.toml"
+    config_path.write_text(
+        """
+[agent]
+custom_instruction = "Prefer direct answers."
+custom_instruction_file = "main-agent.md"
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DEEPAGENT_CONFIG", str(config_path))
+
+    with pytest.raises(ValueError, match="custom_instruction_file"):
+        deepagent_runtime.load_extensions_config()
+
+
 def test_load_extensions_config_rejects_invalid_chainlit_starters(
     tmp_path: Path,
     monkeypatch,


### PR DESCRIPTION
## Summary
- Add `agent.custom_instruction_file` support alongside the existing inline setting.
- Resolve relative file paths from the active `deepagent.toml` and reject configs that set both forms.
- Document the new option in `README.md` and `deepagent.toml.example`.
- Cover file loading and mutual-exclusion behavior with unit tests.

## Testing
- Unit tests added for file-based instruction loading and invalid dual-definition configs.