### PR TITLE
Add named model profiles for runtime selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,37 @@ thinking = "auto"
 # endpoint_url = "https://claude-proxy.example/proxy/v1/messages"
 ```
 
+Named model profiles let the main agent, Chainlit mode picker, and sync
+subagents use different provider settings from the same config file:
+
+```toml
+[model]
+provider = "openai_compatible"
+base_url = "http://127.0.0.1:1234/v1"
+name = "local-default"
+models = ["local-default"]
+
+[model.profiles.fast-local]
+name = "local-fast"
+temperature = 0.1
+reasoning_effort = "low"
+
+[model.profiles.claude-reviewer]
+provider = "anthropic"
+name = "claude-sonnet-4-6"
+thinking = "auto"
+# api_key = "optional-if-ANTHROPIC_API_KEY-or-DEEPAGENT_MODEL_API_KEY-is-set"
+
+[agent]
+model = "fast-local"
+
+[[subagents]]
+name = "reviewer"
+description = "Reviews proposed changes."
+system_prompt = "Review for bugs, regressions, and missing tests."
+model = "claude-reviewer"
+```
+
 Notes:
 
 - `provider` selects `ChatOllama`, `ChatOpenAI`, or `ChatAnthropic`.
@@ -366,6 +397,9 @@ Notes:
 - `disable_streaming = "tool_calling"` or `disable_streaming_for_tool_calls = true` bypasses model streaming only when tools are attached to the request; use this for providers that have trouble streaming tool-call chunks. `disable_streaming = true` disables model streaming for all requests.
 - `endpoint_url` is an override for full non-standard model endpoint URLs. OpenAI-compatible paths ending in `/chat/completions` or `/responses` are normalized to the client base URL and query parameters are forwarded as OpenAI client default query parameters. Anthropic paths ending in `/v1/messages` are normalized to the Claude client base URL and query parameters are forwarded as Anthropic client default query parameters.
 - `models` is an optional list of model IDs surfaced in Chainlit settings and modes so users can switch models per session or per message.
+- `[model.profiles.<name>]` defines a named profile. Profiles inherit omitted fields from `[model]` when they keep the same provider; profiles that switch to `openai_compatible` must provide `base_url` or `endpoint_url`, and profiles that switch to `anthropic` default to `https://api.anthropic.com` unless `base_url` or `endpoint_url` is set.
+- Profile names are surfaced in Chainlit settings and modes alongside `[model].models`. When a selected value matches a profile name, the full profile is used; otherwise the value is treated as a raw model name using the inherited/default provider settings.
+- `[agent].model` optionally sets the main/supervisor agent's default profile or raw model name. CLI and environment model overrides still take precedence.
 - `api_key` is optional for `provider = "openai_compatible"`; when omitted, the runtime sends a placeholder token that local servers like LM Studio accept.
 - Anthropic requires an API key from `ANTHROPIC_API_KEY`, `DEEPAGENT_MODEL_API_KEY`, or `api_key`; when multiple are set, `ANTHROPIC_API_KEY` takes precedence over the generic key.
 - When switching from another provider to Anthropic through environment or CLI overrides, provide Anthropic credentials through `ANTHROPIC_API_KEY`, `DEEPAGENT_MODEL_API_KEY`, or `--api-key`; the runtime will not reuse an `api_key` from another provider's TOML config.
@@ -587,7 +621,7 @@ Supported subagent fields:
 - `system_prompt` or `system_prompt_file`: one is required
 - `skills`: optional list of skill source paths for that subagent
 - `mcp_servers`: optional list of MCP server names to attach to that subagent
-- `model`: optional model override
+- `model`: optional profile name or raw model name. Profile names can switch provider settings and tool-schema handling for that sync subagent. Raw model names inherit the parent/default provider settings.
 - `nested_subagents`: optional list of top-level sync subagent names exposed as children of this subagent
 - `[[subagents.subagents]]`: optional inline private sync child subagents under a parent subagent
 
@@ -603,6 +637,7 @@ Main `[agent]` additions:
 - `recursion_limit`: optional positive integer LangGraph step limit for a single agent run. Defaults to `100` unless overridden by `DEEPAGENT_RECURSION_LIMIT`.
 - `memory_namespace`: optional non-empty namespace for agent-scoped `/memories/` storage. Defaults to `filesystem`; allowed characters are letters, numbers, `-`, `_`, `.`, `@`, `+`, `:`, and `~`.
 - `memory_files`: optional list of absolute `/memories/` file paths loaded into the DeepAgents startup memory prompt. Defaults to `["/memories/AGENTS.md"]`; use `[]` to disable startup memory loading.
+- `model`: optional profile name or raw model name for the main/supervisor agent. CLI and environment model overrides take precedence.
 - `[agent.reflection]`: optional correction-learning workflow. `enabled = true` requires `state = "stateful"` and a `memory_file` under `/memories/`; `max_lesson_chars` limits proposal size; `tool_failure_mode = "unrecovered"` only proposes lessons for failed tool calls that do not produce a later final response.
 - `AGENTS.md`: optional repo-root file that is automatically appended to the **main/supervisor** agent system prompt when present. It is not applied to separately configured async graph prompts.
 - `custom_instruction`: optional string appended to the **main/supervisor** agent system prompt. This setting does **not** get applied to separately configured prompts such as the `async_researcher` graph prompt.

--- a/chainagents/interfaces/api/app.py
+++ b/chainagents/interfaces/api/app.py
@@ -70,6 +70,7 @@ class AgentRunContext:
     thread_id: str
     model_name: str
     reasoning_level: ReasoningLevel
+    reasoning_level_is_explicit: bool
     async_subagent_url: str | None
     mcp_session_id: str | None
 
@@ -245,6 +246,7 @@ def _run_context(runtime: Any, request: AgentRunRequest) -> AgentRunContext:
         thread_id=thread_id,
         model_name=model_name,
         reasoning_level=reasoning_level,
+        reasoning_level_is_explicit=request.reasoning is not None,
         async_subagent_url=_optional_text(request.async_subagent_url),
         mcp_session_id=_optional_text(request.mcp_session_id),
     )
@@ -273,6 +275,7 @@ async def _iter_agent_events(
     agent = await runtime.get_agent(
         context.reasoning_level,
         model_name=context.model_name,
+        reasoning_level_is_explicit=context.reasoning_level_is_explicit,
         thread_id=context.thread_id,
         async_subagent_url_override=context.async_subagent_url,
         mcp_session_id=context.mcp_session_id,

--- a/chainagents/interfaces/api/app.py
+++ b/chainagents/interfaces/api/app.py
@@ -21,6 +21,7 @@ from chainagents.runtime import (
     ReasoningLevel,
     build_langgraph_run_config,
     normalize_reasoning_level,
+    resolve_runtime_model_profile,
 )
 from chainagents.runtime.reflection import ReflectionCollector
 
@@ -113,9 +114,10 @@ def create_app(runtime: Any | None = None) -> FastAPI:
     async def status(request: Request) -> RuntimeStatusResponse:
         active_runtime = _runtime_from_request(request)
         config = active_runtime.config
+        active_model = resolve_runtime_model_profile(config)
         return RuntimeStatusResponse(
             model=config.model_name,
-            model_provider=config.model_provider,
+            model_provider=active_model.provider,
             model_choices=list(config.model_choices),
             default_reasoning=config.default_reasoning,
             agent_state=config.agent_state,

--- a/chainagents/interfaces/chainlit/app.py
+++ b/chainagents/interfaces/chainlit/app.py
@@ -1150,6 +1150,18 @@ def resolve_reasoning_level_for_message(
     )
 
 
+def message_has_reasoning_level_override(
+    message: cl.Message,
+    *,
+    reasoning_mode_enabled: bool = True,
+) -> bool:
+    """Return whether a message explicitly selected a reasoning level."""
+    if not reasoning_mode_enabled:
+        return False
+    raw_modes = getattr(message, "modes", None)
+    return isinstance(raw_modes, dict) and raw_modes.get("reasoning_level") is not None
+
+
 def resolve_model_name_for_message(
     message: cl.Message,
     settings: AppSettings,
@@ -1672,6 +1684,10 @@ async def on_message(message: cl.Message) -> None:
     agent = await runtime.get_agent(
         effective_reasoning_level,
         model_name=effective_model_name,
+        reasoning_level_is_explicit=message_has_reasoning_level_override(
+            message,
+            reasoning_mode_enabled=runtime.config.extensions.chainlit_reasoning_mode_enabled,
+        ),
         thread_id=settings.thread_id,
         async_subagent_url_override=async_url_override,
         mcp_session_id=mcp_session_id,

--- a/chainagents/interfaces/chainlit/app.py
+++ b/chainagents/interfaces/chainlit/app.py
@@ -43,6 +43,7 @@ from chainagents.runtime import (
     build_langgraph_run_config,
     format_model_provider,
     normalize_reasoning_level,
+    resolve_runtime_model_profile,
 )
 from chainagents.runtime.reflection import (
     ReflectionCollector,
@@ -1351,10 +1352,11 @@ async def on_chat_start() -> None:
     if extensions.config_path is not None:
         extensions_line += f"- Extensions config: `{extensions.config_path.name}`\n"
     if runtime.config.extensions.chainlit_startup_status_enabled:
+        startup_model_profile = resolve_runtime_model_profile(runtime.config)
         startup_message = cl.Message(
             content=(
                 "Workspace agent ready.\n\n"
-                f"- Model provider: `{format_model_provider(runtime.config.model_provider)}`\n"
+                f"- Model provider: `{format_model_provider(startup_model_profile.provider)}`\n"
                 f"- Model: `{runtime.config.model_name}`\n"
                 f"- Thread ID: `{settings.thread_id}`\n"
                 f"{persistence_line}"

--- a/chainagents/interfaces/chainlit/app.py
+++ b/chainagents/interfaces/chainlit/app.py
@@ -43,6 +43,7 @@ from chainagents.runtime import (
     build_langgraph_run_config,
     format_model_provider,
     normalize_reasoning_level,
+    reasoning_level_for_profile,
     resolve_runtime_model_profile,
 )
 from chainagents.runtime.reflection import (
@@ -1060,6 +1061,8 @@ def coerce_settings(
     *,
     default_model_name: str,
     available_models: tuple[str, ...],
+    default_reasoning_level: ReasoningLevel = DEFAULT_REASONING_LEVEL,
+    runtime_config: RuntimeConfig | None = None,
     show_reasoning_stream_default: bool = True,
     show_tool_calls_default: bool = True,
 ) -> AppSettings:
@@ -1069,6 +1072,8 @@ def coerce_settings(
         raw_settings: Raw settings to process.
         default_model_name: The default model name value.
         available_models: The available models value.
+        default_reasoning_level: Reasoning default when settings omit it.
+        runtime_config: Runtime config used to derive profile-aware defaults.
         show_reasoning_stream_default: Default reasoning stream visibility.
         show_tool_calls_default: Default tool-call visibility.
 
@@ -1100,8 +1105,14 @@ def coerce_settings(
         available_models=available_models,
         default=default_model_name,
     )
+    reasoning_default = (
+        default_reasoning_level_for_model(runtime_config, model_name)
+        if runtime_config is not None
+        else default_reasoning_level
+    )
     reasoning_level = normalize_reasoning_level(
-        raw_settings.get("reasoning_level", DEFAULT_REASONING_LEVEL)
+        raw_settings.get("reasoning_level", reasoning_default),
+        default=reasoning_default,
     )
     thread_id = str(
         raw_settings.get("thread_id") or current_chainlit_thread_id()
@@ -1160,6 +1171,32 @@ def message_has_reasoning_level_override(
         return False
     raw_modes = getattr(message, "modes", None)
     return isinstance(raw_modes, dict) and raw_modes.get("reasoning_level") is not None
+
+
+def default_reasoning_level_for_model(
+    config: RuntimeConfig,
+    model_name: str | None,
+) -> ReasoningLevel:
+    """Return the profile-aware reasoning default for a Chainlit model choice."""
+    model_profile = resolve_runtime_model_profile(config, model_name)
+    return reasoning_level_for_profile(
+        model_profile,
+        config.default_reasoning,
+        fallback_is_explicit=config.model_reasoning_override,
+    )
+
+
+def settings_reasoning_level_is_explicit(
+    config: RuntimeConfig,
+    settings: AppSettings,
+    model_name: str | None = None,
+) -> bool:
+    """Return whether chat settings override the selected model's reasoning default."""
+    selected_model = model_name if model_name is not None else settings.model_name
+    return (
+        normalize_reasoning_level(settings.reasoning_level)
+        != default_reasoning_level_for_model(config, selected_model)
+    )
 
 
 def resolve_model_name_for_message(
@@ -1296,7 +1333,10 @@ async def on_chat_start() -> None:
     extensions = runtime.config.extensions
     settings = AppSettings(
         model_name=runtime.config.model_name,
-        reasoning_level=runtime.config.default_reasoning,
+        reasoning_level=default_reasoning_level_for_model(
+            runtime.config,
+            runtime.config.model_name,
+        ),
         thread_id=current_chainlit_thread_id(),
         show_reasoning_stream=extensions.chainlit_reasoning_steps_enabled,
         show_tool_calls=extensions.chainlit_tool_steps_enabled,
@@ -1407,6 +1447,7 @@ async def on_chat_resume(thread: ThreadDict) -> None:
         raw_settings,
         default_model_name=runtime.config.model_name,
         available_models=runtime.config.model_choices,
+        runtime_config=runtime.config,
         show_reasoning_stream_default=extensions.chainlit_reasoning_steps_enabled,
         show_tool_calls_default=extensions.chainlit_tool_steps_enabled,
     )
@@ -1431,6 +1472,11 @@ async def on_chat_resume(thread: ThreadDict) -> None:
     agent = await runtime.get_agent(
         settings.reasoning_level,
         model_name=settings.model_name,
+        reasoning_level_is_explicit=settings_reasoning_level_is_explicit(
+            runtime.config,
+            settings,
+            settings.model_name,
+        ),
         thread_id=settings.thread_id,
         async_subagent_url_override=async_url_override,
         mcp_session_id=mcp_session_id,
@@ -1459,6 +1505,7 @@ async def on_settings_update(raw_settings: dict[str, Any]) -> None:
         raw_settings,
         default_model_name=runtime.config.model_name,
         available_models=runtime.config.model_choices,
+        runtime_config=runtime.config,
         show_reasoning_stream_default=(
             runtime.config.extensions.chainlit_reasoning_steps_enabled
         ),
@@ -1543,6 +1590,7 @@ async def upload_rag_file(action: cl.Action) -> None:
         cl.user_session.get(SESSION_SETTINGS_KEY),
         default_model_name=runtime.config.model_name,
         available_models=runtime.config.model_choices,
+        runtime_config=runtime.config,
         show_reasoning_stream_default=(
             runtime.config.extensions.chainlit_reasoning_steps_enabled
         ),
@@ -1681,13 +1729,21 @@ async def on_message(message: cl.Message) -> None:
         prompt_note=prompt_note,
     )
     async_url_override = async_subagent_url_override()
+    reasoning_level_is_explicit = (
+        message_has_reasoning_level_override(
+            message,
+            reasoning_mode_enabled=runtime.config.extensions.chainlit_reasoning_mode_enabled,
+        )
+        or settings_reasoning_level_is_explicit(
+            runtime.config,
+            settings,
+            effective_model_name,
+        )
+    )
     agent = await runtime.get_agent(
         effective_reasoning_level,
         model_name=effective_model_name,
-        reasoning_level_is_explicit=message_has_reasoning_level_override(
-            message,
-            reasoning_mode_enabled=runtime.config.extensions.chainlit_reasoning_mode_enabled,
-        ),
+        reasoning_level_is_explicit=reasoning_level_is_explicit,
         thread_id=settings.thread_id,
         async_subagent_url_override=async_url_override,
         mcp_session_id=mcp_session_id,

--- a/chainagents/interfaces/cli/app.py
+++ b/chainagents/interfaces/cli/app.py
@@ -48,6 +48,7 @@ from chainagents.runtime import (
     shutdown_langfuse_client,
     format_model_provider,
     normalize_reasoning_level,
+    resolve_runtime_model_profile,
     resolve_local_path,
 )
 from chainagents.rag.runtime import RagStatus, RagUploadResult, UploadedRagFile
@@ -1301,12 +1302,13 @@ def runtime_status_payload(runtime: AgentRuntime) -> dict[str, Any]:
         The constructed the json payload for cli runtime status output.
     """
     extensions = runtime.config.extensions
+    active_model = resolve_runtime_model_profile(runtime.config)
     return {
-        "model_provider": runtime.config.model_provider,
-        "model_provider_label": format_model_provider(runtime.config.model_provider),
+        "model_provider": active_model.provider,
+        "model_provider_label": format_model_provider(active_model.provider),
         "model": runtime.config.model_name,
         "model_choices": list(runtime.config.model_choices),
-        "model_base_url": runtime.config.model_base_url,
+        "model_base_url": active_model.base_url,
         "reasoning": runtime.config.default_reasoning,
         "model_disable_streaming": runtime.config.model_disable_streaming,
         "agent_state": runtime.config.agent_state,

--- a/chainagents/runtime/core.py
+++ b/chainagents/runtime/core.py
@@ -2992,7 +2992,12 @@ class RuntimeConfig:
             )
             or model_defaults.name
         )
-        model_default_name = generic_model_name or model_name_alias or model_defaults.name
+        model_name_override = generic_model_name or model_name_alias
+        model_default_name = (
+            model_defaults.name
+            if model_name_override in file_config.model_profiles
+            else model_name_override or model_defaults.name
+        )
         model_choices = tuple(
             dict.fromkeys(
                 [
@@ -3852,6 +3857,21 @@ def inherited_tools_for_model(
     return sanitize_tools_for_model(effective_provider, list(inherited_tools))
 
 
+def reasoning_level_for_profile(
+    model_profile: ModelDefaults,
+    fallback: ReasoningLevel,
+) -> ReasoningLevel:
+    """Return the reasoning level to use when building a profile-backed model."""
+    if "reasoning_effort" in model_profile.explicit_fields:
+        return model_profile.reasoning_effort
+    if (
+        not model_profile.explicit_fields
+        and model_profile.reasoning_effort != DEFAULT_REASONING_LEVEL
+    ):
+        return model_profile.reasoning_effort
+    return fallback
+
+
 def build_static_sync_subagent_spec(
     config: RuntimeConfig,
     subagent: SubagentConfig,
@@ -3869,6 +3889,10 @@ def build_static_sync_subagent_spec(
         subagent.model,
         inherited_model=inherited_model,
     )
+    effective_reasoning_level = reasoning_level_for_profile(
+        effective_model,
+        reasoning_level,
+    )
     inherited_model_tools = inherited_tools_for_model(
         inherited_tools=inherited_tools,
         inherited_provider=inherited_model.provider,
@@ -3877,7 +3901,7 @@ def build_static_sync_subagent_spec(
     effective_tools = inherited_model_tools
     middleware = build_agent_middleware(
         config=config,
-        reasoning_level=reasoning_level,
+        reasoning_level=effective_reasoning_level,
         model_name=effective_model.name,
         source=subagent.name,
         project_root=project_root,
@@ -3886,7 +3910,7 @@ def build_static_sync_subagent_spec(
         subagent_model = (
             build_model_for_profile(
                 config,
-                reasoning_level,
+                effective_reasoning_level,
                 effective_model,
             )
             if subagent.model
@@ -3910,7 +3934,7 @@ def build_static_sync_subagent_spec(
             registry=registry,
             backend=backend,
             inherited_tools=effective_tools,
-            reasoning_level=reasoning_level,
+            reasoning_level=effective_reasoning_level,
             inherited_model=effective_model,
             project_root=project_root,
         )
@@ -3919,7 +3943,7 @@ def build_static_sync_subagent_spec(
     runnable_kwargs: dict[str, Any] = {
         "model": build_model_for_profile(
             config,
-            reasoning_level,
+            effective_reasoning_level,
             effective_model,
         ),
         "tools": effective_tools or None,
@@ -4340,6 +4364,10 @@ class AgentRuntime:
             subagent.model,
             inherited_model=inherited_model,
         )
+        effective_reasoning_level = reasoning_level_for_profile(
+            effective_model,
+            reasoning_level,
+        )
         raw_own_tools = await self._get_mcp_tools(
             subagent.mcp_servers,
             thread_id=thread_id,
@@ -4362,7 +4390,7 @@ class AgentRuntime:
         )
         middleware = build_agent_middleware(
             config=self.config,
-            reasoning_level=reasoning_level,
+            reasoning_level=effective_reasoning_level,
             model_name=effective_model.name,
             source=subagent.name,
             project_root=self.project_root,
@@ -4378,7 +4406,7 @@ class AgentRuntime:
                 subagent_tools = inherited_model_tools
             subagent_model = (
                 self._build_model(
-                    reasoning_level,
+                    effective_reasoning_level,
                     model_profile=effective_model,
                 )
                 if subagent.model
@@ -4394,7 +4422,7 @@ class AgentRuntime:
             await self._build_runtime_sync_subagent_spec(
                 child,
                 registry=registry,
-                reasoning_level=reasoning_level,
+                reasoning_level=effective_reasoning_level,
                 inherited_model=effective_model,
                 backend=backend,
                 inherited_tools=effective_tools,
@@ -4405,7 +4433,7 @@ class AgentRuntime:
         ]
         runnable_kwargs: dict[str, Any] = {
             "model": self._build_model(
-                reasoning_level,
+                effective_reasoning_level,
                 model_profile=effective_model,
             ),
             "tools": effective_tools or None,

--- a/chainagents/runtime/core.py
+++ b/chainagents/runtime/core.py
@@ -1703,6 +1703,7 @@ class ModelDefaults:
         repeat_penalty: The repeat penalty value.
         disable_streaming: Whether to disable model streaming.
         explicit_fields: Profile fields explicitly set in TOML.
+        runtime_override_fields: Fields explicitly overridden at runtime.
     """
 
     provider: ModelProvider = DEFAULT_MODEL_PROVIDER
@@ -1718,6 +1719,11 @@ class ModelDefaults:
     repeat_penalty: float | None = None
     disable_streaming: DisableStreaming = False
     explicit_fields: frozenset[str] = field(
+        default_factory=frozenset,
+        compare=False,
+        repr=False,
+    )
+    runtime_override_fields: frozenset[str] = field(
         default_factory=frozenset,
         compare=False,
         repr=False,
@@ -1994,7 +2000,10 @@ def rebase_model_profile_defaults(
         updates["name_is_explicit"] = base_model.name_is_explicit
     if "models" not in explicit_fields:
         updates["models"] = base_model.models
-    if "base_url" not in explicit_fields:
+    if (
+        "base_url" in base_model.runtime_override_fields
+        or "base_url" not in explicit_fields
+    ):
         updates["base_url"] = base_model.base_url
         updates["endpoint_query"] = base_model.endpoint_query
     if "api_key" not in explicit_fields:
@@ -2825,6 +2834,8 @@ class RuntimeConfig:
         model_api_key_override: Explicit runtime API key override.
         model_default_name: Runtime default model name before agent/profile selection.
         model_default_choices: Runtime default model list before profile names are added.
+        model_reasoning_override: Whether reasoning was explicitly overridden at runtime.
+        model_base_url_override: Whether the model endpoint was overridden at runtime.
     """
 
     database_url: str | None
@@ -2851,6 +2862,8 @@ class RuntimeConfig:
     model_api_key_override: str | None = None
     model_default_name: str | None = None
     model_default_choices: tuple[str, ...] = ()
+    model_reasoning_override: bool = False
+    model_base_url_override: bool = False
 
     @classmethod
     def from_env(
@@ -2924,17 +2937,42 @@ class RuntimeConfig:
             else ""
         )
 
-        endpoint_url_satisfies_provider_switch = (
-            model_provider == "openai_compatible" and bool(generic_model_endpoint_url)
-        )
         provider_changed = (
             bool(model_provider_override) and model_provider != model_defaults.provider
+        )
+        model_name = (
+            generic_model_name
+            or model_name_alias
+            or (
+                file_config.extensions.agent_model
+                if not provider_changed
+                else None
+            )
+            or model_defaults.name
+        )
+        model_name_override = generic_model_name or model_name_alias
+        model_default_name = (
+            model_defaults.name
+            if model_name_override in file_config.model_profiles
+            else model_name_override or model_defaults.name
+        )
+        selected_override_profile = file_config.model_profiles.get(
+            model_name_override or ""
+        )
+        profile_endpoint_satisfies_provider_switch = bool(
+            selected_override_profile is not None
+            and selected_override_profile.provider == model_provider
+            and selected_override_profile.base_url
+        )
+        endpoint_url_satisfies_provider_switch = (
+            model_provider == "openai_compatible" and bool(generic_model_endpoint_url)
         )
         provider_switch_requires_url = (
             provider_changed
             and model_provider in {"ollama", "openai_compatible"}
             and not generic_model_base_url
             and not endpoint_url_satisfies_provider_switch
+            and not profile_endpoint_satisfies_provider_switch
         )
         if provider_switch_requires_url:
             required_url_env = "DEEPAGENT_MODEL_BASE_URL"
@@ -2982,22 +3020,6 @@ class RuntimeConfig:
                 "or set a non-empty [model].name in deepagent.toml."
             )
 
-        model_name = (
-            generic_model_name
-            or model_name_alias
-            or (
-                file_config.extensions.agent_model
-                if not provider_changed
-                else None
-            )
-            or model_defaults.name
-        )
-        model_name_override = generic_model_name or model_name_alias
-        model_default_name = (
-            model_defaults.name
-            if model_name_override in file_config.model_profiles
-            else model_name_override or model_defaults.name
-        )
         model_choices = tuple(
             dict.fromkeys(
                 [
@@ -3101,6 +3123,7 @@ class RuntimeConfig:
             generic_model_reasoning or model_reasoning_alias,
             default=active_model_defaults.reasoning_effort,
         )
+        model_reasoning_override = bool(generic_model_reasoning or model_reasoning_alias)
         recursion_limit = normalize_recursion_limit(
             (
                 overrides.recursion_limit
@@ -3123,6 +3146,13 @@ class RuntimeConfig:
             temperature=model_temperature,
             repeat_penalty=model_repeat_penalty,
             disable_streaming=model_disable_streaming,
+            runtime_override_fields=(
+                frozenset({"base_url"})
+                if generic_model_base_url
+                or model_base_url_alias
+                or generic_model_endpoint_url
+                else frozenset()
+            ),
         )
         active_runtime_model = resolve_model_profile_defaults(
             runtime_default_model,
@@ -3198,6 +3228,14 @@ class RuntimeConfig:
             model_api_key_override=model_api_key_override,
             model_default_name=model_default_name,
             model_default_choices=model_defaults.models,
+            model_reasoning_override=model_reasoning_override,
+            model_base_url_override=(
+                bool(
+                    generic_model_base_url
+                    or model_base_url_alias
+                    or generic_model_endpoint_url
+                )
+            ),
         )
 
 
@@ -3321,6 +3359,11 @@ def runtime_default_model_profile(config: RuntimeConfig) -> ModelDefaults:
         ),
         disable_streaming=normalize_disable_streaming(
             getattr(config, "model_disable_streaming", False)
+        ),
+        runtime_override_fields=(
+            frozenset({"base_url"})
+            if getattr(config, "model_base_url_override", False)
+            else frozenset()
         ),
     )
 
@@ -3853,20 +3896,29 @@ def has_nested_child_subagents(subagent: SubagentConfig) -> bool:
 def inherited_tools_for_model(
     *,
     inherited_tools: list[Any],
+    sanitized_inherited_tools: list[Any] | None = None,
     inherited_provider: ModelProvider,
     effective_provider: ModelProvider,
 ) -> list[Any]:
     """Return inherited tools adjusted for a subagent's effective model provider."""
     if effective_provider == inherited_provider:
-        return list(inherited_tools)
+        return list(
+            sanitized_inherited_tools
+            if sanitized_inherited_tools is not None
+            else inherited_tools
+        )
     return sanitize_tools_for_model(effective_provider, list(inherited_tools))
 
 
 def reasoning_level_for_profile(
     model_profile: ModelDefaults,
     fallback: ReasoningLevel,
+    *,
+    fallback_is_explicit: bool = False,
 ) -> ReasoningLevel:
     """Return the reasoning level to use when building a profile-backed model."""
+    if fallback_is_explicit:
+        return fallback
     if "reasoning_effort" in model_profile.explicit_fields:
         return model_profile.reasoning_effort
     if (
@@ -3887,6 +3939,7 @@ def build_static_sync_subagent_spec(
     reasoning_level: ReasoningLevel,
     inherited_model: ModelDefaults,
     project_root: Path | None,
+    reasoning_level_is_explicit: bool = False,
 ) -> dict[str, Any]:
     """Build a sync subagent spec for configured graph creation."""
     effective_model = resolve_runtime_model_profile(
@@ -3897,6 +3950,7 @@ def build_static_sync_subagent_spec(
     effective_reasoning_level = reasoning_level_for_profile(
         effective_model,
         reasoning_level,
+        fallback_is_explicit=reasoning_level_is_explicit,
     )
     inherited_model_tools = inherited_tools_for_model(
         inherited_tools=inherited_tools,
@@ -3940,6 +3994,7 @@ def build_static_sync_subagent_spec(
             backend=backend,
             inherited_tools=effective_tools,
             reasoning_level=effective_reasoning_level,
+            reasoning_level_is_explicit=reasoning_level_is_explicit,
             inherited_model=effective_model,
             project_root=project_root,
         )
@@ -4003,6 +4058,7 @@ def build_graph_subagent_specs(
             backend=resolved_backend,
             inherited_tools=list(inherited_tools or []),
             reasoning_level=config.default_reasoning,
+            reasoning_level_is_explicit=config.model_reasoning_override,
             inherited_model=resolve_runtime_model_profile(config),
             project_root=project_root,
         )
@@ -4327,9 +4383,11 @@ class AgentRuntime:
         self,
         *,
         reasoning_level: ReasoningLevel,
+        reasoning_level_is_explicit: bool,
         selected_model_profile: ModelDefaults,
         backend: Any,
         inherited_tools: list[Any],
+        sanitized_inherited_tools: list[Any],
         thread_id: str | None,
         mcp_session_id: str | None,
     ) -> list[Any]:
@@ -4342,9 +4400,11 @@ class AgentRuntime:
                 subagent,
                 registry=registry,
                 reasoning_level=reasoning_level,
+                reasoning_level_is_explicit=reasoning_level_is_explicit,
                 inherited_model=selected_model_profile,
                 backend=backend,
                 inherited_tools=inherited_tools,
+                sanitized_inherited_tools=sanitized_inherited_tools,
                 thread_id=thread_id,
                 mcp_session_id=mcp_session_id,
             )
@@ -4357,9 +4417,11 @@ class AgentRuntime:
         *,
         registry: dict[str, SubagentConfig],
         reasoning_level: ReasoningLevel,
+        reasoning_level_is_explicit: bool,
         inherited_model: ModelDefaults,
         backend: Any,
         inherited_tools: list[Any],
+        sanitized_inherited_tools: list[Any],
         thread_id: str | None,
         mcp_session_id: str | None,
     ) -> dict[str, Any]:
@@ -4372,6 +4434,7 @@ class AgentRuntime:
         effective_reasoning_level = reasoning_level_for_profile(
             effective_model,
             reasoning_level,
+            fallback_is_explicit=reasoning_level_is_explicit,
         )
         raw_own_tools = await self._get_mcp_tools(
             subagent.mcp_servers,
@@ -4384,6 +4447,7 @@ class AgentRuntime:
         )
         inherited_model_tools = inherited_tools_for_model(
             inherited_tools=inherited_tools,
+            sanitized_inherited_tools=sanitized_inherited_tools,
             inherited_provider=inherited_model.provider,
             effective_provider=effective_model.provider,
         )
@@ -4428,9 +4492,11 @@ class AgentRuntime:
                 child,
                 registry=registry,
                 reasoning_level=effective_reasoning_level,
+                reasoning_level_is_explicit=reasoning_level_is_explicit,
                 inherited_model=effective_model,
                 backend=backend,
-                inherited_tools=effective_tools,
+                inherited_tools=raw_own_tools if has_configured_own_tools else inherited_tools,
+                sanitized_inherited_tools=effective_tools,
                 thread_id=thread_id,
                 mcp_session_id=mcp_session_id,
             )
@@ -4490,9 +4556,14 @@ class AgentRuntime:
             self.config,
             selected_model,
         )
+        reasoning_level_is_explicit = (
+            self.config.model_reasoning_override
+            or reasoning_level != self.config.default_reasoning
+        )
         effective_reasoning_level = reasoning_level_for_profile(
             selected_model_profile,
             reasoning_level,
+            fallback_is_explicit=reasoning_level_is_explicit,
         )
         mcp_scope = self._mcp_scope(
             mcp_session_id=mcp_session_id,
@@ -4513,12 +4584,13 @@ class AgentRuntime:
                     model_profile=selected_model_profile,
                 )
                 rag_tool_enabled = self._rag_service is not None
+                raw_main_tools = await self._build_main_tools(
+                    thread_id=thread_id,
+                    mcp_session_id=mcp_session_id,
+                )
                 main_tools = sanitize_tools_for_model(
                     selected_model_profile.provider,
-                    await self._build_main_tools(
-                        thread_id=thread_id,
-                        mcp_session_id=mcp_session_id,
-                    ),
+                    raw_main_tools,
                 )
                 middleware = build_agent_middleware(
                     config=self.config,
@@ -4534,9 +4606,11 @@ class AgentRuntime:
                 )
                 subagent_specs = await self._build_runtime_subagent_specs(
                     reasoning_level=effective_reasoning_level,
+                    reasoning_level_is_explicit=reasoning_level_is_explicit,
                     selected_model_profile=selected_model_profile,
                     backend=backend,
-                    inherited_tools=main_tools,
+                    inherited_tools=raw_main_tools,
+                    sanitized_inherited_tools=main_tools,
                     thread_id=thread_id,
                     mcp_session_id=mcp_session_id,
                 )

--- a/chainagents/runtime/core.py
+++ b/chainagents/runtime/core.py
@@ -2015,7 +2015,7 @@ def rebase_model_profile_defaults(
         "repeat_penalty",
         "disable_streaming",
     ):
-        if field_name not in explicit_fields:
+        if field_name in base_model.runtime_override_fields or field_name not in explicit_fields:
             updates[field_name] = getattr(base_model, field_name)
 
     if not updates:
@@ -2836,6 +2836,8 @@ class RuntimeConfig:
         model_default_choices: Runtime default model list before profile names are added.
         model_reasoning_override: Whether reasoning was explicitly overridden at runtime.
         model_base_url_override: Whether the model endpoint was overridden at runtime.
+        model_temperature_override: Whether temperature was overridden at runtime.
+        model_disable_streaming_override: Whether streaming was overridden at runtime.
     """
 
     database_url: str | None
@@ -2864,6 +2866,8 @@ class RuntimeConfig:
     model_default_choices: tuple[str, ...] = ()
     model_reasoning_override: bool = False
     model_base_url_override: bool = False
+    model_temperature_override: bool = False
+    model_disable_streaming_override: bool = False
 
     @classmethod
     def from_env(
@@ -3101,18 +3105,27 @@ class RuntimeConfig:
             if overrides.model_temperature is not None
             else model_defaults.temperature
         )
+        model_temperature_override = overrides.model_temperature is not None
         model_repeat_penalty = model_defaults.repeat_penalty
+        raw_disable_streaming = os.getenv("DEEPAGENT_MODEL_DISABLE_STREAMING")
+        raw_disable_streaming_for_tool_calls = os.getenv(
+            "DEEPAGENT_MODEL_DISABLE_STREAMING_FOR_TOOL_CALLS"
+        )
+        model_disable_streaming_override = bool(
+            overrides.model_disable_streaming is not None
+            or raw_disable_streaming is not None
+            or raw_disable_streaming_for_tool_calls is not None
+        )
         if overrides.model_disable_streaming is not None:
             model_disable_streaming = normalize_disable_streaming(
                 overrides.model_disable_streaming
             )
         else:
-            raw_disable_streaming = os.getenv("DEEPAGENT_MODEL_DISABLE_STREAMING")
             if raw_disable_streaming is not None:
                 model_disable_streaming = normalize_disable_streaming(raw_disable_streaming)
-            elif os.getenv("DEEPAGENT_MODEL_DISABLE_STREAMING_FOR_TOOL_CALLS") is not None:
+            elif raw_disable_streaming_for_tool_calls is not None:
                 if normalize_disable_streaming_for_tool_calls(
-                    os.getenv("DEEPAGENT_MODEL_DISABLE_STREAMING_FOR_TOOL_CALLS")
+                    raw_disable_streaming_for_tool_calls
                 ):
                     model_disable_streaming = "tool_calling"
                 else:
@@ -3147,11 +3160,24 @@ class RuntimeConfig:
             repeat_penalty=model_repeat_penalty,
             disable_streaming=model_disable_streaming,
             runtime_override_fields=(
-                frozenset({"base_url"})
-                if generic_model_base_url
-                or model_base_url_alias
-                or generic_model_endpoint_url
-                else frozenset()
+                frozenset(
+                    {
+                        field_name
+                        for field_name, enabled in (
+                            (
+                                "base_url",
+                                bool(
+                                    generic_model_base_url
+                                    or model_base_url_alias
+                                    or generic_model_endpoint_url
+                                ),
+                            ),
+                            ("temperature", model_temperature_override),
+                            ("disable_streaming", model_disable_streaming_override),
+                        )
+                        if enabled
+                    }
+                )
             ),
         )
         active_runtime_model = resolve_model_profile_defaults(
@@ -3236,6 +3262,8 @@ class RuntimeConfig:
                     or generic_model_endpoint_url
                 )
             ),
+            model_temperature_override=model_temperature_override,
+            model_disable_streaming_override=model_disable_streaming_override,
         )
 
 
@@ -3361,9 +3389,27 @@ def runtime_default_model_profile(config: RuntimeConfig) -> ModelDefaults:
             getattr(config, "model_disable_streaming", False)
         ),
         runtime_override_fields=(
-            frozenset({"base_url"})
-            if getattr(config, "model_base_url_override", False)
-            else frozenset()
+            frozenset(
+                {
+                    field_name
+                    for field_name, enabled in (
+                        ("base_url", getattr(config, "model_base_url_override", False)),
+                        (
+                            "temperature",
+                            getattr(config, "model_temperature_override", False),
+                        ),
+                        (
+                            "disable_streaming",
+                            getattr(
+                                config,
+                                "model_disable_streaming_override",
+                                False,
+                            ),
+                        ),
+                    )
+                    if enabled
+                }
+            )
         ),
     )
 
@@ -4532,6 +4578,7 @@ class AgentRuntime:
         reasoning_level: ReasoningLevel,
         *,
         model_name: str | None = None,
+        reasoning_level_is_explicit: bool = False,
         thread_id: str | None = None,
         async_subagent_url_override: str | None = None,
         mcp_session_id: str | None = None,
@@ -4541,6 +4588,7 @@ class AgentRuntime:
         Args:
             reasoning_level: The reasoning level value.
             model_name: The model name value.
+            reasoning_level_is_explicit: Whether reasoning was set for this run.
             thread_id: Conversation thread identifier.
             async_subagent_url_override: The async subagent URL override value.
             mcp_session_id: MCP session identifier.
@@ -4558,6 +4606,7 @@ class AgentRuntime:
         )
         reasoning_level_is_explicit = (
             self.config.model_reasoning_override
+            or reasoning_level_is_explicit
             or reasoning_level != self.config.default_reasoning
         )
         effective_reasoning_level = reasoning_level_for_profile(

--- a/chainagents/runtime/core.py
+++ b/chainagents/runtime/core.py
@@ -3711,6 +3711,18 @@ def has_nested_child_subagents(subagent: SubagentConfig) -> bool:
     return bool(subagent.subagents or subagent.nested_subagent_names)
 
 
+def inherited_tools_for_model(
+    *,
+    inherited_tools: list[Any],
+    inherited_provider: ModelProvider,
+    effective_provider: ModelProvider,
+) -> list[Any]:
+    """Return inherited tools adjusted for a subagent's effective model provider."""
+    if effective_provider == inherited_provider:
+        return list(inherited_tools)
+    return sanitize_tools_for_model(effective_provider, list(inherited_tools))
+
+
 def build_static_sync_subagent_spec(
     config: RuntimeConfig,
     subagent: SubagentConfig,
@@ -3728,7 +3740,12 @@ def build_static_sync_subagent_spec(
         subagent.model,
         inherited_model=inherited_model,
     )
-    effective_tools = list(inherited_tools)
+    inherited_model_tools = inherited_tools_for_model(
+        inherited_tools=inherited_tools,
+        inherited_provider=inherited_model.provider,
+        effective_provider=effective_model.provider,
+    )
+    effective_tools = inherited_model_tools
     middleware = build_agent_middleware(
         config=config,
         reasoning_level=reasoning_level,
@@ -3746,7 +3763,13 @@ def build_static_sync_subagent_spec(
             if subagent.model
             else None
         )
+        subagent_tools = (
+            inherited_model_tools
+            if subagent.model and effective_model.provider != inherited_model.provider
+            else []
+        )
         return subagent.to_deepagents_spec(
+            tools=subagent_tools,
             middleware=middleware,
             model=subagent_model,
         )
@@ -4196,7 +4219,12 @@ class AgentRuntime:
                 mcp_session_id=mcp_session_id,
             ),
         )
-        effective_tools = own_tools or list(inherited_tools)
+        inherited_model_tools = inherited_tools_for_model(
+            inherited_tools=inherited_tools,
+            inherited_provider=inherited_model.provider,
+            effective_provider=effective_model.provider,
+        )
+        effective_tools = own_tools or inherited_model_tools
         middleware = build_agent_middleware(
             config=self.config,
             reasoning_level=reasoning_level,
@@ -4205,6 +4233,13 @@ class AgentRuntime:
             project_root=self.project_root,
         )
         if not has_nested_child_subagents(subagent):
+            subagent_tools = own_tools
+            if (
+                not subagent_tools
+                and subagent.model
+                and effective_model.provider != inherited_model.provider
+            ):
+                subagent_tools = inherited_model_tools
             subagent_model = (
                 self._build_model(
                     reasoning_level,
@@ -4214,7 +4249,7 @@ class AgentRuntime:
                 else None
             )
             return subagent.to_deepagents_spec(
-                tools=own_tools,
+                tools=subagent_tools,
                 middleware=middleware,
                 model=subagent_model,
             )

--- a/chainagents/runtime/core.py
+++ b/chainagents/runtime/core.py
@@ -3208,12 +3208,12 @@ class RuntimeConfig:
             if rag_embedding_provider == "auto":
                 rag_model_provider = active_runtime_model.provider
                 rag_model_base_url = active_runtime_model.base_url
-            elif rag_embedding_provider == runtime_default_model.provider:
-                rag_model_provider = runtime_default_model.provider
-                rag_model_base_url = runtime_default_model.base_url
             elif rag_embedding_provider == active_runtime_model.provider:
                 rag_model_provider = active_runtime_model.provider
                 rag_model_base_url = active_runtime_model.base_url
+            elif rag_embedding_provider == runtime_default_model.provider:
+                rag_model_provider = runtime_default_model.provider
+                rag_model_base_url = runtime_default_model.base_url
             elif rag_embedding_provider == "ollama":
                 rag_model_provider = "ollama"
                 rag_model_base_url = DEFAULT_OLLAMA_BASE_URL

--- a/chainagents/runtime/core.py
+++ b/chainagents/runtime/core.py
@@ -1702,6 +1702,10 @@ class ModelDefaults:
         temperature: The temperature value.
         repeat_penalty: The repeat penalty value.
         disable_streaming: Whether to disable model streaming.
+        cross_provider_base_url: Runtime endpoint override for provider-switched
+            profiles.
+        cross_provider_endpoint_query: Runtime endpoint query for provider-switched
+            profiles.
         explicit_fields: Profile fields explicitly set in TOML.
         runtime_override_fields: Fields explicitly overridden at runtime.
     """
@@ -1718,6 +1722,8 @@ class ModelDefaults:
     temperature: float = DEFAULT_TEMPERATURE
     repeat_penalty: float | None = None
     disable_streaming: DisableStreaming = False
+    cross_provider_base_url: str | None = None
+    cross_provider_endpoint_query: tuple[tuple[str, str], ...] = ()
     explicit_fields: frozenset[str] = field(
         default_factory=frozenset,
         compare=False,
@@ -1995,8 +2001,27 @@ def rebase_model_profile_defaults(
     if model_profile.provider != base_model.provider:
         updates: dict[str, Any] = {}
         if "cross_provider_base_url" in runtime_override_fields:
-            updates["base_url"] = base_model.base_url
-            updates["endpoint_query"] = base_model.endpoint_query
+            updates["base_url"] = (
+                base_model.cross_provider_base_url or base_model.base_url
+            )
+            updates["endpoint_query"] = (
+                base_model.cross_provider_endpoint_query
+                or base_model.endpoint_query
+            )
+        for field_name in ("temperature", "disable_streaming"):
+            if field_name in runtime_override_fields:
+                updates[field_name] = getattr(base_model, field_name)
+        if model_profile.runtime_override_fields != runtime_override_fields:
+            updates["runtime_override_fields"] = runtime_override_fields
+        if model_profile.cross_provider_base_url != base_model.cross_provider_base_url:
+            updates["cross_provider_base_url"] = base_model.cross_provider_base_url
+        if (
+            model_profile.cross_provider_endpoint_query
+            != base_model.cross_provider_endpoint_query
+        ):
+            updates["cross_provider_endpoint_query"] = (
+                base_model.cross_provider_endpoint_query
+            )
         if not updates:
             return model_profile
         return replace(model_profile, **updates)
@@ -2027,6 +2052,17 @@ def rebase_model_profile_defaults(
             or field_name not in explicit_fields
         ):
             updates[field_name] = getattr(base_model, field_name)
+    if model_profile.runtime_override_fields != runtime_override_fields:
+        updates["runtime_override_fields"] = runtime_override_fields
+    if model_profile.cross_provider_base_url != base_model.cross_provider_base_url:
+        updates["cross_provider_base_url"] = base_model.cross_provider_base_url
+    if (
+        model_profile.cross_provider_endpoint_query
+        != base_model.cross_provider_endpoint_query
+    ):
+        updates["cross_provider_endpoint_query"] = (
+            base_model.cross_provider_endpoint_query
+        )
 
     if not updates:
         return model_profile
@@ -2848,6 +2884,10 @@ class RuntimeConfig:
         model_base_url_override: Whether the model endpoint was overridden at runtime.
         model_cross_provider_base_url_override: Whether a generic runtime endpoint
             override may apply across profile provider boundaries.
+        model_cross_provider_base_url: Generic runtime endpoint for provider-switched
+            profiles.
+        model_cross_provider_endpoint_query: Generic runtime endpoint query for
+            provider-switched profiles.
         model_temperature_override: Whether temperature was overridden at runtime.
         model_disable_streaming_override: Whether streaming was overridden at runtime.
     """
@@ -2879,6 +2919,8 @@ class RuntimeConfig:
     model_reasoning_override: bool = False
     model_base_url_override: bool = False
     model_cross_provider_base_url_override: bool = False
+    model_cross_provider_base_url: str | None = None
+    model_cross_provider_endpoint_query: tuple[tuple[str, str], ...] = ()
     model_temperature_override: bool = False
     model_disable_streaming_override: bool = False
 
@@ -2977,6 +3019,16 @@ class RuntimeConfig:
         selected_override_profile = file_config.model_profiles.get(
             model_name_override or ""
         )
+        if (
+            model_provider_override
+            and selected_override_profile is not None
+            and selected_override_profile.provider != model_provider
+        ):
+            raise ValueError(
+                f"Model provider override '{model_provider}' does not match "
+                f"selected profile '{model_name_override}' provider "
+                f"'{selected_override_profile.provider}'."
+            )
         profile_endpoint_satisfies_provider_switch = bool(
             selected_override_profile is not None
             and selected_override_profile.provider == model_provider
@@ -3063,7 +3115,39 @@ class RuntimeConfig:
             file_config.model_profiles,
             model_name,
         )
+        cross_provider_model_base_url = (
+            generic_model_base_url if generic_model_base_url_override else None
+        )
+        cross_provider_model_endpoint_query: tuple[tuple[str, str], ...] = ()
         model_endpoint_query = model_defaults.endpoint_query
+        if (
+            generic_model_endpoint_url
+            and model_name in file_config.model_profiles
+            and active_model_defaults.provider != model_provider
+        ):
+            if active_model_defaults.provider == "anthropic":
+                (
+                    cross_provider_model_base_url,
+                    cross_provider_model_endpoint_query,
+                ) = normalize_anthropic_endpoint_url(
+                    generic_model_endpoint_url,
+                    required_message=(
+                        "The Anthropic model endpoint URL cannot be empty."
+                    ),
+                )
+            elif active_model_defaults.provider == "openai_compatible":
+                (
+                    cross_provider_model_base_url,
+                    cross_provider_model_endpoint_query,
+                ) = normalize_openai_endpoint_url(
+                    generic_model_endpoint_url,
+                    required_message="The model endpoint URL cannot be empty.",
+                )
+            else:
+                raise ValueError(
+                    "DEEPAGENT_MODEL_ENDPOINT_URL can only target "
+                    "provider-switched Anthropic or OpenAI-compatible profiles."
+                )
         if model_provider == "anthropic":
             if generic_model_endpoint_url:
                 model_base_url, model_endpoint_query = normalize_anthropic_endpoint_url(
@@ -3158,7 +3242,7 @@ class RuntimeConfig:
                 model_disable_streaming = model_defaults.disable_streaming
         default_reasoning = normalize_reasoning_level(
             generic_model_reasoning or model_reasoning_alias,
-            default=active_model_defaults.reasoning_effort,
+            default=model_defaults.reasoning_effort,
         )
         model_reasoning_override = bool(generic_model_reasoning or model_reasoning_alias)
         recursion_limit = normalize_recursion_limit(
@@ -3183,6 +3267,8 @@ class RuntimeConfig:
             temperature=model_temperature,
             repeat_penalty=model_repeat_penalty,
             disable_streaming=model_disable_streaming,
+            cross_provider_base_url=cross_provider_model_base_url,
+            cross_provider_endpoint_query=cross_provider_model_endpoint_query,
             runtime_override_fields=(
                 frozenset(
                     {
@@ -3198,7 +3284,7 @@ class RuntimeConfig:
                             ),
                             (
                                 "cross_provider_base_url",
-                                generic_model_base_url_override,
+                                bool(cross_provider_model_base_url),
                             ),
                             ("temperature", model_temperature_override),
                             ("disable_streaming", model_disable_streaming_override),
@@ -3290,7 +3376,13 @@ class RuntimeConfig:
                     or generic_model_endpoint_url
                 )
             ),
-            model_cross_provider_base_url_override=generic_model_base_url_override,
+            model_cross_provider_base_url_override=bool(
+                cross_provider_model_base_url
+            ),
+            model_cross_provider_base_url=cross_provider_model_base_url,
+            model_cross_provider_endpoint_query=(
+                cross_provider_model_endpoint_query
+            ),
             model_temperature_override=model_temperature_override,
             model_disable_streaming_override=model_disable_streaming_override,
         )
@@ -3416,6 +3508,14 @@ def runtime_default_model_profile(config: RuntimeConfig) -> ModelDefaults:
         ),
         disable_streaming=normalize_disable_streaming(
             getattr(config, "model_disable_streaming", False)
+        ),
+        cross_provider_base_url=getattr(
+            config,
+            "model_cross_provider_base_url",
+            None,
+        ),
+        cross_provider_endpoint_query=tuple(
+            getattr(config, "model_cross_provider_endpoint_query", ())
         ),
         runtime_override_fields=(
             frozenset(

--- a/chainagents/runtime/core.py
+++ b/chainagents/runtime/core.py
@@ -1702,6 +1702,7 @@ class ModelDefaults:
         temperature: The temperature value.
         repeat_penalty: The repeat penalty value.
         disable_streaming: Whether to disable model streaming.
+        explicit_fields: Profile fields explicitly set in TOML.
     """
 
     provider: ModelProvider = DEFAULT_MODEL_PROVIDER
@@ -1716,6 +1717,11 @@ class ModelDefaults:
     temperature: float = DEFAULT_TEMPERATURE
     repeat_penalty: float | None = None
     disable_streaming: DisableStreaming = False
+    explicit_fields: frozenset[str] = field(
+        default_factory=frozenset,
+        compare=False,
+        repr=False,
+    )
 
 
 def _parse_model_names(value: Any, *, field_name: str) -> tuple[str, ...]:
@@ -1744,8 +1750,11 @@ def parse_model_profile_defaults(
             f"The top-level '{field_prefix.strip('[]')}' config must be a table/object."
         )
 
+    explicit_fields: set[str] = set()
     base_provider = base.provider if base is not None else DEFAULT_MODEL_PROVIDER
     provider_is_explicit = "provider" in raw_model
+    if provider_is_explicit:
+        explicit_fields.add("provider")
     provider = normalize_model_provider(
         raw_model.get("provider"),
         default=base_provider,
@@ -1756,14 +1765,19 @@ def parse_model_profile_defaults(
 
     raw_models = raw_model.get("models") if "models" in raw_model else None
     parsed_models = _parse_model_names(raw_models, field_name=f"{field_prefix}.models")
+    if raw_models is not None:
+        explicit_fields.add("models")
     if raw_models is None and base is not None and not provider_changed:
         parsed_models = base.models
 
     raw_name = str(raw_model.get("name", "")).strip() if "name" in raw_model else ""
     if raw_name:
+        explicit_fields.add("name")
+    if raw_name:
         name = raw_name
     elif parsed_models:
         name = parsed_models[0]
+        explicit_fields.add("name")
     elif base is not None and not provider_changed:
         name = base.name
     else:
@@ -1781,6 +1795,14 @@ def parse_model_profile_defaults(
     raw_base_url = normalize_optional_string(raw_model.get("base_url"))
     raw_endpoint_url = raw_model.get("endpoint_url")
     has_endpoint_url = normalize_optional_string(raw_endpoint_url) is not None
+    endpoint_is_explicit = bool(
+        raw_base_url is not None
+        or has_endpoint_url
+        or "endpoint" in raw_model
+        or "port" in raw_model
+    )
+    if endpoint_is_explicit:
+        explicit_fields.update({"base_url", "endpoint_query"})
     inherits_endpoint = bool(
         base is not None
         and not provider_changed
@@ -1832,6 +1854,8 @@ def parse_model_profile_defaults(
         if "api_key" in raw_model
         else (base.api_key if base is not None and not provider_changed else None)
     )
+    if "api_key" in raw_model:
+        explicit_fields.add("api_key")
     reasoning_effort = (
         normalize_reasoning_level(
             raw_model.get("reasoning_effort"),
@@ -1844,11 +1868,15 @@ def parse_model_profile_defaults(
         if "reasoning_effort" in raw_model or base is None
         else base.reasoning_effort
     )
+    if "reasoning_effort" in raw_model:
+        explicit_fields.add("reasoning_effort")
     thinking = (
         normalize_model_thinking(raw_model.get("thinking"))
         if "thinking" in raw_model or base is None
         else base.thinking
     )
+    if "thinking" in raw_model:
+        explicit_fields.add("thinking")
     temperature = (
         normalize_model_temperature(
             raw_model.get("temperature", raw_model.get("tempreature"))
@@ -1856,11 +1884,15 @@ def parse_model_profile_defaults(
         if "temperature" in raw_model or "tempreature" in raw_model or base is None
         else base.temperature
     )
+    if "temperature" in raw_model or "tempreature" in raw_model:
+        explicit_fields.add("temperature")
     repeat_penalty = (
         normalize_repeat_penalty(raw_model.get("repeat_penalty"))
         if "repeat_penalty" in raw_model or base is None
         else base.repeat_penalty
     )
+    if "repeat_penalty" in raw_model:
+        explicit_fields.add("repeat_penalty")
     disable_streaming = (
         parse_model_disable_streaming(raw_model)
         if (
@@ -1870,6 +1902,11 @@ def parse_model_profile_defaults(
         )
         else base.disable_streaming
     )
+    if (
+        "disable_streaming" in raw_model
+        or "disable_streaming_for_tool_calls" in raw_model
+    ):
+        explicit_fields.add("disable_streaming")
 
     return ModelDefaults(
         provider=provider,
@@ -1884,6 +1921,7 @@ def parse_model_profile_defaults(
         temperature=temperature,
         repeat_penalty=repeat_penalty,
         disable_streaming=disable_streaming,
+        explicit_fields=frozenset(explicit_fields),
     )
 
 
@@ -1927,15 +1965,51 @@ def resolve_model_profile_defaults(
     base_model = inherited_model or default_model
     selected_ref = normalize_optional_string(model_ref)
     if selected_ref and selected_ref in model_profiles:
-        return model_profiles[selected_ref]
+        return rebase_model_profile_defaults(model_profiles[selected_ref], base_model)
     if selected_ref:
         return replace(
             base_model,
             name=selected_ref,
             models=(),
             name_is_explicit=True,
+            explicit_fields=base_model.explicit_fields | frozenset({"name", "models"}),
         )
     return base_model
+
+
+def rebase_model_profile_defaults(
+    model_profile: ModelDefaults,
+    base_model: ModelDefaults,
+) -> ModelDefaults:
+    """Apply runtime base fields to profile values inherited from parsed defaults."""
+    if model_profile.provider != base_model.provider:
+        return model_profile
+
+    explicit_fields = model_profile.explicit_fields
+    updates: dict[str, Any] = {}
+    if "name" not in explicit_fields:
+        updates["name"] = base_model.name
+        updates["name_is_explicit"] = base_model.name_is_explicit
+    if "models" not in explicit_fields:
+        updates["models"] = base_model.models
+    if "base_url" not in explicit_fields:
+        updates["base_url"] = base_model.base_url
+        updates["endpoint_query"] = base_model.endpoint_query
+    if "api_key" not in explicit_fields:
+        updates["api_key"] = base_model.api_key
+    for field_name in (
+        "reasoning_effort",
+        "thinking",
+        "temperature",
+        "repeat_penalty",
+        "disable_streaming",
+    ):
+        if field_name not in explicit_fields:
+            updates[field_name] = getattr(base_model, field_name)
+
+    if not updates:
+        return model_profile
+    return replace(model_profile, **updates)
 
 
 @dataclass(frozen=True)
@@ -2746,6 +2820,7 @@ class RuntimeConfig:
         model_disable_streaming: Whether to disable model streaming.
         model_thinking: Anthropic thinking mode.
         model_profiles: Named model profiles available by profile name.
+        model_api_key_override: Explicit runtime API key override.
     """
 
     database_url: str | None
@@ -2769,6 +2844,7 @@ class RuntimeConfig:
     model_disable_streaming: DisableStreaming = False
     model_thinking: ModelThinking = DEFAULT_MODEL_THINKING
     model_profiles: dict[str, ModelDefaults] = field(default_factory=dict)
+    model_api_key_override: str | None = None
 
     @classmethod
     def from_env(
@@ -2959,8 +3035,13 @@ class RuntimeConfig:
             )
             if generic_model_base_url or model_base_url_alias:
                 model_endpoint_query = ()
+        model_api_key_override = (
+            normalize_optional_string(overrides.model_api_key)
+            if overrides.model_api_key is not None
+            else None
+        )
         if overrides.model_api_key is not None:
-            model_api_key = normalize_optional_string(overrides.model_api_key)
+            model_api_key = model_api_key_override
         else:
             provider_specific_api_key = (
                 normalize_optional_string(os.getenv("ANTHROPIC_API_KEY"))
@@ -2976,11 +3057,6 @@ class RuntimeConfig:
                 provider_specific_api_key
                 or normalize_optional_string(os.getenv("DEEPAGENT_MODEL_API_KEY"))
                 or model_default_api_key
-            )
-        if model_provider == "anthropic" and not model_api_key:
-            raise ValueError(
-                "Anthropic runtime requires DEEPAGENT_MODEL_API_KEY, "
-                "ANTHROPIC_API_KEY, or [model].api_key."
             )
         model_temperature = (
             normalize_model_temperature(overrides.model_temperature)
@@ -3037,15 +3113,46 @@ class RuntimeConfig:
             file_config.model_profiles,
             model_name,
         )
+        active_runtime_api_key = (
+            model_api_key_override
+            or (
+                normalize_optional_string(os.getenv("ANTHROPIC_API_KEY"))
+                if active_runtime_model.provider == "anthropic"
+                else None
+            )
+            or normalize_optional_string(os.getenv("DEEPAGENT_MODEL_API_KEY"))
+            or active_runtime_model.api_key
+        )
+        if active_runtime_model.provider == "anthropic" and not active_runtime_api_key:
+            raise ValueError(
+                "Anthropic runtime requires DEEPAGENT_MODEL_API_KEY, "
+                "ANTHROPIC_API_KEY, or [model].api_key."
+            )
         rag_requested = file_config.rag.enabled and not overrides.disable_rag
         rag = None
         rag_error = None
         if rag_requested:
+            rag_embedding_provider = file_config.rag.embedding.provider
+            if rag_embedding_provider == "auto":
+                rag_model_provider = active_runtime_model.provider
+                rag_model_base_url = active_runtime_model.base_url
+            elif rag_embedding_provider == runtime_default_model.provider:
+                rag_model_provider = runtime_default_model.provider
+                rag_model_base_url = runtime_default_model.base_url
+            elif rag_embedding_provider == active_runtime_model.provider:
+                rag_model_provider = active_runtime_model.provider
+                rag_model_base_url = active_runtime_model.base_url
+            elif rag_embedding_provider == "ollama":
+                rag_model_provider = "ollama"
+                rag_model_base_url = DEFAULT_OLLAMA_BASE_URL
+            else:
+                rag_model_provider = rag_embedding_provider
+                rag_model_base_url = ""
             try:
                 rag = resolve_rag_config(
                     file_config.rag,
-                    model_provider=active_runtime_model.provider,
-                    model_base_url=active_runtime_model.base_url,
+                    model_provider=rag_model_provider,
+                    model_base_url=rag_model_base_url,
                 )
             except ValueError as exc:
                 rag_error = str(exc)
@@ -3072,6 +3179,7 @@ class RuntimeConfig:
             model_disable_streaming=model_disable_streaming,
             model_thinking=model_defaults.thinking,
             model_profiles=file_config.model_profiles,
+            model_api_key_override=model_api_key_override,
         )
 
 
@@ -3214,17 +3322,19 @@ def model_api_key_for_profile(
     model_profile: ModelDefaults,
 ) -> str | None:
     """Return the effective API key for a resolved model profile."""
+    if config.model_api_key_override:
+        return config.model_api_key_override
+    if model_profile.provider == "anthropic":
+        provider_key = normalize_optional_string(os.getenv("ANTHROPIC_API_KEY"))
+        if provider_key:
+            return provider_key
+    generic_key = normalize_optional_string(os.getenv("DEEPAGENT_MODEL_API_KEY"))
+    if generic_key:
+        return generic_key
     if model_profile.api_key:
         return model_profile.api_key
     if model_profile.provider == config.model_provider and config.model_api_key:
         return config.model_api_key
-    if model_profile.provider == "anthropic":
-        return (
-            normalize_optional_string(os.getenv("ANTHROPIC_API_KEY"))
-            or normalize_optional_string(os.getenv("DEEPAGENT_MODEL_API_KEY"))
-        )
-    if model_profile.provider == "openai_compatible":
-        return normalize_optional_string(os.getenv("DEEPAGENT_MODEL_API_KEY"))
     return None
 
 

--- a/chainagents/runtime/core.py
+++ b/chainagents/runtime/core.py
@@ -2987,7 +2987,7 @@ class RuntimeConfig:
             or model_name_alias
             or (
                 file_config.extensions.agent_model
-                if model_provider_override is None
+                if not provider_changed
                 else None
             )
             or model_defaults.name
@@ -3332,7 +3332,12 @@ def resolve_runtime_model_profile(
     inherited_model: ModelDefaults | None = None,
 ) -> ModelDefaults:
     """Resolve a runtime profile-or-model reference."""
-    model_ref = model_name if model_name is not None else config.model_name
+    if model_name is not None:
+        model_ref = model_name
+    elif inherited_model is not None:
+        model_ref = None
+    else:
+        model_ref = config.model_name
     return resolve_model_profile_defaults(
         runtime_default_model_profile(config),
         getattr(config, "model_profiles", {}),
@@ -4485,12 +4490,16 @@ class AgentRuntime:
             self.config,
             selected_model,
         )
+        effective_reasoning_level = reasoning_level_for_profile(
+            selected_model_profile,
+            reasoning_level,
+        )
         mcp_scope = self._mcp_scope(
             mcp_session_id=mcp_session_id,
             thread_id=thread_id,
         )
         cache_key = (
-            reasoning_level,
+            effective_reasoning_level,
             selected_model,
             thread_id,
             async_subagent_url_override,
@@ -4500,7 +4509,7 @@ class AgentRuntime:
             agent = self._agents.get(cache_key)
             if agent is None:
                 model = self._build_model(
-                    reasoning_level,
+                    effective_reasoning_level,
                     model_profile=selected_model_profile,
                 )
                 rag_tool_enabled = self._rag_service is not None
@@ -4513,7 +4522,7 @@ class AgentRuntime:
                 )
                 middleware = build_agent_middleware(
                     config=self.config,
-                    reasoning_level=reasoning_level,
+                    reasoning_level=effective_reasoning_level,
                     model_name=selected_model,
                     source="main-agent",
                     project_root=self.project_root,
@@ -4524,7 +4533,7 @@ class AgentRuntime:
                     memory_namespace=self.config.extensions.agent_memory_namespace,
                 )
                 subagent_specs = await self._build_runtime_subagent_specs(
-                    reasoning_level=reasoning_level,
+                    reasoning_level=effective_reasoning_level,
                     selected_model_profile=selected_model_profile,
                     backend=backend,
                     inherited_tools=main_tools,

--- a/chainagents/runtime/core.py
+++ b/chainagents/runtime/core.py
@@ -14,7 +14,7 @@ import threading
 import tomllib
 from collections.abc import Awaitable, Callable
 from contextlib import AsyncExitStack
-from dataclasses import dataclass
+from dataclasses import dataclass, field, replace
 from functools import cached_property
 from pathlib import Path, PurePosixPath
 from typing import Any, Literal
@@ -1412,12 +1412,14 @@ class SubagentConfig:
         *,
         tools: list[Any] | None = None,
         middleware: list[AgentMiddleware[Any, Any, Any]] | None = None,
+        model: Any | None = None,
     ) -> dict[str, Any]:
         """Convert this object to deepagents spec.
 
         Args:
             tools: The tools value.
             middleware: The middleware value.
+            model: Resolved model object for this subagent.
 
         Returns:
             The converted value.
@@ -1433,7 +1435,9 @@ class SubagentConfig:
             spec["tools"] = tools
         if middleware:
             spec["middleware"] = list(middleware)
-        if self.model:
+        if model is not None:
+            spec["model"] = model
+        elif self.model:
             spec["model"] = self.model
         return spec
 
@@ -1616,6 +1620,7 @@ class ExtensionsConfig:
         agent_memory_namespace: Shared StoreBackend namespace for /memories/.
         agent_memory_files: Startup memory files loaded into the agent prompt.
         agent_reflection: Correction reflection workflow configuration.
+        agent_model: Optional main-agent model profile or raw model name.
         recursion_limit: The recursion limit value.
         mcp_servers: The MCP servers value.
         skills: The skills value.
@@ -1643,6 +1648,7 @@ class ExtensionsConfig:
     agent_memory_namespace: str = DEFAULT_AGENT_MEMORY_NAMESPACE
     agent_memory_files: tuple[str, ...] = DEFAULT_AGENT_MEMORY_FILES
     agent_reflection: ReflectionConfig = ReflectionConfig()
+    agent_model: str | None = None
     recursion_limit: int = DEFAULT_RECURSION_LIMIT
     mcp_servers: dict[str, dict[str, Any]] | None = None
     skills: tuple[str, ...] = ()
@@ -1712,12 +1718,233 @@ class ModelDefaults:
     disable_streaming: DisableStreaming = False
 
 
+def _parse_model_names(value: Any, *, field_name: str) -> tuple[str, ...]:
+    """Parse a TOML model list while preserving order and removing duplicates."""
+    if value is None:
+        return ()
+    if not isinstance(value, list):
+        raise ValueError(f"The {field_name} config must be an array of strings.")
+    parsed_models: list[str] = []
+    for raw_candidate in value:
+        candidate = str(raw_candidate or "").strip()
+        if candidate and candidate not in parsed_models:
+            parsed_models.append(candidate)
+    return tuple(parsed_models)
+
+
+def parse_model_profile_defaults(
+    raw_model: dict[str, Any],
+    *,
+    base: ModelDefaults | None = None,
+    field_prefix: str = "[model]",
+) -> ModelDefaults:
+    """Parse one model default/profile table."""
+    if raw_model and not isinstance(raw_model, dict):
+        raise ValueError(
+            f"The top-level '{field_prefix.strip('[]')}' config must be a table/object."
+        )
+
+    base_provider = base.provider if base is not None else DEFAULT_MODEL_PROVIDER
+    provider_is_explicit = "provider" in raw_model
+    provider = normalize_model_provider(
+        raw_model.get("provider"),
+        default=base_provider,
+    )
+    provider_changed = bool(
+        base is not None and provider_is_explicit and provider != base.provider
+    )
+
+    raw_models = raw_model.get("models") if "models" in raw_model else None
+    parsed_models = _parse_model_names(raw_models, field_name=f"{field_prefix}.models")
+    if raw_models is None and base is not None and not provider_changed:
+        parsed_models = base.models
+
+    raw_name = str(raw_model.get("name", "")).strip() if "name" in raw_model else ""
+    if raw_name:
+        name = raw_name
+    elif parsed_models:
+        name = parsed_models[0]
+    elif base is not None and not provider_changed:
+        name = base.name
+    else:
+        name = DEFAULT_MODEL if provider == "ollama" else ""
+
+    if provider in {"openai_compatible", "anthropic"} and not name:
+        provider_label = (
+            "OpenAI-compatible" if provider == "openai_compatible" else "Anthropic"
+        )
+        raise ValueError(
+            f"{provider_label} model config must define a non-empty 'name' or 'models'."
+        )
+
+    endpoint_query: tuple[tuple[str, str], ...] = ()
+    raw_base_url = normalize_optional_string(raw_model.get("base_url"))
+    raw_endpoint_url = raw_model.get("endpoint_url")
+    has_endpoint_url = normalize_optional_string(raw_endpoint_url) is not None
+    inherits_endpoint = bool(
+        base is not None
+        and not provider_changed
+        and raw_base_url is None
+        and not has_endpoint_url
+        and "endpoint" not in raw_model
+        and "port" not in raw_model
+    )
+    if inherits_endpoint:
+        base_url = base.base_url
+        endpoint_query = base.endpoint_query
+    elif provider == "ollama":
+        if raw_base_url:
+            base_url = normalize_model_base_url(
+                raw_base_url,
+                default=DEFAULT_OLLAMA_BASE_URL,
+            )
+        else:
+            base_url = compose_base_url(
+                raw_model.get("endpoint"),
+                normalize_model_port(raw_model.get("port")),
+            )
+    elif provider == "openai_compatible":
+        required_message = (
+            "OpenAI-compatible model config must define a non-empty "
+            "'base_url' or 'endpoint_url'."
+        )
+        if has_endpoint_url:
+            base_url, endpoint_query = normalize_openai_endpoint_url(
+                raw_endpoint_url,
+                required_message=required_message,
+            )
+        else:
+            base_url = normalize_model_base_url(
+                raw_model.get("base_url"),
+                required_message=required_message,
+            )
+    else:
+        if has_endpoint_url:
+            base_url, endpoint_query = normalize_anthropic_endpoint_url(raw_endpoint_url)
+        else:
+            base_url = normalize_model_base_url(
+                raw_model.get("base_url"),
+                default=DEFAULT_ANTHROPIC_BASE_URL,
+            )
+
+    api_key = (
+        normalize_optional_string(raw_model.get("api_key"))
+        if "api_key" in raw_model
+        else (base.api_key if base is not None and not provider_changed else None)
+    )
+    reasoning_effort = (
+        normalize_reasoning_level(
+            raw_model.get("reasoning_effort"),
+            default=(
+                base.reasoning_effort
+                if base is not None
+                else DEFAULT_REASONING_LEVEL
+            ),
+        )
+        if "reasoning_effort" in raw_model or base is None
+        else base.reasoning_effort
+    )
+    thinking = (
+        normalize_model_thinking(raw_model.get("thinking"))
+        if "thinking" in raw_model or base is None
+        else base.thinking
+    )
+    temperature = (
+        normalize_model_temperature(
+            raw_model.get("temperature", raw_model.get("tempreature"))
+        )
+        if "temperature" in raw_model or "tempreature" in raw_model or base is None
+        else base.temperature
+    )
+    repeat_penalty = (
+        normalize_repeat_penalty(raw_model.get("repeat_penalty"))
+        if "repeat_penalty" in raw_model or base is None
+        else base.repeat_penalty
+    )
+    disable_streaming = (
+        parse_model_disable_streaming(raw_model)
+        if (
+            "disable_streaming" in raw_model
+            or "disable_streaming_for_tool_calls" in raw_model
+            or base is None
+        )
+        else base.disable_streaming
+    )
+
+    return ModelDefaults(
+        provider=provider,
+        base_url=base_url,
+        endpoint_query=endpoint_query,
+        name=name,
+        api_key=api_key,
+        models=parsed_models,
+        name_is_explicit=bool(raw_name or parsed_models),
+        reasoning_effort=reasoning_effort,
+        thinking=thinking,
+        temperature=temperature,
+        repeat_penalty=repeat_penalty,
+        disable_streaming=disable_streaming,
+    )
+
+
+def parse_model_profiles(
+    raw_model: dict[str, Any],
+    *,
+    base: ModelDefaults,
+) -> dict[str, ModelDefaults]:
+    """Parse named model profiles from the [model.profiles] TOML table."""
+    raw_profiles = raw_model.get("profiles", {})
+    if raw_profiles in ({}, None):
+        return {}
+    if not isinstance(raw_profiles, dict):
+        raise ValueError("The [model].profiles config must be a table/object.")
+
+    profiles: dict[str, ModelDefaults] = {}
+    for raw_name, raw_profile in raw_profiles.items():
+        profile_name = str(raw_name).strip()
+        if not profile_name:
+            raise ValueError("Model profile names must be non-empty strings.")
+        if not isinstance(raw_profile, dict):
+            raise ValueError(
+                f"Model profile '{profile_name}' must be a table/object."
+            )
+        profiles[profile_name] = parse_model_profile_defaults(
+            raw_profile,
+            base=base,
+            field_prefix=f"[model.profiles.{profile_name}]",
+        )
+    return profiles
+
+
+def resolve_model_profile_defaults(
+    default_model: ModelDefaults,
+    model_profiles: dict[str, ModelDefaults],
+    model_ref: str | None,
+    *,
+    inherited_model: ModelDefaults | None = None,
+) -> ModelDefaults:
+    """Resolve a profile-or-raw-model reference into concrete model settings."""
+    base_model = inherited_model or default_model
+    selected_ref = normalize_optional_string(model_ref)
+    if selected_ref and selected_ref in model_profiles:
+        return model_profiles[selected_ref]
+    if selected_ref:
+        return replace(
+            base_model,
+            name=selected_ref,
+            models=(),
+            name_is_explicit=True,
+        )
+    return base_model
+
+
 @dataclass(frozen=True)
 class FileConfig:
     """Store resolved virtual file-system settings for the runtime.
 
     Attributes:
         model: Model name or model object used by the runtime.
+        model_profiles: Named model profiles available to agents.
         extensions: The extensions value.
         langfuse: Langfuse tracing configuration.
         rag: The RAG value.
@@ -1725,6 +1952,7 @@ class FileConfig:
 
     model: ModelDefaults
     extensions: ExtensionsConfig
+    model_profiles: dict[str, ModelDefaults] = field(default_factory=dict)
     langfuse: LangfuseConfig = LangfuseConfig()
     rag: RagConfig = RagConfig()
 
@@ -1766,83 +1994,7 @@ def parse_model_defaults(raw_config: dict[str, Any]) -> ModelDefaults:
     raw_model = raw_config.get("model", {})
     if raw_model and not isinstance(raw_model, dict):
         raise ValueError("The top-level 'model' config must be a table/object.")
-
-    provider = normalize_model_provider(raw_model.get("provider"))
-    raw_name = str(raw_model.get("name", "")).strip()
-    raw_models = raw_model.get("models", [])
-    if raw_models and not isinstance(raw_models, list):
-        raise ValueError("The [model].models config must be an array of strings.")
-    parsed_models: list[str] = []
-    for raw_candidate in raw_models:
-        candidate = str(raw_candidate or "").strip()
-        if candidate and candidate not in parsed_models:
-            parsed_models.append(candidate)
-
-    if provider in {"openai_compatible", "anthropic"} and not raw_name and not parsed_models:
-        provider_label = (
-            "OpenAI-compatible" if provider == "openai_compatible" else "Anthropic"
-        )
-        raise ValueError(
-            f"{provider_label} model config must define a non-empty 'name' or 'models'."
-        )
-
-    raw_base_url = str(raw_model.get("base_url", "")).strip()
-    raw_endpoint_url = raw_model.get("endpoint_url")
-    endpoint_query: tuple[tuple[str, str], ...] = ()
-    if provider == "ollama":
-        if raw_base_url:
-            base_url = normalize_model_base_url(
-                raw_base_url,
-                default=DEFAULT_OLLAMA_BASE_URL,
-            )
-        else:
-            base_url = compose_base_url(
-                raw_model.get("endpoint"),
-                normalize_model_port(raw_model.get("port")),
-            )
-    elif provider == "openai_compatible":
-        required_message = (
-            "OpenAI-compatible model config must define a non-empty "
-            "'base_url' or 'endpoint_url'."
-        )
-        if normalize_optional_string(raw_endpoint_url):
-            base_url, endpoint_query = normalize_openai_endpoint_url(
-                raw_endpoint_url,
-                required_message=required_message,
-            )
-        else:
-            base_url = normalize_model_base_url(
-                raw_model.get("base_url"),
-                required_message=required_message,
-            )
-    else:
-        if normalize_optional_string(raw_endpoint_url):
-            base_url, endpoint_query = normalize_anthropic_endpoint_url(raw_endpoint_url)
-        else:
-            base_url = normalize_model_base_url(
-                raw_model.get("base_url"),
-                default=DEFAULT_ANTHROPIC_BASE_URL,
-            )
-
-    return ModelDefaults(
-        provider=provider,
-        base_url=base_url,
-        endpoint_query=endpoint_query,
-        name=raw_name or (parsed_models[0] if parsed_models else DEFAULT_MODEL),
-        api_key=normalize_optional_string(raw_model.get("api_key")),
-        models=tuple(parsed_models),
-        name_is_explicit=bool(raw_name or parsed_models),
-        reasoning_effort=normalize_reasoning_level(
-            raw_model.get("reasoning_effort"),
-            default=DEFAULT_REASONING_LEVEL,
-        ),
-        thinking=normalize_model_thinking(raw_model.get("thinking")),
-        temperature=normalize_model_temperature(
-            raw_model.get("temperature", raw_model.get("tempreature"))
-        ),
-        repeat_penalty=normalize_repeat_penalty(raw_model.get("repeat_penalty")),
-        disable_streaming=parse_model_disable_streaming(raw_model),
-    )
+    return parse_model_profile_defaults(raw_model, field_prefix="[model]")
 
 
 def parse_async_subagent_config(
@@ -2160,6 +2312,7 @@ def parse_extensions_config(raw_config: dict[str, Any], config_path: Path) -> Ex
         agent_section.get("reflection"),
         agent_state=agent_state,
     )
+    agent_model = normalize_optional_string(agent_section.get("model"))
     raw_mcp_servers = mcp_section.get("servers", {})
     mcp_servers: dict[str, dict[str, Any]] = {}
     for name, raw_server in raw_mcp_servers.items():
@@ -2381,6 +2534,7 @@ def parse_extensions_config(raw_config: dict[str, Any], config_path: Path) -> Ex
         agent_memory_namespace=agent_memory_namespace,
         agent_memory_files=agent_memory_files,
         agent_reflection=agent_reflection,
+        agent_model=agent_model,
         recursion_limit=recursion_limit,
         mcp_servers=mcp_servers or None,
         skills=skill_paths,
@@ -2499,6 +2653,7 @@ def load_file_config(config_path: str | Path | None = None) -> FileConfig:
         return FileConfig(
             model=ModelDefaults(),
             extensions=ExtensionsConfig(config_path=None),
+            model_profiles={},
             langfuse=LangfuseConfig(),
             rag=RagConfig(),
         )
@@ -2506,9 +2661,12 @@ def load_file_config(config_path: str | Path | None = None) -> FileConfig:
     with resolved_config_path.open("rb") as fh:
         raw_config = tomllib.load(fh)
 
+    model_defaults = parse_model_defaults(raw_config)
+    raw_model = raw_config.get("model", {})
     return FileConfig(
-        model=parse_model_defaults(raw_config),
+        model=model_defaults,
         extensions=parse_extensions_config(raw_config, resolved_config_path),
+        model_profiles=parse_model_profiles(raw_model, base=model_defaults),
         langfuse=parse_langfuse_config(raw_config),
         rag=parse_rag_config(raw_config, resolved_config_path),
     )
@@ -2587,6 +2745,7 @@ class RuntimeConfig:
         model_endpoint_query: The model endpoint query value.
         model_disable_streaming: Whether to disable model streaming.
         model_thinking: Anthropic thinking mode.
+        model_profiles: Named model profiles available by profile name.
     """
 
     database_url: str | None
@@ -2609,6 +2768,7 @@ class RuntimeConfig:
     model_endpoint_query: tuple[tuple[str, str], ...] = ()
     model_disable_streaming: DisableStreaming = False
     model_thinking: ModelThinking = DEFAULT_MODEL_THINKING
+    model_profiles: dict[str, ModelDefaults] = field(default_factory=dict)
 
     @classmethod
     def from_env(
@@ -2740,14 +2900,26 @@ class RuntimeConfig:
                 "or set a non-empty [model].name in deepagent.toml."
             )
 
-        model_name = generic_model_name or model_name_alias or model_defaults.name
+        model_name = (
+            generic_model_name
+            or model_name_alias
+            or file_config.extensions.agent_model
+            or model_defaults.name
+        )
         model_choices = tuple(
             dict.fromkeys(
                 [
                     model_name,
+                    model_defaults.name,
                     *model_defaults.models,
+                    *file_config.model_profiles.keys(),
                 ]
             )
+        )
+        active_model_defaults = resolve_model_profile_defaults(
+            model_defaults,
+            file_config.model_profiles,
+            model_name,
         )
         model_endpoint_query = model_defaults.endpoint_query
         if model_provider == "anthropic":
@@ -2835,7 +3007,7 @@ class RuntimeConfig:
                 model_disable_streaming = model_defaults.disable_streaming
         default_reasoning = normalize_reasoning_level(
             generic_model_reasoning or model_reasoning_alias,
-            default=model_defaults.reasoning_effort,
+            default=active_model_defaults.reasoning_effort,
         )
         recursion_limit = normalize_recursion_limit(
             (
@@ -2846,6 +3018,25 @@ class RuntimeConfig:
             default=file_config.extensions.recursion_limit,
             field_name="DEEPAGENT_RECURSION_LIMIT",
         )
+        runtime_default_model = ModelDefaults(
+            provider=model_provider,
+            base_url=model_base_url,
+            endpoint_query=model_endpoint_query,
+            name=model_name,
+            api_key=model_api_key,
+            models=model_defaults.models,
+            name_is_explicit=True,
+            reasoning_effort=default_reasoning,
+            thinking=model_defaults.thinking,
+            temperature=model_temperature,
+            repeat_penalty=model_repeat_penalty,
+            disable_streaming=model_disable_streaming,
+        )
+        active_runtime_model = resolve_model_profile_defaults(
+            runtime_default_model,
+            file_config.model_profiles,
+            model_name,
+        )
         rag_requested = file_config.rag.enabled and not overrides.disable_rag
         rag = None
         rag_error = None
@@ -2853,8 +3044,8 @@ class RuntimeConfig:
             try:
                 rag = resolve_rag_config(
                     file_config.rag,
-                    model_provider=model_provider,
-                    model_base_url=model_base_url,
+                    model_provider=active_runtime_model.provider,
+                    model_base_url=active_runtime_model.base_url,
                 )
             except ValueError as exc:
                 rag_error = str(exc)
@@ -2880,6 +3071,7 @@ class RuntimeConfig:
             model_endpoint_query=model_endpoint_query,
             model_disable_streaming=model_disable_streaming,
             model_thinking=model_defaults.thinking,
+            model_profiles=file_config.model_profiles,
         )
 
 
@@ -2966,51 +3158,132 @@ def build_langgraph_run_config(
     return run_config
 
 
+def runtime_default_model_profile(config: RuntimeConfig) -> ModelDefaults:
+    """Return the default model profile represented by flattened runtime fields."""
+    provider = normalize_model_provider(
+        getattr(config, "model_provider", None),
+        default=DEFAULT_MODEL_PROVIDER,
+    )
+    default_base_url = (
+        DEFAULT_ANTHROPIC_BASE_URL
+        if provider == "anthropic"
+        else (DEFAULT_OLLAMA_BASE_URL if provider == "ollama" else "")
+    )
+    return ModelDefaults(
+        provider=provider,
+        base_url=str(getattr(config, "model_base_url", None) or default_base_url),
+        endpoint_query=tuple(getattr(config, "model_endpoint_query", ())),
+        name=str(getattr(config, "model_name", DEFAULT_MODEL)),
+        api_key=getattr(config, "model_api_key", None),
+        models=tuple(getattr(config, "model_choices", ())),
+        name_is_explicit=True,
+        reasoning_effort=normalize_reasoning_level(
+            getattr(config, "default_reasoning", DEFAULT_REASONING_LEVEL),
+        ),
+        thinking=normalize_model_thinking(getattr(config, "model_thinking", None)),
+        temperature=normalize_model_temperature(
+            getattr(config, "model_temperature", DEFAULT_TEMPERATURE)
+        ),
+        repeat_penalty=normalize_repeat_penalty(
+            getattr(config, "model_repeat_penalty", None)
+        ),
+        disable_streaming=normalize_disable_streaming(
+            getattr(config, "model_disable_streaming", False)
+        ),
+    )
+
+
+def resolve_runtime_model_profile(
+    config: RuntimeConfig,
+    model_name: str | None = None,
+    *,
+    inherited_model: ModelDefaults | None = None,
+) -> ModelDefaults:
+    """Resolve a runtime profile-or-model reference."""
+    model_ref = model_name if model_name is not None else config.model_name
+    return resolve_model_profile_defaults(
+        runtime_default_model_profile(config),
+        getattr(config, "model_profiles", {}),
+        model_ref,
+        inherited_model=inherited_model,
+    )
+
+
+def model_api_key_for_profile(
+    config: RuntimeConfig,
+    model_profile: ModelDefaults,
+) -> str | None:
+    """Return the effective API key for a resolved model profile."""
+    if model_profile.api_key:
+        return model_profile.api_key
+    if model_profile.provider == config.model_provider and config.model_api_key:
+        return config.model_api_key
+    if model_profile.provider == "anthropic":
+        return (
+            normalize_optional_string(os.getenv("ANTHROPIC_API_KEY"))
+            or normalize_optional_string(os.getenv("DEEPAGENT_MODEL_API_KEY"))
+        )
+    if model_profile.provider == "openai_compatible":
+        return normalize_optional_string(os.getenv("DEEPAGENT_MODEL_API_KEY"))
+    return None
+
+
 def build_model(
     config: RuntimeConfig,
     reasoning_level: ReasoningLevel,
     *,
     model_name: str | None = None,
+    model_profile: ModelDefaults | None = None,
 ) -> Any:
     """Build model.
 
     Args:
         config: Configuration object used by the operation.
         reasoning_level: The reasoning level value.
-        model_name: The model name value.
+        model_name: The model name or profile reference.
+        model_profile: Already resolved model profile settings.
 
     Returns:
         The constructed model.
     """
-    selected_model = str(model_name or config.model_name).strip() or config.model_name
-    if config.model_provider == "ollama":
+    resolved_profile = model_profile or resolve_runtime_model_profile(
+        config,
+        model_name,
+    )
+    selected_model = resolved_profile.name
+    if resolved_profile.provider == "ollama":
         kwargs: dict[str, Any] = {
             "model": selected_model,
-            "base_url": config.model_base_url,
+            "base_url": resolved_profile.base_url,
             "reasoning": reasoning_level,
-            "temperature": config.model_temperature,
-            "disable_streaming": config.model_disable_streaming,
+            "temperature": resolved_profile.temperature,
+            "disable_streaming": resolved_profile.disable_streaming,
         }
-        if config.model_repeat_penalty is not None:
-            kwargs["repeat_penalty"] = config.model_repeat_penalty
+        if resolved_profile.repeat_penalty is not None:
+            kwargs["repeat_penalty"] = resolved_profile.repeat_penalty
         return ChatOllama(**kwargs)
 
-    if config.model_provider == "anthropic":
+    api_key = model_api_key_for_profile(config, resolved_profile)
+    if resolved_profile.provider == "anthropic":
+        if not api_key:
+            raise ValueError(
+                "Anthropic runtime requires DEEPAGENT_MODEL_API_KEY, "
+                "ANTHROPIC_API_KEY, or [model].api_key."
+            )
         kwargs: dict[str, Any] = {
             "model": selected_model,
-            "base_url": config.model_base_url,
-            "temperature": config.model_temperature,
+            "base_url": resolved_profile.base_url,
+            "temperature": resolved_profile.temperature,
             "effort": reasoning_level,
-            "disable_streaming": config.model_disable_streaming,
+            "disable_streaming": resolved_profile.disable_streaming,
         }
         if should_enable_anthropic_adaptive_thinking(
             selected_model,
-            config.model_thinking,
+            resolved_profile.thinking,
         ):
             kwargs["thinking"] = {"type": "adaptive"}
-        if config.model_api_key:
-            kwargs["api_key"] = config.model_api_key
-        default_query = model_endpoint_query_to_dict(config.model_endpoint_query)
+        kwargs["api_key"] = api_key
+        default_query = model_endpoint_query_to_dict(resolved_profile.endpoint_query)
         if default_query:
             kwargs["default_query"] = default_query
             return AnthropicDefaultQueryChatAnthropic(**kwargs)
@@ -3018,15 +3291,34 @@ def build_model(
 
     kwargs: dict[str, Any] = {
         "model": selected_model,
-        "base_url": config.model_base_url,
-        "api_key": config.model_api_key or "deepagent",
-        "temperature": config.model_temperature,
-        "disable_streaming": config.model_disable_streaming,
+        "base_url": resolved_profile.base_url,
+        "api_key": api_key or "deepagent",
+        "temperature": resolved_profile.temperature,
+        "disable_streaming": resolved_profile.disable_streaming,
     }
-    default_query = model_endpoint_query_to_dict(config.model_endpoint_query)
+    default_query = model_endpoint_query_to_dict(resolved_profile.endpoint_query)
     if default_query:
         kwargs["default_query"] = default_query
     return OpenAICompatibleChatOpenAI(**kwargs)
+
+
+def build_model_for_profile(
+    config: RuntimeConfig,
+    reasoning_level: ReasoningLevel,
+    model_profile: ModelDefaults,
+) -> Any:
+    """Build a model from resolved profile settings."""
+    try:
+        parameters = inspect.signature(build_model).parameters
+    except (TypeError, ValueError):
+        parameters = {}
+    if "model_profile" in parameters:
+        return build_model(
+            config,
+            reasoning_level,
+            model_profile=model_profile,
+        )
+    return build_model(config, reasoning_level, model_name=model_profile.name)
 
 
 def should_enable_anthropic_adaptive_thinking(
@@ -3427,21 +3719,37 @@ def build_static_sync_subagent_spec(
     backend: Any,
     inherited_tools: list[Any],
     reasoning_level: ReasoningLevel,
-    inherited_model_name: str,
+    inherited_model: ModelDefaults,
     project_root: Path | None,
 ) -> dict[str, Any]:
     """Build a sync subagent spec for configured graph creation."""
-    effective_model_name = subagent.model or inherited_model_name
+    effective_model = resolve_runtime_model_profile(
+        config,
+        subagent.model,
+        inherited_model=inherited_model,
+    )
     effective_tools = list(inherited_tools)
     middleware = build_agent_middleware(
         config=config,
         reasoning_level=reasoning_level,
-        model_name=effective_model_name,
+        model_name=effective_model.name,
         source=subagent.name,
         project_root=project_root,
     )
     if not has_nested_child_subagents(subagent):
-        return subagent.to_deepagents_spec(middleware=middleware)
+        subagent_model = (
+            build_model_for_profile(
+                config,
+                reasoning_level,
+                effective_model,
+            )
+            if subagent.model
+            else None
+        )
+        return subagent.to_deepagents_spec(
+            middleware=middleware,
+            model=subagent_model,
+        )
 
     child_specs = [
         build_static_sync_subagent_spec(
@@ -3451,16 +3759,16 @@ def build_static_sync_subagent_spec(
             backend=backend,
             inherited_tools=effective_tools,
             reasoning_level=reasoning_level,
-            inherited_model_name=effective_model_name,
+            inherited_model=effective_model,
             project_root=project_root,
         )
         for child in nested_child_subagents(subagent, registry)
     ]
     runnable_kwargs: dict[str, Any] = {
-        "model": build_model(
+        "model": build_model_for_profile(
             config,
             reasoning_level,
-            model_name=effective_model_name,
+            effective_model,
         ),
         "tools": effective_tools or None,
         "system_prompt": subagent.system_prompt,
@@ -3514,7 +3822,7 @@ def build_graph_subagent_specs(
             backend=resolved_backend,
             inherited_tools=list(inherited_tools or []),
             reasoning_level=config.default_reasoning,
-            inherited_model_name=config.model_name,
+            inherited_model=resolve_runtime_model_profile(config),
             project_root=project_root,
         )
         for subagent in config.extensions.subagents
@@ -3572,7 +3880,8 @@ def create_configured_graph(
     else:
         if config.rag_requested and config.rag_error:
             logger.warning("RAG is configured but unavailable: %s", config.rag_error)
-    main_tools = sanitize_tools_for_model(config.model_provider, tools)
+    main_model_profile = resolve_runtime_model_profile(config)
+    main_tools = sanitize_tools_for_model(main_model_profile.provider, tools)
     subagent_specs = build_graph_subagent_specs(
         config,
         include_async_subagents=include_async_subagents,
@@ -3581,7 +3890,11 @@ def create_configured_graph(
         inherited_tools=main_tools,
     )
     agent_kwargs: dict[str, Any] = {
-        "model": build_model(config, config.default_reasoning),
+        "model": build_model_for_profile(
+            config,
+            config.default_reasoning,
+            main_model_profile,
+        ),
         "tools": main_tools or None,
         "system_prompt": compose_rag_system_prompt(
             compose_agent_system_prompt(
@@ -3833,7 +4146,7 @@ class AgentRuntime:
         self,
         *,
         reasoning_level: ReasoningLevel,
-        selected_model: str,
+        selected_model_profile: ModelDefaults,
         backend: Any,
         inherited_tools: list[Any],
         thread_id: str | None,
@@ -3848,7 +4161,7 @@ class AgentRuntime:
                 subagent,
                 registry=registry,
                 reasoning_level=reasoning_level,
-                inherited_model_name=selected_model,
+                inherited_model=selected_model_profile,
                 backend=backend,
                 inherited_tools=inherited_tools,
                 thread_id=thread_id,
@@ -3863,16 +4176,20 @@ class AgentRuntime:
         *,
         registry: dict[str, SubagentConfig],
         reasoning_level: ReasoningLevel,
-        inherited_model_name: str,
+        inherited_model: ModelDefaults,
         backend: Any,
         inherited_tools: list[Any],
         thread_id: str | None,
         mcp_session_id: str | None,
     ) -> dict[str, Any]:
         """Build one sync subagent spec, compiling it when it has children."""
-        effective_model_name = subagent.model or inherited_model_name
+        effective_model = resolve_runtime_model_profile(
+            self.config,
+            subagent.model,
+            inherited_model=inherited_model,
+        )
         own_tools = sanitize_tools_for_model(
-            self.config.model_provider,
+            effective_model.provider,
             await self._get_mcp_tools(
                 subagent.mcp_servers,
                 thread_id=thread_id,
@@ -3883,14 +4200,23 @@ class AgentRuntime:
         middleware = build_agent_middleware(
             config=self.config,
             reasoning_level=reasoning_level,
-            model_name=effective_model_name,
+            model_name=effective_model.name,
             source=subagent.name,
             project_root=self.project_root,
         )
         if not has_nested_child_subagents(subagent):
+            subagent_model = (
+                self._build_model(
+                    reasoning_level,
+                    model_profile=effective_model,
+                )
+                if subagent.model
+                else None
+            )
             return subagent.to_deepagents_spec(
                 tools=own_tools,
                 middleware=middleware,
+                model=subagent_model,
             )
 
         child_specs = [
@@ -3898,7 +4224,7 @@ class AgentRuntime:
                 child,
                 registry=registry,
                 reasoning_level=reasoning_level,
-                inherited_model_name=effective_model_name,
+                inherited_model=effective_model,
                 backend=backend,
                 inherited_tools=effective_tools,
                 thread_id=thread_id,
@@ -3909,7 +4235,7 @@ class AgentRuntime:
         runnable_kwargs: dict[str, Any] = {
             "model": self._build_model(
                 reasoning_level,
-                model_name=effective_model_name,
+                model_profile=effective_model,
             ),
             "tools": effective_tools or None,
             "system_prompt": subagent.system_prompt,
@@ -3952,7 +4278,14 @@ class AgentRuntime:
         Returns:
             The configured agent for a specific runtime context.
         """
-        selected_model = str(model_name or self.config.model_name).strip() or self.config.model_name
+        selected_model = (
+            str(model_name or self.config.model_name).strip()
+            or self.config.model_name
+        )
+        selected_model_profile = resolve_runtime_model_profile(
+            self.config,
+            selected_model,
+        )
         mcp_scope = self._mcp_scope(
             mcp_session_id=mcp_session_id,
             thread_id=thread_id,
@@ -3969,11 +4302,11 @@ class AgentRuntime:
             if agent is None:
                 model = self._build_model(
                     reasoning_level,
-                    model_name=selected_model,
+                    model_profile=selected_model_profile,
                 )
                 rag_tool_enabled = self._rag_service is not None
                 main_tools = sanitize_tools_for_model(
-                    self.config.model_provider,
+                    selected_model_profile.provider,
                     await self._build_main_tools(
                         thread_id=thread_id,
                         mcp_session_id=mcp_session_id,
@@ -3993,7 +4326,7 @@ class AgentRuntime:
                 )
                 subagent_specs = await self._build_runtime_subagent_specs(
                     reasoning_level=reasoning_level,
-                    selected_model=selected_model,
+                    selected_model_profile=selected_model_profile,
                     backend=backend,
                     inherited_tools=main_tools,
                     thread_id=thread_id,
@@ -4199,6 +4532,7 @@ class AgentRuntime:
         reasoning_level: ReasoningLevel,
         *,
         model_name: str | None = None,
+        model_profile: ModelDefaults | None = None,
     ) -> Any:
         """Build the chat model for the current runtime settings.
 
@@ -4209,6 +4543,12 @@ class AgentRuntime:
         Returns:
             The constructed the chat model for the current runtime settings.
         """
+        if model_profile is not None:
+            return build_model_for_profile(
+                self.config,
+                reasoning_level,
+                model_profile,
+            )
         return build_model(self.config, reasoning_level, model_name=model_name)
 
     def _mcp_scope(

--- a/chainagents/runtime/core.py
+++ b/chainagents/runtime/core.py
@@ -3101,12 +3101,18 @@ class RuntimeConfig:
             if profile_endpoint_only_satisfies_provider_switch
             else (model_defaults.name, *model_defaults.models)
         )
+        profile_choices = tuple(
+            profile_name
+            for profile_name, profile in file_config.model_profiles.items()
+            if not (provider_changed and model_provider_override)
+            or profile.provider == model_provider
+        )
         model_choices = tuple(
             dict.fromkeys(
                 [
                     model_name,
                     *default_model_choices,
-                    *file_config.model_profiles.keys(),
+                    *profile_choices,
                 ]
             )
         )
@@ -4233,6 +4239,12 @@ def build_graph_subagent_specs(
         include_memories=config.agent_state == "stateful",
         memory_namespace=config.extensions.agent_memory_namespace,
     )
+    inherited_model = resolve_runtime_model_profile(config)
+    graph_reasoning_level = reasoning_level_for_profile(
+        inherited_model,
+        config.default_reasoning,
+        fallback_is_explicit=config.model_reasoning_override,
+    )
     subagent_specs: list[Any] = [
         build_static_sync_subagent_spec(
             config,
@@ -4240,9 +4252,9 @@ def build_graph_subagent_specs(
             registry=registry,
             backend=resolved_backend,
             inherited_tools=list(inherited_tools or []),
-            reasoning_level=config.default_reasoning,
+            reasoning_level=graph_reasoning_level,
             reasoning_level_is_explicit=config.model_reasoning_override,
-            inherited_model=resolve_runtime_model_profile(config),
+            inherited_model=inherited_model,
             project_root=project_root,
         )
         for subagent in config.extensions.subagents
@@ -4302,6 +4314,11 @@ def create_configured_graph(
             logger.warning("RAG is configured but unavailable: %s", config.rag_error)
     main_model_profile = resolve_runtime_model_profile(config)
     main_tools = sanitize_tools_for_model(main_model_profile.provider, tools)
+    main_reasoning_level = reasoning_level_for_profile(
+        main_model_profile,
+        config.default_reasoning,
+        fallback_is_explicit=config.model_reasoning_override,
+    )
     subagent_specs = build_graph_subagent_specs(
         config,
         include_async_subagents=include_async_subagents,
@@ -4312,7 +4329,7 @@ def create_configured_graph(
     agent_kwargs: dict[str, Any] = {
         "model": build_model_for_profile(
             config,
-            config.default_reasoning,
+            main_reasoning_level,
             main_model_profile,
         ),
         "tools": main_tools or None,
@@ -4330,7 +4347,7 @@ def create_configured_graph(
         ),
         "middleware": build_agent_middleware(
             config=config,
-            reasoning_level=config.default_reasoning,
+            reasoning_level=main_reasoning_level,
             source="main-agent",
             project_root=PROJECT_ROOT,
         ),

--- a/chainagents/runtime/core.py
+++ b/chainagents/runtime/core.py
@@ -2971,6 +2971,12 @@ class RuntimeConfig:
         endpoint_url_satisfies_provider_switch = (
             model_provider == "openai_compatible" and bool(generic_model_endpoint_url)
         )
+        profile_endpoint_only_satisfies_provider_switch = (
+            provider_changed
+            and profile_endpoint_satisfies_provider_switch
+            and not generic_model_base_url
+            and not endpoint_url_satisfies_provider_switch
+        )
         provider_switch_requires_url = (
             provider_changed
             and model_provider in {"ollama", "openai_compatible"}
@@ -3024,12 +3030,16 @@ class RuntimeConfig:
                 "or set a non-empty [model].name in deepagent.toml."
             )
 
+        default_model_choices = (
+            ()
+            if profile_endpoint_only_satisfies_provider_switch
+            else (model_defaults.name, *model_defaults.models)
+        )
         model_choices = tuple(
             dict.fromkeys(
                 [
                     model_name,
-                    model_defaults.name,
-                    *model_defaults.models,
+                    *default_model_choices,
                     *file_config.model_profiles.keys(),
                 ]
             )
@@ -4620,6 +4630,7 @@ class AgentRuntime:
         )
         cache_key = (
             effective_reasoning_level,
+            reasoning_level_is_explicit,
             selected_model,
             thread_id,
             async_subagent_url_override,

--- a/chainagents/runtime/core.py
+++ b/chainagents/runtime/core.py
@@ -1990,10 +1990,17 @@ def rebase_model_profile_defaults(
     base_model: ModelDefaults,
 ) -> ModelDefaults:
     """Apply runtime base fields to profile values inherited from parsed defaults."""
-    if model_profile.provider != base_model.provider:
-        return model_profile
-
     explicit_fields = model_profile.explicit_fields
+    runtime_override_fields = base_model.runtime_override_fields
+    if model_profile.provider != base_model.provider:
+        updates: dict[str, Any] = {}
+        if "cross_provider_base_url" in runtime_override_fields:
+            updates["base_url"] = base_model.base_url
+            updates["endpoint_query"] = base_model.endpoint_query
+        if not updates:
+            return model_profile
+        return replace(model_profile, **updates)
+
     updates: dict[str, Any] = {}
     if "name" not in explicit_fields:
         updates["name"] = base_model.name
@@ -2001,7 +2008,7 @@ def rebase_model_profile_defaults(
     if "models" not in explicit_fields:
         updates["models"] = base_model.models
     if (
-        "base_url" in base_model.runtime_override_fields
+        "base_url" in runtime_override_fields
         or "base_url" not in explicit_fields
     ):
         updates["base_url"] = base_model.base_url
@@ -2015,7 +2022,10 @@ def rebase_model_profile_defaults(
         "repeat_penalty",
         "disable_streaming",
     ):
-        if field_name in base_model.runtime_override_fields or field_name not in explicit_fields:
+        if (
+            field_name in runtime_override_fields
+            or field_name not in explicit_fields
+        ):
             updates[field_name] = getattr(base_model, field_name)
 
     if not updates:
@@ -2836,6 +2846,8 @@ class RuntimeConfig:
         model_default_choices: Runtime default model list before profile names are added.
         model_reasoning_override: Whether reasoning was explicitly overridden at runtime.
         model_base_url_override: Whether the model endpoint was overridden at runtime.
+        model_cross_provider_base_url_override: Whether a generic runtime endpoint
+            override may apply across profile provider boundaries.
         model_temperature_override: Whether temperature was overridden at runtime.
         model_disable_streaming_override: Whether streaming was overridden at runtime.
     """
@@ -2866,6 +2878,7 @@ class RuntimeConfig:
     model_default_choices: tuple[str, ...] = ()
     model_reasoning_override: bool = False
     model_base_url_override: bool = False
+    model_cross_provider_base_url_override: bool = False
     model_temperature_override: bool = False
     model_disable_streaming_override: bool = False
 
@@ -2914,6 +2927,7 @@ class RuntimeConfig:
             os.getenv("DEEPAGENT_MODEL_BASE_URL")
         )
         generic_model_base_url = override_model_base_url or env_model_base_url or ""
+        generic_model_base_url_override = bool(generic_model_base_url)
         generic_model_base_url_from_env = (
             override_model_base_url is None and env_model_base_url is not None
         )
@@ -3182,6 +3196,10 @@ class RuntimeConfig:
                                     or generic_model_endpoint_url
                                 ),
                             ),
+                            (
+                                "cross_provider_base_url",
+                                generic_model_base_url_override,
+                            ),
                             ("temperature", model_temperature_override),
                             ("disable_streaming", model_disable_streaming_override),
                         )
@@ -3272,6 +3290,7 @@ class RuntimeConfig:
                     or generic_model_endpoint_url
                 )
             ),
+            model_cross_provider_base_url_override=generic_model_base_url_override,
             model_temperature_override=model_temperature_override,
             model_disable_streaming_override=model_disable_streaming_override,
         )
@@ -3404,6 +3423,14 @@ def runtime_default_model_profile(config: RuntimeConfig) -> ModelDefaults:
                     field_name
                     for field_name, enabled in (
                         ("base_url", getattr(config, "model_base_url_override", False)),
+                        (
+                            "cross_provider_base_url",
+                            getattr(
+                                config,
+                                "model_cross_provider_base_url_override",
+                                False,
+                            ),
+                        ),
                         (
                             "temperature",
                             getattr(config, "model_temperature_override", False),

--- a/chainagents/runtime/core.py
+++ b/chainagents/runtime/core.py
@@ -1775,11 +1775,13 @@ def parse_model_profile_defaults(
         explicit_fields.add("name")
     if raw_name:
         name = raw_name
-    elif parsed_models:
+    elif raw_models is not None and parsed_models:
         name = parsed_models[0]
         explicit_fields.add("name")
     elif base is not None and not provider_changed:
         name = base.name
+    elif parsed_models:
+        name = parsed_models[0]
     else:
         name = DEFAULT_MODEL if provider == "ollama" else ""
 
@@ -2821,6 +2823,8 @@ class RuntimeConfig:
         model_thinking: Anthropic thinking mode.
         model_profiles: Named model profiles available by profile name.
         model_api_key_override: Explicit runtime API key override.
+        model_default_name: Runtime default model name before agent/profile selection.
+        model_default_choices: Runtime default model list before profile names are added.
     """
 
     database_url: str | None
@@ -2845,6 +2849,8 @@ class RuntimeConfig:
     model_thinking: ModelThinking = DEFAULT_MODEL_THINKING
     model_profiles: dict[str, ModelDefaults] = field(default_factory=dict)
     model_api_key_override: str | None = None
+    model_default_name: str | None = None
+    model_default_choices: tuple[str, ...] = ()
 
     @classmethod
     def from_env(
@@ -2979,9 +2985,14 @@ class RuntimeConfig:
         model_name = (
             generic_model_name
             or model_name_alias
-            or file_config.extensions.agent_model
+            or (
+                file_config.extensions.agent_model
+                if model_provider_override is None
+                else None
+            )
             or model_defaults.name
         )
+        model_default_name = generic_model_name or model_name_alias or model_defaults.name
         model_choices = tuple(
             dict.fromkeys(
                 [
@@ -3098,7 +3109,7 @@ class RuntimeConfig:
             provider=model_provider,
             base_url=model_base_url,
             endpoint_query=model_endpoint_query,
-            name=model_name,
+            name=model_default_name,
             api_key=model_api_key,
             models=model_defaults.models,
             name_is_explicit=True,
@@ -3180,6 +3191,8 @@ class RuntimeConfig:
             model_thinking=model_defaults.thinking,
             model_profiles=file_config.model_profiles,
             model_api_key_override=model_api_key_override,
+            model_default_name=model_default_name,
+            model_default_choices=model_defaults.models,
         )
 
 
@@ -3281,9 +3294,15 @@ def runtime_default_model_profile(config: RuntimeConfig) -> ModelDefaults:
         provider=provider,
         base_url=str(getattr(config, "model_base_url", None) or default_base_url),
         endpoint_query=tuple(getattr(config, "model_endpoint_query", ())),
-        name=str(getattr(config, "model_name", DEFAULT_MODEL)),
+        name=str(
+            getattr(config, "model_default_name", None)
+            or getattr(config, "model_name", DEFAULT_MODEL)
+        ),
         api_key=getattr(config, "model_api_key", None),
-        models=tuple(getattr(config, "model_choices", ())),
+        models=tuple(
+            getattr(config, "model_default_choices", ())
+            or getattr(config, "model_choices", ())
+        ),
         name_is_explicit=True,
         reasoning_effort=normalize_reasoning_level(
             getattr(config, "default_reasoning", DEFAULT_REASONING_LEVEL),
@@ -4321,20 +4340,26 @@ class AgentRuntime:
             subagent.model,
             inherited_model=inherited_model,
         )
+        raw_own_tools = await self._get_mcp_tools(
+            subagent.mcp_servers,
+            thread_id=thread_id,
+            mcp_session_id=mcp_session_id,
+        )
         own_tools = sanitize_tools_for_model(
             effective_model.provider,
-            await self._get_mcp_tools(
-                subagent.mcp_servers,
-                thread_id=thread_id,
-                mcp_session_id=mcp_session_id,
-            ),
+            raw_own_tools,
         )
         inherited_model_tools = inherited_tools_for_model(
             inherited_tools=inherited_tools,
             inherited_provider=inherited_model.provider,
             effective_provider=effective_model.provider,
         )
-        effective_tools = own_tools or inherited_model_tools
+        has_configured_own_tools = bool(subagent.mcp_servers)
+        effective_tools = (
+            own_tools
+            if has_configured_own_tools
+            else own_tools or inherited_model_tools
+        )
         middleware = build_agent_middleware(
             config=self.config,
             reasoning_level=reasoning_level,
@@ -4348,6 +4373,7 @@ class AgentRuntime:
                 not subagent_tools
                 and subagent.model
                 and effective_model.provider != inherited_model.provider
+                and not has_configured_own_tools
             ):
                 subagent_tools = inherited_model_tools
             subagent_model = (

--- a/deepagent.toml
+++ b/deepagent.toml
@@ -32,6 +32,19 @@ reasoning_effort = "high"
 #thinking = "auto"
 #base_url = "https://api.anthropic.com"
 
+# Named profiles can override any [model] field. They can be selected from
+# Chainlit modes/settings or referenced by [agent].model and subagent model.
+#[model.profiles.fast-local]
+#name = "Qwen3.6-35B-A3B-UD-Q4_K_M.gguf"
+#temperature = 0.1
+#reasoning_effort = "medium"
+#
+#[model.profiles.claude-reviewer]
+#provider = "anthropic"
+#name = "claude-sonnet-4-6"
+#thinking = "auto"
+#api_key = ""  # optional when ANTHROPIC_API_KEY or DEEPAGENT_MODEL_API_KEY is set
+
 [langfuse]
 # Set true to attach Langfuse's LangChain callback handler to agent runs.
 enabled = false
@@ -48,6 +61,8 @@ cwd = "."
 
 [agent]
 state = "stateful"
+# Optional profile or raw model name for the main/supervisor agent.
+# model = "fast-local"
 recursion_limit = 200
 memory_namespace = "filesystem"
 memory_files = ["/memories/AGENTS.md"]
@@ -101,6 +116,7 @@ description = "Researches the current repository, explains architecture, and ide
 system_prompt_file = "prompts/repo-researcher.md"
 skills = ["skills"]
 mcp_servers = ["repo"]
+# model = "claude-reviewer"
 
 [chainlit]
 # Set false to hide model selection in chat settings and Modes.

--- a/deepagent.toml.example
+++ b/deepagent.toml.example
@@ -21,6 +21,19 @@ disable_streaming_for_tool_calls = false
 # thinking = "auto"  # auto, adaptive, or disabled
 # endpoint_url = "https://claude-proxy.example/proxy/v1/messages"
 # api_key = ""  # optional when ANTHROPIC_API_KEY or DEEPAGENT_MODEL_API_KEY is set
+#
+# Named profiles can override any [model] field and can be selected from
+# Chainlit modes/settings or referenced by [agent].model and subagent model.
+[model.profiles.fast-local]
+name = "gemma4:27b"
+temperature = 0
+reasoning_effort = "low"
+
+[model.profiles.claude-reviewer]
+provider = "anthropic"
+name = "claude-sonnet-4-6"
+thinking = "auto"
+# api_key = ""  # optional when ANTHROPIC_API_KEY or DEEPAGENT_MODEL_API_KEY is set
 
 [langfuse]
 # Set true to attach Langfuse's LangChain callback handler to agent runs.
@@ -42,6 +55,8 @@ url = "http://localhost:8000/mcp"
 
 [agent]
 state = "stateful"
+# Optional profile or raw model name for the main/supervisor agent.
+# model = "fast-local"
 # A repo-root AGENTS.md file is loaded automatically into the main agent prompt.
 # Agent-scoped DeepAgents memory is shared across all threads using this namespace.
 # The default preserves existing store-backed /memories/ data from older configs.
@@ -124,7 +139,7 @@ system_prompt_file = "prompts/repo-researcher.md"
 skills = ["skills/research"]
 mcp_servers = ["repo", "docs"]
 nested_subagents = ["reviewer"]
-# model = "gpt-oss:20b"
+# model = "claude-reviewer"
 
 [[subagents.subagents]]
 name = "repo-planner"

--- a/tests/test_chainagents_api.py
+++ b/tests/test_chainagents_api.py
@@ -139,6 +139,7 @@ def test_invoke_runs_prompt_through_agent() -> None:
             "args": ("high",),
             "kwargs": {
                 "model_name": "other-model",
+                "reasoning_level_is_explicit": True,
                 "thread_id": "thread-1",
                 "async_subagent_url_override": None,
                 "mcp_session_id": "session-1",

--- a/tests/test_deepagent_runtime_rag.py
+++ b/tests/test_deepagent_runtime_rag.py
@@ -620,6 +620,41 @@ model = "fast"
     assert active_model.base_url == "http://env-ollama.example:11434"
 
 
+def test_provider_switched_profile_base_url_uses_generic_runtime_override(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Verify generic endpoint overrides replace provider-switched profile URLs."""
+    config_path = tmp_path / "deepagent.toml"
+    config_path.write_text(
+        """
+[model]
+provider = "ollama"
+base_url = "http://127.0.0.1:11434"
+name = "default-local"
+
+[model.profiles.lmstudio]
+provider = "openai_compatible"
+base_url = "https://profile-openai.example/v1"
+name = "tool-model"
+api_key = "profile-key"
+
+[agent]
+model = "lmstudio"
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DEEPAGENT_CONFIG", str(config_path))
+    monkeypatch.setenv("DEEPAGENT_MODEL_BASE_URL", "https://env-openai.example/v1")
+
+    config = deepagent_runtime.RuntimeConfig.from_env()
+    active_model = deepagent_runtime.resolve_runtime_model_profile(config)
+
+    assert active_model.provider == "openai_compatible"
+    assert active_model.name == "tool-model"
+    assert active_model.base_url == "https://env-openai.example/v1"
+
+
 def test_model_profile_temperature_uses_runtime_override(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_deepagent_runtime_rag.py
+++ b/tests/test_deepagent_runtime_rag.py
@@ -783,6 +783,7 @@ api_key = "profile-key"
 
     assert config.model_provider == "openai_compatible"
     assert config.model_name == "lmstudio"
+    assert config.model_choices == ("lmstudio",)
     assert active_model.provider == "openai_compatible"
     assert active_model.base_url == "https://lmstudio.example/v1"
 
@@ -3353,6 +3354,86 @@ def test_get_agent_explicit_default_reasoning_overrides_profile_default(
     )
 
     assert captured["kwargs"]["model"] == "model:review-model:low"
+
+
+def test_get_agent_cache_distinguishes_reasoning_explicitness_for_subagents(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Verify agent caching preserves subagent reasoning explicitness."""
+    created_graphs: list[SimpleNamespace] = []
+
+    def fake_create_deep_agent(**kwargs):
+        """Capture each DeepAgents graph creation call."""
+        graph = SimpleNamespace(kwargs=kwargs)
+        created_graphs.append(graph)
+        return graph
+
+    def fake_build_model(config, reasoning_level, *, model_name=None, model_profile=None):
+        """Capture the effective model and reasoning level."""
+        selected_name = model_profile.name if model_profile is not None else model_name
+        return f"model:{selected_name}:{reasoning_level}"
+
+    monkeypatch.setattr(deepagent_runtime, "create_deep_agent", fake_create_deep_agent)
+    monkeypatch.setattr(deepagent_runtime, "build_model", fake_build_model)
+
+    runtime = AgentRuntime(
+        RuntimeConfig(
+            database_url=None,
+            model_provider="ollama",
+            model_name="main",
+            model_choices=("main", "reviewer"),
+            model_base_url="http://127.0.0.1:11434",
+            model_api_key=None,
+            model_temperature=0.0,
+            default_reasoning="high",
+            persistence_mode="memory",
+            extensions=ExtensionsConfig(
+                config_path=None,
+                subagents=(
+                    SubagentConfig(
+                        name="reviewer",
+                        description="Reviews output.",
+                        system_prompt="Review the work.",
+                        model="reviewer",
+                    ),
+                ),
+            ),
+            model_profiles={
+                "main": deepagent_runtime.ModelDefaults(
+                    provider="ollama",
+                    base_url="http://127.0.0.1:11434",
+                    name="main-model",
+                    reasoning_effort="high",
+                    explicit_fields=frozenset({"name", "reasoning_effort"}),
+                ),
+                "reviewer": deepagent_runtime.ModelDefaults(
+                    provider="ollama",
+                    base_url="http://127.0.0.1:11434",
+                    name="review-model",
+                    reasoning_effort="low",
+                    explicit_fields=frozenset({"name", "reasoning_effort"}),
+                ),
+            },
+        ),
+        project_root=tmp_path,
+    )
+    runtime._store = InMemoryStore()
+    runtime._checkpointer = MemorySaver()
+
+    asyncio.run(runtime.get_agent("high", model_name="main", thread_id="thread-1"))
+    asyncio.run(
+        runtime.get_agent(
+            "high",
+            model_name="main",
+            reasoning_level_is_explicit=True,
+            thread_id="thread-1",
+        )
+    )
+
+    assert len(created_graphs) == 2
+    assert created_graphs[0].kwargs["subagents"][0]["model"] == "model:review-model:low"
+    assert created_graphs[1].kwargs["subagents"][0]["model"] == "model:review-model:high"
 
 
 def test_get_agent_preserves_inherited_tools_for_compiled_nested_subagents(

--- a/tests/test_deepagent_runtime_rag.py
+++ b/tests/test_deepagent_runtime_rag.py
@@ -487,6 +487,43 @@ model = "claude"
     assert model.thinking is None
 
 
+def test_profile_agent_model_does_not_change_raw_model_default_reasoning(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Verify raw model choices keep the base model reasoning default."""
+    config_path = tmp_path / "deepagent.toml"
+    config_path.write_text(
+        """
+[model]
+provider = "ollama"
+base_url = "http://127.0.0.1:11434"
+name = "default-local"
+reasoning_effort = "medium"
+
+[model.profiles.fast]
+name = "fast-local"
+reasoning_effort = "low"
+
+[agent]
+model = "fast"
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DEEPAGENT_CONFIG", str(config_path))
+
+    config = deepagent_runtime.RuntimeConfig.from_env()
+    selected_profile = deepagent_runtime.resolve_runtime_model_profile(config)
+    raw_model = deepagent_runtime.resolve_runtime_model_profile(
+        config,
+        "default-local",
+    )
+
+    assert config.default_reasoning == "medium"
+    assert selected_profile.reasoning_effort == "low"
+    assert raw_model.reasoning_effort == "medium"
+
+
 def test_runtime_config_validates_credentials_against_selected_profile(
     tmp_path: Path,
     monkeypatch,
@@ -655,6 +692,88 @@ model = "lmstudio"
     assert active_model.base_url == "https://env-openai.example/v1"
 
 
+def test_provider_switched_profile_endpoint_url_uses_generic_runtime_override(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Verify endpoint URL overrides can rebase provider-switched profiles."""
+    config_path = tmp_path / "deepagent.toml"
+    config_path.write_text(
+        """
+[model]
+provider = "ollama"
+base_url = "http://127.0.0.1:11434"
+name = "default-local"
+
+[model.profiles.lmstudio]
+provider = "openai_compatible"
+base_url = "https://profile-openai.example/v1"
+name = "tool-model"
+api_key = "profile-key"
+
+[agent]
+model = "lmstudio"
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DEEPAGENT_CONFIG", str(config_path))
+    monkeypatch.setenv(
+        "DEEPAGENT_MODEL_ENDPOINT_URL",
+        (
+            "https://env-openai.example/openai/deployments/tool/chat/completions"
+            "?api-version=2026-01-01"
+        ),
+    )
+
+    config = deepagent_runtime.RuntimeConfig.from_env()
+    active_model = deepagent_runtime.resolve_runtime_model_profile(config)
+
+    assert active_model.provider == "openai_compatible"
+    assert active_model.name == "tool-model"
+    assert active_model.base_url == "https://env-openai.example/openai/deployments/tool"
+    assert active_model.endpoint_query == (("api-version", "2026-01-01"),)
+
+
+def test_rebased_profile_preserves_runtime_overrides_for_child_profiles() -> None:
+    """Verify inherited rebased profiles carry runtime override provenance."""
+    base_model = deepagent_runtime.ModelDefaults(
+        provider="ollama",
+        base_url="http://env-ollama.example:11434",
+        name="default-local",
+        temperature=0.7,
+        runtime_override_fields=frozenset({"base_url", "temperature"}),
+    )
+    main_profile = deepagent_runtime.ModelDefaults(
+        provider="ollama",
+        base_url="http://profile-main.example:11434",
+        name="fast-local",
+        temperature=0.1,
+        explicit_fields=frozenset({"base_url", "name", "temperature"}),
+    )
+    child_profile = deepagent_runtime.ModelDefaults(
+        provider="ollama",
+        base_url="http://profile-child.example:11434",
+        name="child-local",
+        temperature=0.2,
+        explicit_fields=frozenset({"base_url", "name", "temperature"}),
+    )
+
+    rebased_main = deepagent_runtime.rebase_model_profile_defaults(
+        main_profile,
+        base_model,
+    )
+    rebased_child = deepagent_runtime.rebase_model_profile_defaults(
+        child_profile,
+        rebased_main,
+    )
+
+    assert rebased_main.runtime_override_fields == frozenset(
+        {"base_url", "temperature"}
+    )
+    assert rebased_child.base_url == "http://env-ollama.example:11434"
+    assert rebased_child.temperature == 0.7
+
+
 def test_model_profile_temperature_uses_runtime_override(
     tmp_path: Path,
 ) -> None:
@@ -821,6 +940,36 @@ api_key = "profile-key"
     assert config.model_choices == ("lmstudio",)
     assert active_model.provider == "openai_compatible"
     assert active_model.base_url == "https://lmstudio.example/v1"
+
+
+def test_provider_override_rejects_selected_profile_provider_mismatch(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Verify provider overrides cannot select a mismatched named profile."""
+    config_path = tmp_path / "deepagent.toml"
+    config_path.write_text(
+        """
+[model]
+provider = "ollama"
+base_url = "http://127.0.0.1:11434"
+name = "local-default"
+
+[model.profiles.claude-reviewer]
+provider = "anthropic"
+name = "claude-sonnet-4-6"
+api_key = "profile-key"
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DEEPAGENT_CONFIG", str(config_path))
+    monkeypatch.setenv("DEEPAGENT_MODEL_PROVIDER", "openai_compatible")
+    monkeypatch.setenv("DEEPAGENT_MODEL_NAME", "claude-reviewer")
+    monkeypatch.setenv("DEEPAGENT_MODEL_BASE_URL", "https://openai.example/v1")
+    monkeypatch.setenv("DEEPAGENT_MODEL_API_KEY", "openai-key")
+
+    with pytest.raises(ValueError, match="provider.*claude-reviewer"):
+        deepagent_runtime.RuntimeConfig.from_env()
 
 
 def test_same_provider_override_preserves_agent_model_profile(

--- a/tests/test_deepagent_runtime_rag.py
+++ b/tests/test_deepagent_runtime_rag.py
@@ -297,6 +297,44 @@ provider = "auto"
     assert "rag.embedding.model" in config.rag_error
 
 
+def test_runtime_config_keeps_explicit_rag_provider_on_default_model_url(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Verify explicit RAG providers do not inherit selected chat profile URLs."""
+    config_path = tmp_path / "deepagent.toml"
+    config_path.write_text(
+        """
+[model]
+provider = "ollama"
+base_url = "http://127.0.0.1:11434"
+name = "local-chat"
+
+[model.profiles.claude]
+provider = "anthropic"
+name = "claude-sonnet-4-6"
+api_key = "profile-key"
+
+[agent]
+model = "claude"
+
+[rag]
+enabled = true
+
+[rag.embedding]
+provider = "ollama"
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DEEPAGENT_CONFIG", str(config_path))
+
+    config = deepagent_runtime.RuntimeConfig.from_env()
+
+    assert config.rag is not None
+    assert config.rag.embedding.provider == "ollama"
+    assert config.rag.embedding.base_url == "http://127.0.0.1:11434"
+
+
 def test_load_extensions_config_reads_mcp_stateful_flag(
     tmp_path: Path,
     monkeypatch,
@@ -408,6 +446,107 @@ model = "claude"
     assert model.temperature == 0.4
     assert model.effort == "medium"
     assert model.thinking is None
+
+
+def test_runtime_config_validates_credentials_against_selected_profile(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Verify unused top-level providers do not require credentials."""
+    config_path = tmp_path / "deepagent.toml"
+    config_path.write_text(
+        """
+[model]
+provider = "anthropic"
+name = "claude-sonnet-4-6"
+
+[model.profiles.local]
+provider = "ollama"
+base_url = "http://127.0.0.1:11434"
+name = "local-model"
+
+[agent]
+model = "local"
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DEEPAGENT_CONFIG", str(config_path))
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("DEEPAGENT_MODEL_API_KEY", raising=False)
+
+    config = deepagent_runtime.RuntimeConfig.from_env()
+    active_model = deepagent_runtime.resolve_runtime_model_profile(config)
+
+    assert config.model_name == "local"
+    assert active_model.provider == "ollama"
+    assert active_model.name == "local-model"
+
+
+def test_model_profile_api_key_prefers_env_over_profile_toml(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Verify environment credentials override selected profile keys."""
+    from langchain_anthropic import ChatAnthropic
+
+    config_path = tmp_path / "deepagent.toml"
+    config_path.write_text(
+        """
+[model]
+provider = "ollama"
+base_url = "http://127.0.0.1:11434"
+name = "default-local"
+
+[model.profiles.claude]
+provider = "anthropic"
+name = "claude-sonnet-4-6"
+api_key = "stale-profile-key"
+
+[agent]
+model = "claude"
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DEEPAGENT_CONFIG", str(config_path))
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "env-anthropic-key")
+
+    config = deepagent_runtime.RuntimeConfig.from_env()
+    model = deepagent_runtime.build_model(config, "medium")
+
+    assert isinstance(model, ChatAnthropic)
+    assert model.anthropic_api_key.get_secret_value() == "env-anthropic-key"
+
+
+def test_model_profile_inherits_runtime_base_url_override(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Verify inherited profile endpoints are rebased on runtime overrides."""
+    config_path = tmp_path / "deepagent.toml"
+    config_path.write_text(
+        """
+[model]
+provider = "ollama"
+base_url = "http://toml-ollama.example:11434"
+name = "default-local"
+
+[model.profiles.fast]
+name = "fast-local"
+
+[agent]
+model = "fast"
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DEEPAGENT_CONFIG", str(config_path))
+    monkeypatch.setenv("OLLAMA_BASE_URL", "http://env-ollama.example:11434")
+
+    config = deepagent_runtime.RuntimeConfig.from_env()
+    active_model = deepagent_runtime.resolve_runtime_model_profile(config)
+
+    assert config.model_base_url == "http://env-ollama.example:11434"
+    assert active_model.base_url == "http://env-ollama.example:11434"
+    assert active_model.name == "fast-local"
 
 
 def test_build_model_resolves_named_profile_over_raw_model_name(

--- a/tests/test_deepagent_runtime_rag.py
+++ b/tests/test_deepagent_runtime_rag.py
@@ -581,6 +581,40 @@ model = "fast"
     assert active_model.base_url == "http://env-ollama.example:11434"
 
 
+def test_model_profile_temperature_uses_runtime_override(
+    tmp_path: Path,
+) -> None:
+    """Verify runtime temperature overrides replace profile defaults."""
+    config_path = tmp_path / "deepagent.toml"
+    config_path.write_text(
+        """
+[model]
+provider = "ollama"
+base_url = "http://127.0.0.1:11434"
+name = "default-local"
+
+[model.profiles.fast]
+name = "fast-local"
+temperature = 0.1
+
+[agent]
+model = "fast"
+""".strip(),
+        encoding="utf-8",
+    )
+
+    config = deepagent_runtime.RuntimeConfig.from_env(
+        deepagent_runtime.RuntimeConfigOverrides(
+            config_path=config_path,
+            model_temperature=0.7,
+        )
+    )
+    active_model = deepagent_runtime.resolve_runtime_model_profile(config)
+
+    assert active_model.name == "fast-local"
+    assert active_model.temperature == 0.7
+
+
 def test_model_profile_without_name_inherits_default_name_before_models(
     tmp_path: Path,
     monkeypatch,
@@ -1019,6 +1053,39 @@ disable_streaming = false
     config = deepagent_runtime.RuntimeConfig.from_env()
 
     assert config.model_disable_streaming == "tool_calling"
+
+
+def test_model_profile_disable_streaming_uses_runtime_override(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Verify runtime disable_streaming overrides replace profile defaults."""
+    config_path = tmp_path / "deepagent.toml"
+    config_path.write_text(
+        """
+[model]
+provider = "ollama"
+base_url = "http://127.0.0.1:11434"
+name = "default-local"
+disable_streaming = false
+
+[model.profiles.fast]
+name = "fast-local"
+disable_streaming = false
+
+[agent]
+model = "fast"
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DEEPAGENT_CONFIG", str(config_path))
+    monkeypatch.setenv("DEEPAGENT_MODEL_DISABLE_STREAMING", "tool_calling")
+
+    config = deepagent_runtime.RuntimeConfig.from_env()
+    active_model = deepagent_runtime.resolve_runtime_model_profile(config)
+
+    assert config.model_disable_streaming == "tool_calling"
+    assert active_model.disable_streaming == "tool_calling"
 
 
 def test_runtime_config_reads_openai_endpoint_url_from_toml(
@@ -3188,6 +3255,65 @@ model = "fast"
 
     assert config.default_reasoning == "high"
     assert captured["kwargs"]["model"] == "model:fast-model:high"
+
+
+def test_get_agent_explicit_default_reasoning_overrides_profile_default(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Verify explicit per-run reasoning equal to default still overrides profiles."""
+    captured: dict[str, Any] = {}
+
+    def fake_create_deep_agent(**kwargs):
+        """Capture the main DeepAgents graph creation call."""
+        captured["kwargs"] = kwargs
+        return SimpleNamespace(kwargs=kwargs)
+
+    def fake_build_model(config, reasoning_level, *, model_name=None, model_profile=None):
+        """Capture the effective model and reasoning level."""
+        selected_name = model_profile.name if model_profile is not None else model_name
+        return f"model:{selected_name}:{reasoning_level}"
+
+    monkeypatch.setattr(deepagent_runtime, "create_deep_agent", fake_create_deep_agent)
+    monkeypatch.setattr(deepagent_runtime, "build_model", fake_build_model)
+
+    runtime = AgentRuntime(
+        RuntimeConfig(
+            database_url=None,
+            model_provider="ollama",
+            model_name="default-local",
+            model_choices=("default-local", "reviewer"),
+            model_base_url="http://127.0.0.1:11434",
+            model_api_key=None,
+            model_temperature=0.0,
+            default_reasoning="low",
+            persistence_mode="memory",
+            extensions=ExtensionsConfig(config_path=None),
+            model_profiles={
+                "reviewer": deepagent_runtime.ModelDefaults(
+                    provider="ollama",
+                    base_url="http://127.0.0.1:11434",
+                    name="review-model",
+                    reasoning_effort="high",
+                    explicit_fields=frozenset({"name", "reasoning_effort"}),
+                )
+            },
+        ),
+        project_root=tmp_path,
+    )
+    runtime._store = InMemoryStore()
+    runtime._checkpointer = MemorySaver()
+
+    asyncio.run(
+        runtime.get_agent(
+            "low",
+            model_name="reviewer",
+            reasoning_level_is_explicit=True,
+            thread_id="thread-1",
+        )
+    )
+
+    assert captured["kwargs"]["model"] == "model:review-model:low"
 
 
 def test_get_agent_preserves_inherited_tools_for_compiled_nested_subagents(

--- a/tests/test_deepagent_runtime_rag.py
+++ b/tests/test_deepagent_runtime_rag.py
@@ -581,6 +581,36 @@ model = "fast"
     assert active_model.temperature == 0.1
 
 
+def test_model_profile_name_override_inherits_default_model_name(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Verify a profile reference override does not become the inherited model name."""
+    config_path = tmp_path / "deepagent.toml"
+    config_path.write_text(
+        """
+[model]
+provider = "ollama"
+base_url = "http://127.0.0.1:11434"
+name = "prod-local"
+models = ["debug-local"]
+
+[model.profiles.fast]
+temperature = 0.1
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DEEPAGENT_CONFIG", str(config_path))
+    monkeypatch.setenv("DEEPAGENT_MODEL_NAME", "fast")
+
+    config = deepagent_runtime.RuntimeConfig.from_env()
+    active_model = deepagent_runtime.resolve_runtime_model_profile(config)
+
+    assert config.model_name == "fast"
+    assert active_model.name == "prod-local"
+    assert active_model.temperature == 0.1
+
+
 def test_provider_override_bypasses_agent_model_profile(
     tmp_path: Path,
     monkeypatch,
@@ -2580,6 +2610,7 @@ def test_get_agent_uses_subagent_model_profile_for_model_and_tools(
                     name="claude-sonnet-4-6",
                     api_key="anthropic-key",
                     temperature=0.2,
+                    reasoning_effort="high",
                     thinking="disabled",
                 )
             },
@@ -2602,12 +2633,13 @@ def test_get_agent_uses_subagent_model_profile_for_model_and_tools(
 
     runtime._get_mcp_tools = fake_get_mcp_tools  # type: ignore[assignment]
 
-    asyncio.run(runtime.get_agent("medium", thread_id="thread-1"))
+    asyncio.run(runtime.get_agent("low", thread_id="thread-1"))
 
     subagent_spec = captured["kwargs"]["subagents"][0]
     assert isinstance(subagent_spec["model"], ChatAnthropic)
     assert subagent_spec["model"].model == "claude-sonnet-4-6"
     assert subagent_spec["model"].anthropic_api_key.get_secret_value() == "anthropic-key"
+    assert subagent_spec["model"].effort == "high"
     assert len(subagent_spec["tools"]) == 1
     anthropic_tool = convert_to_anthropic_tool(subagent_spec["tools"][0])
     assert anthropic_tool["input_schema"]["type"] == "object"

--- a/tests/test_deepagent_runtime_rag.py
+++ b/tests/test_deepagent_runtime_rag.py
@@ -8,6 +8,7 @@ import sys
 from contextlib import asynccontextmanager
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
+from typing import Any
 
 from langchain.agents.middleware.types import ToolCallRequest
 from langchain_anthropic.chat_models import convert_to_anthropic_tool
@@ -356,6 +357,95 @@ models = ["gpt-oss:20b", "gemma4:27b"]
 
     assert config.model_name == "gpt-oss:20b"
     assert config.model_choices == ("gpt-oss:20b", "gemma4:27b")
+
+
+def test_runtime_config_reads_named_model_profiles_and_agent_model(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Verify named model profiles can be selected as the main agent model."""
+    from langchain_anthropic import ChatAnthropic
+
+    config_path = tmp_path / "deepagent.toml"
+    config_path.write_text(
+        """
+[model]
+provider = "ollama"
+base_url = "http://127.0.0.1:11434"
+name = "default-local"
+models = ["default-local", "backup-local"]
+
+[model.profiles.fast]
+name = "fast-local"
+temperature = 0.2
+reasoning_effort = "low"
+
+[model.profiles.claude]
+provider = "anthropic"
+name = "claude-sonnet-4-6"
+api_key = "toml-key"
+temperature = 0.4
+thinking = "disabled"
+
+[agent]
+model = "claude"
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DEEPAGENT_CONFIG", str(config_path))
+
+    config = deepagent_runtime.RuntimeConfig.from_env()
+    model = deepagent_runtime.build_model(config, "medium")
+
+    assert config.model_name == "claude"
+    assert config.model_choices == ("claude", "default-local", "backup-local", "fast")
+    assert set(config.model_profiles) == {"fast", "claude"}
+    assert config.extensions.agent_model == "claude"
+    assert isinstance(model, ChatAnthropic)
+    assert model.model == "claude-sonnet-4-6"
+    assert model.anthropic_api_url == deepagent_runtime.DEFAULT_ANTHROPIC_BASE_URL
+    assert model.anthropic_api_key.get_secret_value() == "toml-key"
+    assert model.temperature == 0.4
+    assert model.effort == "medium"
+    assert model.thinking is None
+
+
+def test_build_model_resolves_named_profile_over_raw_model_name(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Verify profile names can switch provider settings at model-build time."""
+    from langchain_openai import ChatOpenAI
+
+    config_path = tmp_path / "deepagent.toml"
+    config_path.write_text(
+        """
+[model]
+provider = "ollama"
+base_url = "http://127.0.0.1:11434"
+name = "default-local"
+
+[model.profiles.openai-tools]
+provider = "openai_compatible"
+base_url = "https://openai-compatible.example/v1"
+name = "tool-model"
+api_key = "profile-key"
+temperature = 0.1
+disable_streaming = "tool_calling"
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DEEPAGENT_CONFIG", str(config_path))
+
+    config = deepagent_runtime.RuntimeConfig.from_env()
+    model = deepagent_runtime.build_model(config, "high", model_name="openai-tools")
+
+    assert isinstance(model, ChatOpenAI)
+    assert model.model_name == "tool-model"
+    assert str(model.openai_api_base).rstrip("/") == "https://openai-compatible.example/v1"
+    assert model.openai_api_key.get_secret_value() == "profile-key"
+    assert model.temperature == 0.1
+    assert model.disable_streaming == "tool_calling"
 
 
 def test_runtime_config_reads_langfuse_enabled_from_toml(
@@ -2218,6 +2308,101 @@ def test_get_agent_builds_compiled_subagents_for_nested_sync_subagents(
     assert ("manager-mcp",) in mcp_tool_calls
     assert ("private-mcp",) in mcp_tool_calls
     assert ("reviewer-mcp",) in mcp_tool_calls
+
+
+def test_get_agent_uses_subagent_model_profile_for_model_and_tools(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Verify subagent model profiles control model construction and tool schemas."""
+    from langchain_anthropic import ChatAnthropic
+
+    async def fake_mcp_tool(**kwargs):
+        """Return fake MCP tool arguments."""
+        return kwargs
+
+    mcp_tool = StructuredTool(
+        name="read_file",
+        description="Read a file.",
+        args_schema={
+            "properties": {"path": {"type": "string"}},
+            "required": ["path"],
+        },
+        coroutine=fake_mcp_tool,
+    )
+    captured: dict[str, Any] = {}
+
+    def fake_create_deep_agent(**kwargs):
+        """Capture the main DeepAgents graph creation call."""
+        captured["kwargs"] = kwargs
+        return SimpleNamespace(kwargs=kwargs)
+
+    monkeypatch.setattr(deepagent_runtime, "create_deep_agent", fake_create_deep_agent)
+
+    runtime = AgentRuntime(
+        RuntimeConfig(
+            database_url=None,
+            model_provider="openai_compatible",
+            model_name="default-openai",
+            model_choices=("default-openai", "claude-reviewer"),
+            model_base_url="https://openai-compatible.example/v1",
+            model_api_key="openai-key",
+            model_temperature=0.0,
+            default_reasoning="medium",
+            persistence_mode="memory",
+            extensions=ExtensionsConfig(
+                config_path=None,
+                mcp_servers={
+                    "repo": {"transport": "stdio", "command": "npx", "args": []},
+                },
+                subagents=(
+                    SubagentConfig(
+                        name="reviewer",
+                        description="Reviews output.",
+                        system_prompt="Review the work.",
+                        mcp_servers=("repo",),
+                        model="claude-reviewer",
+                    ),
+                ),
+            ),
+            model_profiles={
+                "claude-reviewer": deepagent_runtime.ModelDefaults(
+                    provider="anthropic",
+                    base_url=deepagent_runtime.DEFAULT_ANTHROPIC_BASE_URL,
+                    name="claude-sonnet-4-6",
+                    api_key="anthropic-key",
+                    temperature=0.2,
+                    thinking="disabled",
+                )
+            },
+        ),
+        project_root=tmp_path,
+    )
+    runtime._store = InMemoryStore()
+    runtime._checkpointer = MemorySaver()
+
+    async def fake_get_mcp_tools(
+        server_names,
+        *,
+        thread_id=None,
+        mcp_session_id=None,
+    ):
+        """Return the fake MCP tool for the configured subagent server."""
+        if tuple(server_names) == ("repo",):
+            return [mcp_tool]
+        return []
+
+    runtime._get_mcp_tools = fake_get_mcp_tools  # type: ignore[assignment]
+
+    asyncio.run(runtime.get_agent("medium", thread_id="thread-1"))
+
+    subagent_spec = captured["kwargs"]["subagents"][0]
+    assert isinstance(subagent_spec["model"], ChatAnthropic)
+    assert subagent_spec["model"].model == "claude-sonnet-4-6"
+    assert subagent_spec["model"].anthropic_api_key.get_secret_value() == "anthropic-key"
+    assert len(subagent_spec["tools"]) == 1
+    anthropic_tool = convert_to_anthropic_tool(subagent_spec["tools"][0])
+    assert anthropic_tool["input_schema"]["type"] == "object"
 
 
 def test_get_agent_preserves_inherited_tools_for_compiled_nested_subagents(

--- a/tests/test_deepagent_runtime_rag.py
+++ b/tests/test_deepagent_runtime_rag.py
@@ -648,6 +648,40 @@ model = "claude"
     assert active_model.base_url == "https://openai.example/v1"
 
 
+def test_same_provider_override_preserves_agent_model_profile(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Verify no-op provider overrides still select [agent].model profiles."""
+    config_path = tmp_path / "deepagent.toml"
+    config_path.write_text(
+        """
+[model]
+provider = "ollama"
+base_url = "http://127.0.0.1:11434"
+name = "local-default"
+
+[model.profiles.fast]
+name = "fast-local"
+temperature = 0.2
+
+[agent]
+model = "fast"
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DEEPAGENT_CONFIG", str(config_path))
+    monkeypatch.setenv("DEEPAGENT_MODEL_PROVIDER", "ollama")
+
+    config = deepagent_runtime.RuntimeConfig.from_env()
+    active_model = deepagent_runtime.resolve_runtime_model_profile(config)
+
+    assert config.model_provider == "ollama"
+    assert config.model_name == "fast"
+    assert active_model.name == "fast-local"
+    assert active_model.temperature == 0.2
+
+
 def test_build_model_resolves_named_profile_over_raw_model_name(
     tmp_path: Path,
     monkeypatch,
@@ -2823,6 +2857,135 @@ def test_get_agent_does_not_inherit_tools_when_configured_tools_are_filtered(
 
     subagent_spec = captured["kwargs"]["subagents"][0]
     assert "tools" not in subagent_spec
+
+
+def test_get_agent_inherits_selected_profile_for_model_less_compiled_subagent(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Verify model-less compiled subagents inherit the selected main profile."""
+    created_graphs: list[SimpleNamespace] = []
+
+    def fake_create_deep_agent(**kwargs):
+        """Capture every DeepAgents graph creation call."""
+        graph = SimpleNamespace(kwargs=kwargs)
+        created_graphs.append(graph)
+        return graph
+
+    def fake_build_model(config, reasoning_level, *, model_name=None, model_profile=None):
+        """Capture the effective model and reasoning level."""
+        selected_name = model_profile.name if model_profile is not None else model_name
+        return f"model:{selected_name}:{reasoning_level}"
+
+    monkeypatch.setattr(deepagent_runtime, "create_deep_agent", fake_create_deep_agent)
+    monkeypatch.setattr(deepagent_runtime, "build_model", fake_build_model)
+
+    runtime = AgentRuntime(
+        RuntimeConfig(
+            database_url=None,
+            model_provider="ollama",
+            model_name="default-local",
+            model_choices=("default-local", "claude-reviewer"),
+            model_base_url="http://127.0.0.1:11434",
+            model_api_key=None,
+            model_temperature=0.0,
+            default_reasoning="medium",
+            persistence_mode="memory",
+            extensions=ExtensionsConfig(
+                config_path=None,
+                subagents=(
+                    SubagentConfig(
+                        name="manager",
+                        description="Coordinates review.",
+                        system_prompt="Manage the work.",
+                        subagents=(
+                            SubagentConfig(
+                                name="reviewer",
+                                description="Reviews output.",
+                                system_prompt="Review the work.",
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+            model_profiles={
+                "claude-reviewer": deepagent_runtime.ModelDefaults(
+                    provider="anthropic",
+                    base_url=deepagent_runtime.DEFAULT_ANTHROPIC_BASE_URL,
+                    name="claude-sonnet-4-6",
+                    api_key="anthropic-key",
+                    thinking="disabled",
+                )
+            },
+        ),
+        project_root=tmp_path,
+    )
+    runtime._store = InMemoryStore()
+    runtime._checkpointer = MemorySaver()
+
+    asyncio.run(
+        runtime.get_agent(
+            "medium",
+            model_name="claude-reviewer",
+            thread_id="thread-1",
+        )
+    )
+
+    assert len(created_graphs) == 2
+    manager_kwargs = created_graphs[0].kwargs
+    assert manager_kwargs["model"] == "model:claude-sonnet-4-6:medium"
+
+
+def test_get_agent_uses_selected_profile_reasoning_effort(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Verify per-request model profile picks apply profile reasoning defaults."""
+    captured: dict[str, Any] = {}
+
+    def fake_create_deep_agent(**kwargs):
+        """Capture the main DeepAgents graph creation call."""
+        captured["kwargs"] = kwargs
+        return SimpleNamespace(kwargs=kwargs)
+
+    def fake_build_model(config, reasoning_level, *, model_name=None, model_profile=None):
+        """Capture the effective model and reasoning level."""
+        selected_name = model_profile.name if model_profile is not None else model_name
+        return f"model:{selected_name}:{reasoning_level}"
+
+    monkeypatch.setattr(deepagent_runtime, "create_deep_agent", fake_create_deep_agent)
+    monkeypatch.setattr(deepagent_runtime, "build_model", fake_build_model)
+
+    runtime = AgentRuntime(
+        RuntimeConfig(
+            database_url=None,
+            model_provider="ollama",
+            model_name="default-local",
+            model_choices=("default-local", "fast-local"),
+            model_base_url="http://127.0.0.1:11434",
+            model_api_key=None,
+            model_temperature=0.0,
+            default_reasoning="medium",
+            persistence_mode="memory",
+            extensions=ExtensionsConfig(config_path=None),
+            model_profiles={
+                "fast-local": deepagent_runtime.ModelDefaults(
+                    provider="ollama",
+                    base_url="http://127.0.0.1:11434",
+                    name="fast-model",
+                    reasoning_effort="low",
+                    explicit_fields=frozenset({"name", "reasoning_effort"}),
+                )
+            },
+        ),
+        project_root=tmp_path,
+    )
+    runtime._store = InMemoryStore()
+    runtime._checkpointer = MemorySaver()
+
+    asyncio.run(runtime.get_agent("medium", model_name="fast-local", thread_id="thread-1"))
+
+    assert captured["kwargs"]["model"] == "model:fast-model:low"
 
 
 def test_get_agent_preserves_inherited_tools_for_compiled_nested_subagents(

--- a/tests/test_deepagent_runtime_rag.py
+++ b/tests/test_deepagent_runtime_rag.py
@@ -549,6 +549,75 @@ model = "fast"
     assert active_model.name == "fast-local"
 
 
+def test_model_profile_without_name_inherits_default_name_before_models(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Verify inherited model lists do not make profile names explicit."""
+    config_path = tmp_path / "deepagent.toml"
+    config_path.write_text(
+        """
+[model]
+provider = "ollama"
+base_url = "http://127.0.0.1:11434"
+name = "prod-local"
+models = ["debug-local"]
+
+[model.profiles.fast]
+temperature = 0.1
+
+[agent]
+model = "fast"
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DEEPAGENT_CONFIG", str(config_path))
+
+    config = deepagent_runtime.RuntimeConfig.from_env()
+    active_model = deepagent_runtime.resolve_runtime_model_profile(config)
+
+    assert active_model.name == "prod-local"
+    assert active_model.models == ("debug-local",)
+    assert active_model.temperature == 0.1
+
+
+def test_provider_override_bypasses_agent_model_profile(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Verify provider overrides do not keep selecting [agent].model profiles."""
+    config_path = tmp_path / "deepagent.toml"
+    config_path.write_text(
+        """
+[model]
+provider = "ollama"
+base_url = "http://127.0.0.1:11434"
+name = "local-default"
+
+[model.profiles.claude]
+provider = "anthropic"
+name = "claude-sonnet-4-6"
+api_key = "profile-key"
+
+[agent]
+model = "claude"
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DEEPAGENT_CONFIG", str(config_path))
+    monkeypatch.setenv("DEEPAGENT_MODEL_PROVIDER", "openai_compatible")
+    monkeypatch.setenv("DEEPAGENT_MODEL_BASE_URL", "https://openai.example/v1")
+    monkeypatch.setenv("DEEPAGENT_MODEL_API_KEY", "openai-key")
+
+    config = deepagent_runtime.RuntimeConfig.from_env()
+    active_model = deepagent_runtime.resolve_runtime_model_profile(config)
+
+    assert config.model_provider == "openai_compatible"
+    assert config.model_name == "local-default"
+    assert active_model.provider == "openai_compatible"
+    assert active_model.base_url == "https://openai.example/v1"
+
+
 def test_build_model_resolves_named_profile_over_raw_model_name(
     tmp_path: Path,
     monkeypatch,
@@ -2625,6 +2694,103 @@ def test_get_agent_resanitizes_inherited_tools_for_profile_subagent(
     assert anthropic_tool["input_schema"]["properties"] == {
         "path": {"type": "string"},
     }
+
+
+def test_get_agent_does_not_inherit_tools_when_configured_tools_are_filtered(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Verify filtered own tools do not fall back to inherited main-agent tools."""
+
+    async def fake_mcp_tool(**kwargs):
+        """Return fake MCP tool arguments."""
+        return kwargs
+
+    inherited_tool = StructuredTool(
+        name="read_file",
+        description="Read a file.",
+        args_schema={
+            "type": "object",
+            "properties": {"path": {"type": "string"}},
+            "required": ["path"],
+        },
+        coroutine=fake_mcp_tool,
+    )
+    filtered_tool = SimpleNamespace(
+        name="bad_schema",
+        args_schema={"type": "string"},
+    )
+    captured: dict[str, Any] = {}
+
+    def fake_create_deep_agent(**kwargs):
+        """Capture the main DeepAgents graph creation call."""
+        captured["kwargs"] = kwargs
+        return SimpleNamespace(kwargs=kwargs)
+
+    monkeypatch.setattr(deepagent_runtime, "create_deep_agent", fake_create_deep_agent)
+
+    runtime = AgentRuntime(
+        RuntimeConfig(
+            database_url=None,
+            model_provider="ollama",
+            model_name="default-local",
+            model_choices=("default-local", "openai-reviewer"),
+            model_base_url="http://127.0.0.1:11434",
+            model_api_key=None,
+            model_temperature=0.0,
+            default_reasoning="medium",
+            persistence_mode="memory",
+            extensions=ExtensionsConfig(
+                config_path=None,
+                mcp_servers={
+                    "bad": {"transport": "stdio", "command": "npx", "args": []},
+                },
+                subagents=(
+                    SubagentConfig(
+                        name="reviewer",
+                        description="Reviews output.",
+                        system_prompt="Review the work.",
+                        mcp_servers=("bad",),
+                        model="openai-reviewer",
+                    ),
+                ),
+            ),
+            model_profiles={
+                "openai-reviewer": deepagent_runtime.ModelDefaults(
+                    provider="openai_compatible",
+                    base_url="https://openai.example/v1",
+                    name="tool-model",
+                    api_key="openai-key",
+                )
+            },
+        ),
+        project_root=tmp_path,
+    )
+    runtime._store = InMemoryStore()
+    runtime._checkpointer = MemorySaver()
+
+    async def fake_build_main_tools(*, thread_id=None, mcp_session_id=None):
+        """Return an inherited tool valid for OpenAI-compatible schemas."""
+        return [inherited_tool]
+
+    async def fake_get_mcp_tools(
+        server_names,
+        *,
+        thread_id=None,
+        mcp_session_id=None,
+    ):
+        """Return a configured subagent tool that will be filtered out."""
+        if tuple(server_names) == ("bad",):
+            return [filtered_tool]
+        return []
+
+    runtime._build_main_tools = fake_build_main_tools  # type: ignore[assignment]
+    runtime._get_mcp_tools = fake_get_mcp_tools  # type: ignore[assignment]
+
+    asyncio.run(runtime.get_agent("medium", thread_id="thread-1"))
+
+    subagent_spec = captured["kwargs"]["subagents"][0]
+    assert "tools" not in subagent_spec
 
 
 def test_get_agent_preserves_inherited_tools_for_compiled_nested_subagents(

--- a/tests/test_deepagent_runtime_rag.py
+++ b/tests/test_deepagent_runtime_rag.py
@@ -297,6 +297,45 @@ provider = "auto"
     assert "rag.embedding.model" in config.rag_error
 
 
+def test_runtime_config_uses_selected_profile_url_for_matching_rag_provider(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Verify matching RAG providers inherit the selected profile endpoint."""
+    config_path = tmp_path / "deepagent.toml"
+    config_path.write_text(
+        """
+[model]
+provider = "ollama"
+base_url = "http://127.0.0.1:11434"
+name = "local-chat"
+
+[model.profiles.lmstudio]
+provider = "openai_compatible"
+base_url = "https://lmstudio.example/v1"
+name = "tool-model"
+api_key = "profile-key"
+
+[rag]
+enabled = true
+
+[rag.embedding]
+provider = "openai_compatible"
+model = "text-embedding-3-small"
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DEEPAGENT_CONFIG", str(config_path))
+    monkeypatch.setenv("DEEPAGENT_MODEL_PROVIDER", "openai_compatible")
+    monkeypatch.setenv("DEEPAGENT_MODEL_NAME", "lmstudio")
+
+    config = deepagent_runtime.RuntimeConfig.from_env()
+
+    assert config.rag is not None
+    assert config.rag.embedding.provider == "openai_compatible"
+    assert config.rag.embedding.base_url == "https://lmstudio.example/v1"
+
+
 def test_runtime_config_keeps_explicit_rag_provider_on_default_model_url(
     tmp_path: Path,
     monkeypatch,

--- a/tests/test_deepagent_runtime_rag.py
+++ b/tests/test_deepagent_runtime_rag.py
@@ -549,6 +549,38 @@ model = "fast"
     assert active_model.name == "fast-local"
 
 
+def test_model_profile_explicit_base_url_uses_runtime_override(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Verify runtime endpoint overrides replace same-provider profile URLs."""
+    config_path = tmp_path / "deepagent.toml"
+    config_path.write_text(
+        """
+[model]
+provider = "ollama"
+base_url = "http://toml-ollama.example:11434"
+name = "default-local"
+
+[model.profiles.fast]
+base_url = "http://profile-ollama.example:11434"
+name = "fast-local"
+
+[agent]
+model = "fast"
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DEEPAGENT_CONFIG", str(config_path))
+    monkeypatch.setenv("OLLAMA_BASE_URL", "http://env-ollama.example:11434")
+
+    config = deepagent_runtime.RuntimeConfig.from_env()
+    active_model = deepagent_runtime.resolve_runtime_model_profile(config)
+
+    assert active_model.name == "fast-local"
+    assert active_model.base_url == "http://env-ollama.example:11434"
+
+
 def test_model_profile_without_name_inherits_default_name_before_models(
     tmp_path: Path,
     monkeypatch,
@@ -646,6 +678,40 @@ model = "claude"
     assert config.model_name == "local-default"
     assert active_model.provider == "openai_compatible"
     assert active_model.base_url == "https://openai.example/v1"
+
+
+def test_provider_override_allows_selected_profile_endpoint(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Verify selected profile endpoints can satisfy provider-switch preflight."""
+    config_path = tmp_path / "deepagent.toml"
+    config_path.write_text(
+        """
+[model]
+provider = "ollama"
+base_url = "http://127.0.0.1:11434"
+name = "local-default"
+
+[model.profiles.lmstudio]
+provider = "openai_compatible"
+base_url = "https://lmstudio.example/v1"
+name = "tool-model"
+api_key = "profile-key"
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DEEPAGENT_CONFIG", str(config_path))
+    monkeypatch.setenv("DEEPAGENT_MODEL_PROVIDER", "openai_compatible")
+    monkeypatch.setenv("DEEPAGENT_MODEL_NAME", "lmstudio")
+
+    config = deepagent_runtime.RuntimeConfig.from_env()
+    active_model = deepagent_runtime.resolve_runtime_model_profile(config)
+
+    assert config.model_provider == "openai_compatible"
+    assert config.model_name == "lmstudio"
+    assert active_model.provider == "openai_compatible"
+    assert active_model.base_url == "https://lmstudio.example/v1"
 
 
 def test_same_provider_override_preserves_agent_model_profile(
@@ -2667,7 +2733,7 @@ def test_get_agent_uses_subagent_model_profile_for_model_and_tools(
 
     runtime._get_mcp_tools = fake_get_mcp_tools  # type: ignore[assignment]
 
-    asyncio.run(runtime.get_agent("low", thread_id="thread-1"))
+    asyncio.run(runtime.get_agent("medium", thread_id="thread-1"))
 
     subagent_spec = captured["kwargs"]["subagents"][0]
     assert isinstance(subagent_spec["model"], ChatAnthropic)
@@ -2760,6 +2826,92 @@ def test_get_agent_resanitizes_inherited_tools_for_profile_subagent(
     assert anthropic_tool["input_schema"]["properties"] == {
         "path": {"type": "string"},
     }
+
+
+def test_get_agent_preserves_raw_inherited_tools_for_profile_subagent(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Verify provider-switched subagents can use raw main tools."""
+
+    async def fake_mcp_tool(**kwargs):
+        """Return fake MCP tool arguments."""
+        return kwargs
+
+    inherited_tool = StructuredTool(
+        name="read_file",
+        description="Read a file.",
+        args_schema={
+            "properties": {"path": {"type": "string"}},
+            "required": ["path"],
+        },
+        coroutine=fake_mcp_tool,
+    )
+    captured: dict[str, Any] = {}
+
+    def fake_create_deep_agent(**kwargs):
+        """Capture the main DeepAgents graph creation call."""
+        captured["kwargs"] = kwargs
+        return SimpleNamespace(kwargs=kwargs)
+
+    monkeypatch.setattr(deepagent_runtime, "create_deep_agent", fake_create_deep_agent)
+    monkeypatch.setattr(
+        deepagent_runtime,
+        "tool_supports_openai_compatible_schema",
+        lambda tool: False,
+    )
+
+    runtime = AgentRuntime(
+        RuntimeConfig(
+            database_url=None,
+            model_provider="openai_compatible",
+            model_name="default-openai",
+            model_choices=("default-openai", "claude-reviewer"),
+            model_base_url="https://openai-compatible.example/v1",
+            model_api_key="openai-key",
+            model_temperature=0.0,
+            default_reasoning="medium",
+            persistence_mode="memory",
+            extensions=ExtensionsConfig(
+                config_path=None,
+                subagents=(
+                    SubagentConfig(
+                        name="reviewer",
+                        description="Reviews output.",
+                        system_prompt="Review the work.",
+                        model="claude-reviewer",
+                    ),
+                ),
+            ),
+            model_profiles={
+                "claude-reviewer": deepagent_runtime.ModelDefaults(
+                    provider="anthropic",
+                    base_url=deepagent_runtime.DEFAULT_ANTHROPIC_BASE_URL,
+                    name="claude-sonnet-4-6",
+                    api_key="anthropic-key",
+                    thinking="disabled",
+                )
+            },
+        ),
+        project_root=tmp_path,
+    )
+    runtime._store = InMemoryStore()
+    runtime._checkpointer = MemorySaver()
+
+    async def fake_build_main_tools(*, thread_id=None, mcp_session_id=None):
+        """Return a raw main-agent tool filtered out by the OpenAI main model."""
+        return [inherited_tool]
+
+    runtime._build_main_tools = fake_build_main_tools  # type: ignore[assignment]
+
+    asyncio.run(runtime.get_agent("medium", thread_id="thread-1"))
+
+    assert captured["kwargs"]["tools"] is None
+    subagent_spec = captured["kwargs"]["subagents"][0]
+    inherited_tools = subagent_spec["tools"]
+    assert inherited_tools[0] is not inherited_tool
+    anthropic_tool = convert_to_anthropic_tool(inherited_tools[0])
+    assert anthropic_tool["input_schema"]["type"] == "object"
 
 
 def test_get_agent_does_not_inherit_tools_when_configured_tools_are_filtered(
@@ -2986,6 +3138,56 @@ def test_get_agent_uses_selected_profile_reasoning_effort(
     asyncio.run(runtime.get_agent("medium", model_name="fast-local", thread_id="thread-1"))
 
     assert captured["kwargs"]["model"] == "model:fast-model:low"
+
+
+def test_get_agent_explicit_reasoning_overrides_selected_profile_default(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Verify explicit runtime reasoning overrides profile reasoning defaults."""
+    captured: dict[str, Any] = {}
+    config_path = tmp_path / "deepagent.toml"
+    config_path.write_text(
+        """
+[model]
+provider = "ollama"
+base_url = "http://127.0.0.1:11434"
+name = "default-local"
+
+[model.profiles.fast]
+name = "fast-model"
+reasoning_effort = "low"
+
+[agent]
+model = "fast"
+""".strip(),
+        encoding="utf-8",
+    )
+
+    def fake_create_deep_agent(**kwargs):
+        """Capture the main DeepAgents graph creation call."""
+        captured["kwargs"] = kwargs
+        return SimpleNamespace(kwargs=kwargs)
+
+    def fake_build_model(config, reasoning_level, *, model_name=None, model_profile=None):
+        """Capture the effective model and reasoning level."""
+        selected_name = model_profile.name if model_profile is not None else model_name
+        return f"model:{selected_name}:{reasoning_level}"
+
+    monkeypatch.setenv("DEEPAGENT_CONFIG", str(config_path))
+    monkeypatch.setenv("DEEPAGENT_MODEL_REASONING", "high")
+    monkeypatch.setattr(deepagent_runtime, "create_deep_agent", fake_create_deep_agent)
+    monkeypatch.setattr(deepagent_runtime, "build_model", fake_build_model)
+
+    config = deepagent_runtime.RuntimeConfig.from_env()
+    runtime = AgentRuntime(config, project_root=tmp_path)
+    runtime._store = InMemoryStore()
+    runtime._checkpointer = MemorySaver()
+
+    asyncio.run(runtime.get_agent(config.default_reasoning, thread_id="thread-1"))
+
+    assert config.default_reasoning == "high"
+    assert captured["kwargs"]["model"] == "model:fast-model:high"
 
 
 def test_get_agent_preserves_inherited_tools_for_compiled_nested_subagents(

--- a/tests/test_deepagent_runtime_rag.py
+++ b/tests/test_deepagent_runtime_rag.py
@@ -925,6 +925,11 @@ provider = "openai_compatible"
 base_url = "https://lmstudio.example/v1"
 name = "tool-model"
 api_key = "profile-key"
+
+[model.profiles.claude-reviewer]
+provider = "anthropic"
+name = "claude-sonnet-4-6"
+api_key = "anthropic-key"
 """.strip(),
         encoding="utf-8",
     )
@@ -3618,6 +3623,62 @@ def test_get_agent_cache_distinguishes_reasoning_explicitness_for_subagents(
     assert len(created_graphs) == 2
     assert created_graphs[0].kwargs["subagents"][0]["model"] == "model:review-model:low"
     assert created_graphs[1].kwargs["subagents"][0]["model"] == "model:review-model:high"
+
+
+def test_create_configured_graph_uses_agent_profile_reasoning_effort(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Verify static graph export applies the selected main profile reasoning."""
+    captured: dict[str, Any] = {}
+    config = RuntimeConfig(
+        database_url=None,
+        model_provider="ollama",
+        model_name="fast",
+        model_choices=("fast",),
+        model_base_url="http://127.0.0.1:11434",
+        model_api_key=None,
+        model_temperature=0.0,
+        default_reasoning="medium",
+        persistence_mode="memory",
+        extensions=ExtensionsConfig(config_path=None),
+        model_profiles={
+            "fast": deepagent_runtime.ModelDefaults(
+                provider="ollama",
+                base_url="http://127.0.0.1:11434",
+                name="fast-model",
+                reasoning_effort="high",
+                explicit_fields=frozenset({"name", "reasoning_effort"}),
+            )
+        },
+    )
+
+    def fake_create_deep_agent(**kwargs):
+        """Capture the configured static graph."""
+        captured["kwargs"] = kwargs
+        return SimpleNamespace(kwargs=kwargs)
+
+    def fake_build_model(config, reasoning_level, *, model_name=None, model_profile=None):
+        """Capture the effective model and reasoning level."""
+        selected_name = model_profile.name if model_profile is not None else model_name
+        return f"model:{selected_name}:{reasoning_level}"
+
+    monkeypatch.setattr(
+        deepagent_runtime.RuntimeConfig,
+        "from_env",
+        staticmethod(lambda: config),
+    )
+    monkeypatch.setattr(deepagent_runtime, "create_deep_agent", fake_create_deep_agent)
+    monkeypatch.setattr(deepagent_runtime, "build_model", fake_build_model)
+    monkeypatch.setattr(
+        deepagent_runtime,
+        "build_deepagent_backend",
+        lambda **kwargs: SimpleNamespace(),
+    )
+
+    deepagent_runtime.create_configured_graph(include_async_subagents=False)
+
+    assert captured["kwargs"]["model"] == "model:fast-model:high"
 
 
 def test_get_agent_preserves_inherited_tools_for_compiled_nested_subagents(

--- a/tests/test_deepagent_runtime_rag.py
+++ b/tests/test_deepagent_runtime_rag.py
@@ -2405,6 +2405,89 @@ def test_get_agent_uses_subagent_model_profile_for_model_and_tools(
     assert anthropic_tool["input_schema"]["type"] == "object"
 
 
+def test_get_agent_resanitizes_inherited_tools_for_profile_subagent(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Verify inherited tools are sanitized for an explicit subagent profile."""
+
+    async def fake_mcp_tool(**kwargs):
+        """Return fake MCP tool arguments."""
+        return kwargs
+
+    inherited_tool = StructuredTool(
+        name="read_file",
+        description="Read a file.",
+        args_schema={
+            "properties": {"path": {"type": "string"}},
+            "required": ["path"],
+        },
+        coroutine=fake_mcp_tool,
+    )
+    captured: dict[str, Any] = {}
+
+    def fake_create_deep_agent(**kwargs):
+        """Capture the main DeepAgents graph creation call."""
+        captured["kwargs"] = kwargs
+        return SimpleNamespace(kwargs=kwargs)
+
+    monkeypatch.setattr(deepagent_runtime, "create_deep_agent", fake_create_deep_agent)
+
+    runtime = AgentRuntime(
+        RuntimeConfig(
+            database_url=None,
+            model_provider="ollama",
+            model_name="default-local",
+            model_choices=("default-local", "claude-reviewer"),
+            model_base_url="http://127.0.0.1:11434",
+            model_api_key=None,
+            model_temperature=0.0,
+            default_reasoning="medium",
+            persistence_mode="memory",
+            extensions=ExtensionsConfig(
+                config_path=None,
+                subagents=(
+                    SubagentConfig(
+                        name="reviewer",
+                        description="Reviews output.",
+                        system_prompt="Review the work.",
+                        model="claude-reviewer",
+                    ),
+                ),
+            ),
+            model_profiles={
+                "claude-reviewer": deepagent_runtime.ModelDefaults(
+                    provider="anthropic",
+                    base_url=deepagent_runtime.DEFAULT_ANTHROPIC_BASE_URL,
+                    name="claude-sonnet-4-6",
+                    api_key="anthropic-key",
+                    thinking="disabled",
+                )
+            },
+        ),
+        project_root=tmp_path,
+    )
+    runtime._store = InMemoryStore()
+    runtime._checkpointer = MemorySaver()
+
+    async def fake_build_main_tools(*, thread_id=None, mcp_session_id=None):
+        """Return an inherited tool needing Anthropic root-object normalization."""
+        return [inherited_tool]
+
+    runtime._build_main_tools = fake_build_main_tools  # type: ignore[assignment]
+
+    asyncio.run(runtime.get_agent("medium", thread_id="thread-1"))
+
+    subagent_spec = captured["kwargs"]["subagents"][0]
+    inherited_tools = subagent_spec["tools"]
+    assert inherited_tools[0] is not inherited_tool
+    anthropic_tool = convert_to_anthropic_tool(inherited_tools[0])
+    assert anthropic_tool["input_schema"]["type"] == "object"
+    assert anthropic_tool["input_schema"]["properties"] == {
+        "path": {"type": "string"},
+    }
+
+
 def test_get_agent_preserves_inherited_tools_for_compiled_nested_subagents(
     tmp_path: Path,
     monkeypatch,

--- a/tests/test_main_native_commands.py
+++ b/tests/test_main_native_commands.py
@@ -270,6 +270,13 @@ def test_resolve_reasoning_level_for_message_uses_mode_override() -> None:
     assert resolved == "high"
 
 
+def test_message_has_reasoning_level_override_tracks_explicit_mode() -> None:
+    """Verify Chainlit reasoning modes preserve explicit per-message choices."""
+    message = SimpleNamespace(content="hello", modes={"reasoning_level": "medium"})
+
+    assert main.message_has_reasoning_level_override(message)
+
+
 def test_resolve_reasoning_level_for_message_falls_back_to_settings_default() -> None:
     """Verify that resolve reasoning level for message falls back to settings default."""
     message = SimpleNamespace(content="hello", modes={})

--- a/tests/test_main_native_commands.py
+++ b/tests/test_main_native_commands.py
@@ -7,7 +7,13 @@ from types import SimpleNamespace
 import agent_commands
 import main
 import pytest
-from deepagent_runtime import AppSettings, ChainlitStarterConfig
+from deepagent_runtime import (
+    AppSettings,
+    ChainlitStarterConfig,
+    ExtensionsConfig,
+    ModelDefaults,
+    RuntimeConfig,
+)
 from chainagents.runtime.reflection import ReflectionProposal
 
 
@@ -275,6 +281,69 @@ def test_message_has_reasoning_level_override_tracks_explicit_mode() -> None:
     message = SimpleNamespace(content="hello", modes={"reasoning_level": "medium"})
 
     assert main.message_has_reasoning_level_override(message)
+
+
+def test_default_reasoning_level_for_model_uses_profile_default() -> None:
+    """Verify Chainlit defaults settings to the selected profile reasoning."""
+    config = RuntimeConfig(
+        database_url=None,
+        model_provider="ollama",
+        model_name="reviewer",
+        model_choices=("reviewer",),
+        model_base_url="http://127.0.0.1:11434",
+        model_api_key=None,
+        model_temperature=0.0,
+        default_reasoning="low",
+        persistence_mode="memory",
+        extensions=ExtensionsConfig(config_path=None),
+        model_profiles={
+            "reviewer": ModelDefaults(
+                provider="ollama",
+                base_url="http://127.0.0.1:11434",
+                name="review-model",
+                reasoning_effort="high",
+                explicit_fields=frozenset({"name", "reasoning_effort"}),
+            )
+        },
+    )
+
+    assert main.default_reasoning_level_for_model(config, "reviewer") == "high"
+
+
+def test_settings_reasoning_level_is_explicit_for_profile_mismatch() -> None:
+    """Verify Chainlit settings can override a profile reasoning default."""
+    config = RuntimeConfig(
+        database_url=None,
+        model_provider="ollama",
+        model_name="reviewer",
+        model_choices=("reviewer",),
+        model_base_url="http://127.0.0.1:11434",
+        model_api_key=None,
+        model_temperature=0.0,
+        default_reasoning="low",
+        persistence_mode="memory",
+        extensions=ExtensionsConfig(config_path=None),
+        model_profiles={
+            "reviewer": ModelDefaults(
+                provider="ollama",
+                base_url="http://127.0.0.1:11434",
+                name="review-model",
+                reasoning_effort="high",
+                explicit_fields=frozenset({"name", "reasoning_effort"}),
+            )
+        },
+    )
+    settings = AppSettings(
+        model_name="reviewer",
+        reasoning_level="low",
+        thread_id="thread-1",
+    )
+
+    assert main.settings_reasoning_level_is_explicit(
+        config,
+        settings,
+        "reviewer",
+    )
 
 
 def test_resolve_reasoning_level_for_message_falls_back_to_settings_default() -> None:


### PR DESCRIPTION
## Summary
- Document named model profiles and main-agent model overrides in the README
- Resolve profile-aware model/provider settings in the API, CLI, and Chainlit status paths
- Let sync subagents and the main agent inherit or switch to named profiles at config time

## Testing
- Not run (not requested)