### PR TITLE
Add optional generated Chainlit UI panels

### DIFF
--- a/README.md
+++ b/README.md
@@ -669,6 +669,8 @@ reasoning_steps_enabled = true
 tool_steps_enabled = true
 # Set false to hide the initial startup status message ("Workspace agent ready...").
 startup_status_enabled = true
+# Set false to hide generated Chainlit CustomElement panels and remove the render tool.
+generative_ui_enabled = true
 # Set false to keep legacy non-chronological streaming order in Chainlit.
 chronological_ui_enabled = true
 commands = [
@@ -696,6 +698,7 @@ Notes:
 - `[chainlit].reasoning_steps_enabled = false` hides streamed reasoning `cl.Step` panels and reasoning task-list entries while preserving model reasoning settings.
 - `[chainlit].tool_steps_enabled = false` hides streamed tool `cl.Step` panels and tool task-list entries while preserving tool execution.
 - `[chainlit].startup_status_enabled = false` disables the initial startup status message that summarizes runtime configuration.
+- `[chainlit].generative_ui_enabled = false` hides generated Chainlit CustomElement panels and removes the `render_chainlit_ui` tool from the main agent.
 - `[chainlit].chronological_ui_enabled = false` disables chronological UI ordering so response tokens stream immediately and reasoning steps are not force-rolled at tool boundaries.
 - Command `name` is invoked as `/<name>` and must be unique.
 - `template` is optional and may include `{input}`.

--- a/README.md
+++ b/README.md
@@ -442,7 +442,7 @@ memory_files = ["/memories/AGENTS.md"]
 skills = ["skills"]
 mcp_servers = ["repo"]
 # custom_instruction = "Always ask clarifying questions before editing files."
-# custom_instruction_file = "prompts/main-agent.md"
+# custom_instruction_file = "prompts/ui_promots.md"
 
 [agent.reflection]
 enabled = true
@@ -461,7 +461,7 @@ Notes:
 - `memory_namespace` is the shared agent-scoped StoreBackend namespace for `/memories/`. The default is `filesystem` to preserve existing memory data from earlier configs. Use only letters, numbers, hyphens, underscores, dots, `@`, `+`, colons, and tildes.
 - `memory_files` lists `/memories/` files DeepAgents loads into the startup memory prompt. The default is `["/memories/AGENTS.md"]`; set it to `[]` to keep the memory route without startup memory loading.
 - `custom_instruction` appends an inline instruction to the **main/supervisor** agent system prompt.
-- `custom_instruction_file` loads that appended instruction from a UTF-8 text file. Relative paths are resolved from the active `deepagent.toml`; use either `custom_instruction` or `custom_instruction_file`, not both.
+- `custom_instruction_file` loads that appended instruction from a UTF-8 text file. Relative paths are resolved from the active `deepagent.toml`; use either `custom_instruction` or `custom_instruction_file`, not both. This repo uses `prompts/ui_promots.md` to encourage active Chainlit generated UI panels and next-step action buttons.
 - `[agent.reflection]` is opt-in. When enabled for stateful agents, ChainAgents proposes a compact lesson for `memory_file` after correction phrases such as "that was wrong" or after unrecovered tool failures. Chainlit asks with Save/Dismiss before writing through the agent; CLI, TUI, and API expose the proposal without mutating memory.
 
 ## Optional: Enable Workspace Docs RAG

--- a/chainagents/events/stream.py
+++ b/chainagents/events/stream.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Literal
 
 
@@ -13,6 +13,8 @@ StreamEventKind = Literal[
     "tool_call",
     "tool_result",
     "summarization_status",
+    "ui_message",
+    "ui_remove",
 ]
 
 LANGGRAPH_STREAM_MODES = {
@@ -42,6 +44,10 @@ class AgentStreamEvent:
     tool_args_delta: str = ""
     tool_result: str = ""
     status: str = ""
+    ui_id: str = ""
+    ui_name: str = ""
+    ui_props: dict[str, Any] = field(default_factory=dict)
+    ui_metadata: dict[str, Any] = field(default_factory=dict)
 
 
 def stringify_content(value: Any) -> str:
@@ -317,6 +323,10 @@ class AgentStreamEventAdapter:
         data = part.get("data")
         if not isinstance(data, dict):
             return []
+        if data.get("type") == "ui":
+            return self._events_from_ui_message(data)
+        if data.get("type") == "remove-ui":
+            return self._events_from_ui_remove(data)
         if data.get("kind") != SUMMARIZATION_STATUS_KIND:
             return []
 
@@ -328,6 +338,44 @@ class AgentStreamEventAdapter:
                 text=str(
                     data.get("message") or "Conversation summarization triggered."
                 ).strip(),
+            )
+        ]
+
+    @staticmethod
+    def _events_from_ui_message(data: dict[str, Any]) -> list[AgentStreamEvent]:
+        ui_id = str(data.get("id") or "").strip()
+        ui_name = str(data.get("name") or "").strip()
+        props = data.get("props")
+        metadata = data.get("metadata")
+        if not ui_id or not ui_name or not isinstance(props, dict):
+            return []
+        if not isinstance(metadata, dict):
+            metadata = {}
+
+        source = str(
+            metadata.get("source") or metadata.get("name") or "main-agent"
+        ).strip() or "main-agent"
+        return [
+            AgentStreamEvent(
+                kind="ui_message",
+                source=source,
+                ui_id=ui_id,
+                ui_name=ui_name,
+                ui_props=props,
+                ui_metadata=metadata,
+            )
+        ]
+
+    @staticmethod
+    def _events_from_ui_remove(data: dict[str, Any]) -> list[AgentStreamEvent]:
+        ui_id = str(data.get("id") or "").strip()
+        if not ui_id:
+            return []
+        return [
+            AgentStreamEvent(
+                kind="ui_remove",
+                source="main-agent",
+                ui_id=ui_id,
             )
         ]
 

--- a/chainagents/interfaces/api/app.py
+++ b/chainagents/interfaces/api/app.py
@@ -304,6 +304,9 @@ async def _iter_agent_events(
 
 def _event_payload(event: AgentStreamEvent, context: AgentRunContext) -> dict[str, Any]:
     payload = asdict(event)
+    if event.kind not in {"ui_message", "ui_remove"}:
+        for key in ("ui_id", "ui_name", "ui_props", "ui_metadata"):
+            payload.pop(key, None)
     payload.update(
         {
             "thread_id": context.thread_id,

--- a/chainagents/interfaces/chainlit/app.py
+++ b/chainagents/interfaces/chainlit/app.py
@@ -1759,6 +1759,7 @@ async def on_message(message: cl.Message) -> None:
         chronological_ui_enabled=runtime.config.extensions.chainlit_chronological_ui_enabled,
         reasoning_steps_enabled=settings.show_reasoning_stream,
         tool_steps_enabled=settings.show_tool_calls,
+        generative_ui_enabled=runtime.config.extensions.chainlit_generative_ui_enabled,
         reflection_collector=ReflectionCollector.from_runtime_config(
             runtime.config,
             prompt=agent_prompt,

--- a/chainagents/interfaces/chainlit/app.py
+++ b/chainagents/interfaces/chainlit/app.py
@@ -65,6 +65,7 @@ SESSION_SETTINGS_KEY = "agent_settings"
 SESSION_TASK_LIST_KEY = "run_task_list"
 SESSION_ASYNC_TASK_NOTIFIER_KEY = "async_task_notifier"
 SESSION_MCP_SESSION_ID_KEY = "mcp_session_id"
+SESSION_GENERATED_UI_ELEMENTS_KEY = "generated_ui_elements"
 REBUILD_RAG_INDEX_ACTION = "rebuild_knowledge_index"
 UPLOAD_RAG_FILE_ACTION = "upload_rag_file"
 REFLECTION_SAVE_ACTION = "save_reflection_lesson"
@@ -1284,6 +1285,17 @@ async def get_run_task_list(
     return run_task_list
 
 
+def get_generated_ui_elements() -> dict[str, cl.CustomElement]:
+    """Return the per-session generated UI element registry."""
+    generated_ui_elements = cl.user_session.get(SESSION_GENERATED_UI_ELEMENTS_KEY)
+    if isinstance(generated_ui_elements, dict):
+        return generated_ui_elements
+
+    generated_ui_elements = {}
+    cl.user_session.set(SESSION_GENERATED_UI_ELEMENTS_KEY, generated_ui_elements)
+    return generated_ui_elements
+
+
 def get_async_task_notifier(
     *,
     agent: Any,
@@ -1760,6 +1772,7 @@ async def on_message(message: cl.Message) -> None:
         reasoning_steps_enabled=settings.show_reasoning_stream,
         tool_steps_enabled=settings.show_tool_calls,
         generative_ui_enabled=runtime.config.extensions.chainlit_generative_ui_enabled,
+        generated_ui_elements=get_generated_ui_elements(),
         reflection_collector=ReflectionCollector.from_runtime_config(
             runtime.config,
             prompt=agent_prompt,

--- a/chainagents/interfaces/chainlit/bridge.py
+++ b/chainagents/interfaces/chainlit/bridge.py
@@ -971,6 +971,7 @@ class ChainlitEventBridge:
         reasoning_steps_enabled: bool = True,
         tool_steps_enabled: bool = True,
         generative_ui_enabled: bool = True,
+        generated_ui_elements: dict[str, cl.CustomElement] | None = None,
         reflection_collector: ReflectionCollector | None = None,
     ) -> None:
         """Initialize the chainlit event bridge instance.
@@ -982,6 +983,7 @@ class ChainlitEventBridge:
             reasoning_steps_enabled: Whether to show reasoning steps.
             tool_steps_enabled: Whether to show tool steps.
             generative_ui_enabled: Whether to render generated UI custom elements.
+            generated_ui_elements: Shared generated UI element registry for this session.
             reflection_collector: Optional collector for post-run memory proposals.
         """
         self.prompt = prompt
@@ -997,7 +999,9 @@ class ChainlitEventBridge:
         self.reasoning_buffers: dict[str, str] = {}
         self.tool_steps: dict[str, ToolStepState] = {}
         self.summarization_steps: dict[str, cl.Step] = {}
-        self.generated_ui_elements: dict[str, cl.CustomElement] = {}
+        self.generated_ui_elements = (
+            generated_ui_elements if generated_ui_elements is not None else {}
+        )
         self.generated_file_paths: list[str] = []
         self.collapse_scheduled_step_ids: set[str] = set()
         self.pending_collapse_tasks: set[asyncio.Task[Any]] = set()

--- a/chainagents/interfaces/chainlit/bridge.py
+++ b/chainagents/interfaces/chainlit/bridge.py
@@ -77,6 +77,7 @@ GENERATED_FILE_PATH_ARG_KEYS = (
     "dest",
     "output_path",
 )
+GENERATIVE_UI_COMPONENTS = frozenset({"GeneratedPanel"})
 
 
 def stringify_content(value: Any) -> str:
@@ -969,6 +970,7 @@ class ChainlitEventBridge:
         chronological_ui_enabled: bool = True,
         reasoning_steps_enabled: bool = True,
         tool_steps_enabled: bool = True,
+        generative_ui_enabled: bool = True,
         reflection_collector: ReflectionCollector | None = None,
     ) -> None:
         """Initialize the chainlit event bridge instance.
@@ -979,6 +981,7 @@ class ChainlitEventBridge:
             chronological_ui_enabled: The chronological UI enabled value.
             reasoning_steps_enabled: Whether to show reasoning steps.
             tool_steps_enabled: Whether to show tool steps.
+            generative_ui_enabled: Whether to render generated UI custom elements.
             reflection_collector: Optional collector for post-run memory proposals.
         """
         self.prompt = prompt
@@ -994,12 +997,14 @@ class ChainlitEventBridge:
         self.reasoning_buffers: dict[str, str] = {}
         self.tool_steps: dict[str, ToolStepState] = {}
         self.summarization_steps: dict[str, cl.Step] = {}
+        self.generated_ui_elements: dict[str, cl.CustomElement] = {}
         self.generated_file_paths: list[str] = []
         self.collapse_scheduled_step_ids: set[str] = set()
         self.pending_collapse_tasks: set[asyncio.Task[Any]] = set()
         self.chronological_ui_enabled = chronological_ui_enabled
         self.reasoning_steps_enabled = reasoning_steps_enabled
         self.tool_steps_enabled = tool_steps_enabled
+        self.generative_ui_enabled = generative_ui_enabled
         self.reflection_collector = reflection_collector
 
     async def start(self) -> None:
@@ -1033,6 +1038,10 @@ class ChainlitEventBridge:
             await self._complete_tool_event(event)
         elif event.kind == "summarization_status":
             await self._stream_summarization_status_event(event)
+        elif event.kind == "ui_message":
+            await self._render_ui_message(event)
+        elif event.kind == "ui_remove":
+            await self._remove_ui_message(event)
 
     async def _update_todos_from_update_part(self, part: dict[str, Any]) -> None:
         """Refresh Chainlit task list todos from a LangGraph update part."""
@@ -1214,6 +1223,41 @@ class ChainlitEventBridge:
             step.end = utc_now()
             self._schedule_step_auto_collapse(step)
         await step.update()
+
+    async def _render_ui_message(self, event: AgentStreamEvent) -> None:
+        """Render a whitelisted LangGraph UI event as a Chainlit CustomElement."""
+        if not self.generative_ui_enabled:
+            return
+        if event.ui_name not in GENERATIVE_UI_COMPONENTS or not event.ui_id:
+            return
+
+        existing_element = self.generated_ui_elements.get(event.ui_id)
+        if existing_element is not None:
+            if event.ui_metadata.get("merge") is True:
+                existing_element.props = {
+                    **dict(getattr(existing_element, "props", {}) or {}),
+                    **event.ui_props,
+                }
+            else:
+                existing_element.props = event.ui_props
+            await existing_element.update()
+            return
+
+        element = cl.CustomElement(
+            name=event.ui_name,
+            props=event.ui_props,
+            display="inline",
+        )
+        self.generated_ui_elements[event.ui_id] = element
+        await cl.Message(content="", elements=[element]).send()
+
+    async def _remove_ui_message(self, event: AgentStreamEvent) -> None:
+        """Remove a tracked Chainlit CustomElement for a LangGraph remove-ui event."""
+        if not self.generative_ui_enabled or not event.ui_id:
+            return
+        element = self.generated_ui_elements.pop(event.ui_id, None)
+        if element is not None:
+            await element.remove()
 
     async def _stream_tool_call_event(self, event: AgentStreamEvent) -> None:
         """Render a normalized streamed tool call event."""

--- a/chainagents/runtime/core.py
+++ b/chainagents/runtime/core.py
@@ -129,7 +129,7 @@ Operating constraints:
 - When you finish, explain the result clearly and concisely.
 - For non-trivial, multi-step work, call `write_todos` early and keep it updated as you progress so the UI can reflect your current plan and progress.
 - If you expect to use multiple tools or perform more than two distinct steps, create a todo list before proceeding with the main work.
-- In Chainlit, call `render_chainlit_ui` when a structured visual panel would make the answer easier to scan. Use it for concise summaries, facts, short lists, small tables, and follow-up prompt buttons; still provide the normal text answer.
+- Actively use `render_chainlit_ui` in Chainlit for interactive or structured answers. When the tool is available, default to a compact GeneratedPanel for summaries, facts, checklists, comparisons, status updates, choices, and next-step action buttons. Still provide the normal text answer. For simple one-sentence answers or when the tool is absent, answer in text only.
 
 Availability questions:
 - When asked what skills are available, answer from the actually loaded Skills section in your system prompt, not from generic world knowledge or broad capabilities.

--- a/chainagents/runtime/core.py
+++ b/chainagents/runtime/core.py
@@ -1747,6 +1747,7 @@ def create_render_chainlit_ui_tool() -> Any:
             props,
             id=(id.strip() if isinstance(id, str) and id.strip() else None),
             metadata={"source": "main-agent"},
+            state_key=None,
         )
         return {
             "rendered": True,

--- a/chainagents/runtime/core.py
+++ b/chainagents/runtime/core.py
@@ -34,12 +34,15 @@ from deepagents.backends import (
 from deepagents.middleware.skills import _list_skills
 from langchain.agents.middleware.types import AgentMiddleware, ToolCallRequest
 from langchain_core.messages import AIMessageChunk, ToolMessage
+from langchain_core.tools import tool
 from langchain_anthropic import ChatAnthropic
 from langchain_ollama import ChatOllama
 from langchain_openai import ChatOpenAI
+from langgraph.graph.ui import push_ui_message
 from langchain_mcp_adapters.client import MultiServerMCPClient
 from langchain_mcp_adapters.tools import load_mcp_tools
 from langchain_core.utils.function_calling import convert_to_openai_tool
+from pydantic import BaseModel, Field
 from langgraph.checkpoint.memory import MemorySaver
 from langgraph.checkpoint.postgres.aio import AsyncPostgresSaver
 from langgraph.store.memory import InMemoryStore
@@ -104,6 +107,7 @@ OPENAI_COMPATIBLE_REASONING_DELTA_KEYS = (
     "reasoning_details",
 )
 SUMMARIZATION_STATUS_EVENT_KIND = "summarization_status"
+GENERATIVE_UI_COMPONENT_NAME = "GeneratedPanel"
 SYSTEM_PROMPT_MEMORY_LINE = (
     "- Use `/memories/` for agent memory. Persistence depends on runtime configuration."
 )
@@ -125,6 +129,7 @@ Operating constraints:
 - When you finish, explain the result clearly and concisely.
 - For non-trivial, multi-step work, call `write_todos` early and keep it updated as you progress so the UI can reflect your current plan and progress.
 - If you expect to use multiple tools or perform more than two distinct steps, create a todo list before proceeding with the main work.
+- In Chainlit, call `render_chainlit_ui` when a structured visual panel would make the answer easier to scan. Use it for concise summaries, facts, short lists, small tables, and follow-up prompt buttons; still provide the normal text answer.
 
 Availability questions:
 - When asked what skills are available, answer from the actually loaded Skills section in your system prompt, not from generic world knowledge or broad capabilities.
@@ -1608,6 +1613,140 @@ def virtual_workspace_path_to_local(path_value: str, project_root: Path | None =
     return str(local_path)
 
 
+class RenderChainlitUIInput(BaseModel):
+    """Define the schema for generated Chainlit UI panel requests."""
+
+    title: str = Field(
+        ...,
+        min_length=1,
+        description="Short title shown at the top of the generated UI panel.",
+    )
+    summary: str | None = Field(
+        default=None,
+        description="Optional concise markdown-style summary for the panel body.",
+    )
+    facts: dict[str, Any] | None = Field(
+        default=None,
+        description="Optional key-value facts to display in a compact grid.",
+    )
+    items: list[Any] | None = Field(
+        default=None,
+        description=(
+            "Optional short list items to display in order. Prefer strings; "
+            "use actions, not items, for prompt buttons."
+        ),
+    )
+    table: dict[str, Any] | None = Field(
+        default=None,
+        description="Optional small table with columns and rows.",
+    )
+    actions: list[dict[str, Any]] | None = Field(
+        default=None,
+        description="Optional prompt buttons with label and prompt values.",
+    )
+    id: str | None = Field(
+        default=None,
+        description="Optional stable panel id. Reusing it updates the existing panel.",
+    )
+
+
+def _normalize_generated_ui_props(
+    *,
+    title: str,
+    summary: str | None = None,
+    facts: dict[str, Any] | None = None,
+    items: list[Any] | None = None,
+    table: dict[str, Any] | None = None,
+    actions: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Return props accepted by the bundled GeneratedPanel custom element."""
+    props: dict[str, Any] = {"title": title.strip()}
+    normalized_actions: list[dict[str, str]] = []
+    action_keys: set[tuple[str, str]] = set()
+
+    def append_action(value: Any) -> None:
+        if not isinstance(value, dict):
+            return
+        label = str(value.get("label") or "").strip()
+        prompt = str(value.get("prompt") or "").strip()
+        key = (label, prompt)
+        if label and prompt and key not in action_keys:
+            normalized_actions.append({"label": label, "prompt": prompt})
+            action_keys.add(key)
+
+    def item_text(value: Any) -> str:
+        if isinstance(value, dict):
+            for key in ("label", "text", "title", "value", "name"):
+                text = str(value.get(key) or "").strip()
+                if text:
+                    return text
+            return ""
+        return str(value).strip()
+
+    if summary is not None and summary.strip():
+        props["summary"] = summary.strip()
+    if facts:
+        props["facts"] = {str(key): value for key, value in facts.items()}
+    if items:
+        normalized_items: list[str] = []
+        for item in items:
+            text = item_text(item)
+            if text:
+                normalized_items.append(text)
+            append_action(item)
+        if normalized_items:
+            props["items"] = normalized_items
+    if table:
+        props["table"] = table
+    if actions:
+        for action in actions:
+            append_action(action)
+    if normalized_actions:
+        props["actions"] = normalized_actions
+    return props
+
+
+def create_render_chainlit_ui_tool() -> Any:
+    """Create the built-in tool that emits LangGraph UI messages for Chainlit."""
+
+    @tool(
+        "render_chainlit_ui",
+        args_schema=RenderChainlitUIInput,
+        return_direct=False,
+    )
+    def render_chainlit_ui(
+        title: str,
+        summary: str | None = None,
+        facts: dict[str, Any] | None = None,
+        items: list[Any] | None = None,
+        table: dict[str, Any] | None = None,
+        actions: list[dict[str, Any]] | None = None,
+        id: str | None = None,
+    ) -> dict[str, Any]:
+        """Render a whitelisted Chainlit generated UI panel for the current answer."""
+        props = _normalize_generated_ui_props(
+            title=title,
+            summary=summary,
+            facts=facts,
+            items=items,
+            table=table,
+            actions=actions,
+        )
+        ui_message = push_ui_message(
+            GENERATIVE_UI_COMPONENT_NAME,
+            props,
+            id=(id.strip() if isinstance(id, str) and id.strip() else None),
+            metadata={"source": "main-agent"},
+        )
+        return {
+            "rendered": True,
+            "component": ui_message["name"],
+            "id": ui_message["id"],
+        }
+
+    return render_chainlit_ui
+
+
 @dataclass(frozen=True)
 class ExtensionsConfig:
     """Store optional runtime extension settings parsed from configuration.
@@ -1635,6 +1774,7 @@ class ExtensionsConfig:
         chainlit_tool_steps_enabled: The chainlit tool steps enabled value.
         chainlit_startup_status_enabled: The chainlit startup status enabled value.
         chainlit_chronological_ui_enabled: The chainlit chronological UI enabled value.
+        chainlit_generative_ui_enabled: Whether Chainlit generated UI is enabled.
         summarization_middleware_enabled: The summarization middleware enabled value.
         summarization_trigger_tokens: The summarization trigger tokens value.
         summarization_keep_tokens: The summarization keep tokens value.
@@ -1663,6 +1803,7 @@ class ExtensionsConfig:
     chainlit_tool_steps_enabled: bool = True
     chainlit_startup_status_enabled: bool = True
     chainlit_chronological_ui_enabled: bool = True
+    chainlit_generative_ui_enabled: bool = True
     summarization_middleware_enabled: bool = False
     summarization_trigger_tokens: int | None = None
     summarization_keep_tokens: int | None = None
@@ -2554,6 +2695,7 @@ def parse_extensions_config(raw_config: dict[str, Any], config_path: Path) -> Ex
     raw_model_mode_enabled = chainlit_section.get("model_mode_enabled", True)
     raw_startup_status_enabled = chainlit_section.get("startup_status_enabled", True)
     raw_chronological_ui_enabled = chainlit_section.get("chronological_ui_enabled", True)
+    raw_generative_ui_enabled = chainlit_section.get("generative_ui_enabled", True)
     if not isinstance(raw_reasoning_mode_enabled, bool):
         raise ValueError(
             "The top-level 'chainlit.reasoning_mode_enabled' config must be a boolean."
@@ -2577,6 +2719,10 @@ def parse_extensions_config(raw_config: dict[str, Any], config_path: Path) -> Ex
     if not isinstance(raw_chronological_ui_enabled, bool):
         raise ValueError(
             "The top-level 'chainlit.chronological_ui_enabled' config must be a boolean."
+        )
+    if not isinstance(raw_generative_ui_enabled, bool):
+        raise ValueError(
+            "The top-level 'chainlit.generative_ui_enabled' config must be a boolean."
         )
 
     chainlit_commands: list[ChainlitCommandConfig] = []
@@ -2680,6 +2826,7 @@ def parse_extensions_config(raw_config: dict[str, Any], config_path: Path) -> Ex
         chainlit_tool_steps_enabled=raw_tool_steps_enabled,
         chainlit_startup_status_enabled=raw_startup_status_enabled,
         chainlit_chronological_ui_enabled=raw_chronological_ui_enabled,
+        chainlit_generative_ui_enabled=raw_generative_ui_enabled,
         summarization_middleware_enabled=raw_summarization_middleware_enabled,
         summarization_trigger_tokens=raw_summarization_trigger_tokens,
         summarization_keep_tokens=raw_summarization_keep_tokens,
@@ -4303,6 +4450,8 @@ def create_configured_graph(
         memory_namespace=config.extensions.agent_memory_namespace,
     )
     tools: list[Any] = []
+    if config.extensions.chainlit_generative_ui_enabled:
+        tools.append(create_render_chainlit_ui_tool())
     if config.rag is not None:
         tools.append(
             create_search_workspace_knowledge_tool(
@@ -5178,8 +5327,10 @@ class AgentRuntime:
             thread_id=thread_id,
             mcp_session_id=mcp_session_id,
         )
+        tools = list(tools)
+        if self.config.extensions.chainlit_generative_ui_enabled:
+            tools.append(create_render_chainlit_ui_tool())
         if self._rag_service is not None:
-            tools = list(tools)
             tools.append(
                 create_search_workspace_knowledge_tool(
                     self._rag_service,

--- a/chainagents/runtime/core.py
+++ b/chainagents/runtime/core.py
@@ -1664,15 +1664,23 @@ def _normalize_generated_ui_props(
     normalized_actions: list[dict[str, str]] = []
     action_keys: set[tuple[str, str]] = set()
 
-    def append_action(value: Any) -> None:
+    def action_parts(value: Any) -> tuple[str, str] | None:
         if not isinstance(value, dict):
-            return
+            return None
         label = str(value.get("label") or "").strip()
         prompt = str(value.get("prompt") or "").strip()
-        key = (label, prompt)
-        if label and prompt and key not in action_keys:
+        if label and prompt:
+            return label, prompt
+        return None
+
+    def append_action(value: Any) -> None:
+        parts = action_parts(value)
+        if parts is None:
+            return
+        label, prompt = parts
+        if parts not in action_keys:
             normalized_actions.append({"label": label, "prompt": prompt})
-            action_keys.add(key)
+            action_keys.add(parts)
 
     def item_text(value: Any) -> str:
         if isinstance(value, dict):
@@ -1690,10 +1698,12 @@ def _normalize_generated_ui_props(
     if items:
         normalized_items: list[str] = []
         for item in items:
+            append_action(item)
+            if action_parts(item) is not None:
+                continue
             text = item_text(item)
             if text:
                 normalized_items.append(text)
-            append_action(item)
         if normalized_items:
             props["items"] = normalized_items
     if table:

--- a/deepagent.toml
+++ b/deepagent.toml
@@ -71,7 +71,7 @@ mcp_servers = []
 # Optional instruction appended to the main agent system prompt.
 # Use either custom_instruction or custom_instruction_file, not both.
 # custom_instruction = "Always ask clarifying questions before editing files."
-# custom_instruction_file = "prompts/main-agent.md"
+custom_instruction_file = "prompts/ui_promots.md"
 # Legacy flag retained for compatibility; DeepAgents provides summarization.
 summarization_middleware_enabled = true
 # Token thresholds tune DeepAgents' built-in summarizer.
@@ -129,6 +129,8 @@ reasoning_steps_enabled = true
 tool_steps_enabled = true
 # Set false to hide the initial startup status message ("Workspace agent ready...").
 startup_status_enabled = false
+# Set false to hide generated Chainlit CustomElement panels and remove the render tool.
+generative_ui_enabled = true
 chronological_ui_enabled = false
 commands = [
   { name = "ask-researcher", description = "Delegate to repo-researcher.", target = "subagent", value = "repo-researcher", template = "{input}" },

--- a/deepagent.toml.example
+++ b/deepagent.toml.example
@@ -96,6 +96,8 @@ reasoning_steps_enabled = true
 tool_steps_enabled = true
 # Set false to disable the initial startup status message in chat.
 startup_status_enabled = true
+# Set false to hide generated Chainlit CustomElement panels and remove the render tool.
+generative_ui_enabled = true
 # Native slash commands available from the Chainlit composer.
 commands = [
   { name = "summarize-docs", description = "Summarize repository docs.", target = "prompt", value = "Summarize the repository documentation changes.", template = "Summarize docs for: {input}" },

--- a/deepagent.toml.example
+++ b/deepagent.toml.example
@@ -71,7 +71,7 @@ mcp_servers = ["repo"]
 # Optional instruction appended to the main agent system prompt.
 # Use either custom_instruction or custom_instruction_file, not both.
 # custom_instruction = "Always ask clarifying questions before editing files."
-# custom_instruction_file = "prompts/main-agent.md"
+# custom_instruction_file = "prompts/ui_promots.md"
 # DeepAgents 0.6.7 provides summarization middleware in its base agent stack.
 # These optional token thresholds tune DeepAgents' built-in summarizer.
 summarization_trigger_tokens = 6000

--- a/prompts/ui_promots.md
+++ b/prompts/ui_promots.md
@@ -1,8 +1,19 @@
 Chainlit generative UI interaction guidance
 
-Use generated UI as a lightweight interaction layer, not as a replacement for the normal answer.
-When the `render_chainlit_ui` tool is available and a visual panel would help the user decide,
-scan, or continue, use the `chainlit-generative-ui` skill and render a `GeneratedPanel`.
+Use generated UI as the active Chainlit interaction layer, not as a replacement for the normal
+answer. When the `render_chainlit_ui` tool is available, look for useful opportunities to render a
+compact `GeneratedPanel` that helps the user decide, scan, or continue. Use the
+`chainlit-generative-ui` skill for these panels.
+
+Default behavior:
+- Default to rendering UI when the answer has structure, options, progress, results, or a clear
+  next step.
+- Use UI proactively for multi-step tasks, reviews, setup flows, test results, planning,
+  comparisons, status updates, and mock UI requests.
+- Add action buttons whenever the user may reasonably want to continue with one of several next
+  steps.
+- Skip UI for simple one-sentence answers, conversational acknowledgements, or when the
+  `render_chainlit_ui` tool is absent.
 
 When to render UI:
 - The user asks for a mock UI, checklist, status panel, decision summary, comparison, or next-step menu.
@@ -22,6 +33,8 @@ How to compose the panel:
 
 How to suggest further steps through UI:
 - Include two to four useful actions when the user may reasonably want to continue.
+- Prefer one primary action that moves the task forward and one or two secondary actions for
+  inspection, explanation, or configuration.
 - Make action labels direct commands, such as "Run tests", "Show diff", "Explain config",
   "Create PR", or "Generate checklist".
 - Make action prompts explicit and complete, for example:

--- a/prompts/ui_promots.md
+++ b/prompts/ui_promots.md
@@ -1,0 +1,72 @@
+Chainlit generative UI interaction guidance
+
+Use generated UI as a lightweight interaction layer, not as a replacement for the normal answer.
+When the `render_chainlit_ui` tool is available and a visual panel would help the user decide,
+scan, or continue, use the `chainlit-generative-ui` skill and render a `GeneratedPanel`.
+
+When to render UI:
+- The user asks for a mock UI, checklist, status panel, decision summary, comparison, or next-step menu.
+- The answer contains structured facts, short lists, options, tradeoffs, or a small table.
+- The user needs to choose a follow-up path, such as testing, inspecting config, generating a PR,
+  reviewing a diff, or asking for a deeper explanation.
+
+How to compose the panel:
+- Use `title` for the panel purpose.
+- Use `summary` for a one- or two-sentence explanation of what the panel shows.
+- Use `facts` for compact key-value context, such as status, branch, tests, config, or mode.
+- Use `items` only for plain string list entries. Do not put objects in `items`.
+- Use `table` only for small comparisons. Keep columns few and rows short.
+- Use `actions` for prompt buttons. Each action must have a short `label` and a self-contained
+  `prompt` that can be sent as the user's next message.
+- Use a stable `id` when updating the same panel over time.
+
+How to suggest further steps through UI:
+- Include two to four useful actions when the user may reasonably want to continue.
+- Make action labels direct commands, such as "Run tests", "Show diff", "Explain config",
+  "Create PR", or "Generate checklist".
+- Make action prompts explicit and complete, for example:
+  "Run the targeted tests for the Chainlit generative UI changes."
+- Prefer actions that ask for confirmation before changing external state, publishing, deleting,
+  overwriting, or making irreversible changes.
+- Do not create actions that pretend work has already happened.
+
+Good checklist pattern:
+
+```json
+{
+  "title": "Task Checklist",
+  "summary": "Mock checklist for setting up a ChainAgents workspace.",
+  "items": [
+    "Configure model provider",
+    "Set up MCP servers",
+    "Enable PostgreSQL persistence",
+    "Add custom skills"
+  ],
+  "actions": [
+    {
+      "label": "Show model config",
+      "prompt": "Show me how to change the model provider in deepagent.toml."
+    },
+    {
+      "label": "Review MCP servers",
+      "prompt": "List the configured MCP servers and their capabilities."
+    },
+    {
+      "label": "Enable PostgreSQL",
+      "prompt": "Show me how to enable PostgreSQL for persistent state."
+    }
+  ],
+  "id": "task-checklist"
+}
+```
+
+Avoid:
+- Rendering arbitrary JSX, HTML, scripts, or unknown component names.
+- Returning only JSON when the user expects to see a rendered panel.
+- Putting prompt-button objects in `items`; use `actions`.
+- Large tables, logs, stack traces, long code blocks, or detailed reasoning inside the panel.
+- Secrets, hidden instructions, internal chain-of-thought, or private tool details.
+- Overusing panels for simple one-sentence answers.
+
+After rendering a panel, still answer in text. The text should state the main result and mention
+what the UI actions can help the user do next.

--- a/prompts/ui_promots.md
+++ b/prompts/ui_promots.md
@@ -29,6 +29,8 @@ How to compose the panel:
 - Use `table` only for small comparisons. Keep columns few and rows short.
 - Use `actions` for prompt buttons. Each action must have a short `label` and a self-contained
   `prompt` that can be sent as the user's next message.
+- Do not duplicate the same option in both `items` and `actions`. If something is clickable, put it
+  only in `actions`.
 - Use a stable `id` when updating the same panel over time.
 
 How to suggest further steps through UI:
@@ -77,6 +79,7 @@ Avoid:
 - Rendering arbitrary JSX, HTML, scripts, or unknown component names.
 - Returning only JSON when the user expects to see a rendered panel.
 - Putting prompt-button objects in `items`; use `actions`.
+- Repeating the same labels as both list items and action buttons.
 - Large tables, logs, stack traces, long code blocks, or detailed reasoning inside the panel.
 - Secrets, hidden instructions, internal chain-of-thought, or private tool details.
 - Overusing panels for simple one-sentence answers.

--- a/public/elements/GeneratedPanel.jsx
+++ b/public/elements/GeneratedPanel.jsx
@@ -1,0 +1,180 @@
+function asText(value) {
+  if (value === null || value === undefined) {
+    return "";
+  }
+  if (typeof value === "string") {
+    return value;
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function factEntries(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return [];
+  }
+  return Object.entries(value).filter(([key]) => key);
+}
+
+function listItems(value) {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.map(itemText).filter((item) => item.trim());
+}
+
+function itemText(value) {
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    return asText(
+      value.label ?? value.text ?? value.title ?? value.value ?? value.name,
+    );
+  }
+  return asText(value);
+}
+
+function tableColumns(table) {
+  if (!table || typeof table !== "object" || !Array.isArray(table.columns)) {
+    return [];
+  }
+  return table.columns.map(asText).filter((column) => column.trim());
+}
+
+function tableRows(table) {
+  if (!table || typeof table !== "object" || !Array.isArray(table.rows)) {
+    return [];
+  }
+  return table.rows;
+}
+
+function cellValue(row, column, index) {
+  if (Array.isArray(row)) {
+    return asText(row[index]);
+  }
+  if (row && typeof row === "object") {
+    return asText(row[column]);
+  }
+  return index === 0 ? asText(row) : "";
+}
+
+function actionItems(value) {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value
+    .map((action) => ({
+      label: asText(action?.label).trim(),
+      prompt: asText(action?.prompt).trim(),
+    }))
+    .filter((action) => action.label && action.prompt);
+}
+
+function uniqueActions(...groups) {
+  const seen = new Set();
+  const merged = [];
+  groups.flat().forEach((action) => {
+    const key = `${action.label}\n${action.prompt}`;
+    if (!seen.has(key)) {
+      seen.add(key);
+      merged.push(action);
+    }
+  });
+  return merged;
+}
+
+export default function GeneratedPanel() {
+  const title = asText(props.title).trim() || "Generated panel";
+  const summary = asText(props.summary).trim();
+  const facts = factEntries(props.facts);
+  const items = listItems(props.items);
+  const columns = tableColumns(props.table);
+  const rows = tableRows(props.table);
+  const actions = uniqueActions(
+    actionItems(props.actions),
+    actionItems(props.items),
+  );
+
+  return (
+    <section className="mt-3 w-full rounded-md border border-border bg-card text-card-foreground shadow-sm">
+      <div className="border-b border-border px-4 py-3">
+        <h3 className="text-base font-semibold leading-6">{title}</h3>
+        {summary ? (
+          <p className="mt-2 whitespace-pre-wrap text-sm leading-6 text-muted-foreground">
+            {summary}
+          </p>
+        ) : null}
+      </div>
+
+      {facts.length ? (
+        <dl className="grid grid-cols-1 border-b border-border sm:grid-cols-2">
+          {facts.map(([key, value]) => (
+            <div key={key} className="border-border px-4 py-3 sm:border-r">
+              <dt className="text-xs font-medium uppercase tracking-normal text-muted-foreground">
+                {key}
+              </dt>
+              <dd className="mt-1 text-sm leading-6">{asText(value)}</dd>
+            </div>
+          ))}
+        </dl>
+      ) : null}
+
+      {items.length ? (
+        <ul className="space-y-2 border-b border-border px-4 py-3 text-sm leading-6">
+          {items.map((item, index) => (
+            <li key={`${index}-${item}`} className="flex gap-2">
+              <span className="mt-2 h-1.5 w-1.5 flex-none rounded-full bg-primary" />
+              <span>{item}</span>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+
+      {columns.length && rows.length ? (
+        <div className="overflow-x-auto border-b border-border">
+          <table className="w-full min-w-max text-left text-sm">
+            <thead className="bg-muted/60 text-xs uppercase text-muted-foreground">
+              <tr>
+                {columns.map((column) => (
+                  <th key={column} className="px-4 py-2 font-medium">
+                    {column}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((row, rowIndex) => (
+                <tr key={rowIndex} className="border-t border-border">
+                  {columns.map((column, columnIndex) => (
+                    <td key={column} className="px-4 py-2 align-top">
+                      {cellValue(row, column, columnIndex)}
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ) : null}
+
+      {actions.length ? (
+        <div className="flex flex-wrap gap-2 px-4 py-3">
+          {actions.map((action) => (
+            <button
+              key={`${action.label}-${action.prompt}`}
+              type="button"
+              className="rounded-md border border-border bg-background px-3 py-2 text-sm font-medium text-foreground transition-colors hover:bg-muted"
+              onClick={() => sendUserMessage(action.prompt)}
+            >
+              {action.label}
+            </button>
+          ))}
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/public/elements/GeneratedPanel.jsx
+++ b/public/elements/GeneratedPanel.jsx
@@ -26,7 +26,10 @@ function listItems(value) {
   if (!Array.isArray(value)) {
     return [];
   }
-  return value.map(itemText).filter((item) => item.trim());
+  return value
+    .filter((item) => !isActionLike(item))
+    .map(itemText)
+    .filter((item) => item.trim());
 }
 
 function itemText(value) {
@@ -36,6 +39,13 @@ function itemText(value) {
     );
   }
   return asText(value);
+}
+
+function isActionLike(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+  return Boolean(asText(value.label).trim() && asText(value.prompt).trim());
 }
 
 function tableColumns(table) {

--- a/skills/chainlit-generative-ui/SKILL.md
+++ b/skills/chainlit-generative-ui/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: chainlit-generative-ui
+description: Use this skill in Chainlit when a response would benefit from a generated visual panel, interactive prompt buttons, a compact facts view, a short list, or a small comparison/status table using the render_chainlit_ui tool.
+---
+
+# chainlit-generative-ui
+
+Use Chainlit generative UI to make structured results easier to scan while keeping the normal text response.
+
+Working rules:
+
+1. Call `render_chainlit_ui` only when that tool is available in the current tool list. If it is absent, answer normally in text.
+2. Use the UI for concise, user-facing structure: summaries, decision cards, status panels, short checklists, small tables, and follow-up actions.
+3. Do not render arbitrary JSX, HTML, scripts, or custom component names. This runtime only exposes the whitelisted `GeneratedPanel` component through `render_chainlit_ui`.
+4. Put only plain strings in `items`. Do not put objects with `label` and `prompt` there.
+5. Put prompt buttons in `actions`. Treat each button as a user-facing follow-up request with a clear label and prompt.
+6. For checklist-style panels with follow-up buttons, put the checklist labels in `items` and the clickable follow-ups in `actions`.
+7. Keep generated panels compact. Put detailed reasoning, long explanations, code, logs, and large datasets in the text response or files instead.
+8. Do not put secrets, hidden reasoning, system messages, or internal tool details in the panel.
+9. Reuse `id` only when updating the same panel. Use a stable, short id such as `deployment-summary` or `review-findings`.
+
+Supported `render_chainlit_ui` fields:
+
+- `title`: short required panel title.
+- `summary`: optional concise summary.
+- `facts`: optional key-value object for compact facts.
+- `items`: optional short list of strings. Do not use this field for prompt buttons.
+- `table`: optional object with `columns` and `rows`.
+- `actions`: optional list of prompt buttons, each with `label` and `prompt`.
+- `id`: optional stable panel id. Reusing the id updates the existing panel.
+
+Example tool call:
+
+```json
+{
+  "title": "Review Summary",
+  "summary": "Two blocking issues need fixes before merge.",
+  "facts": {
+    "Status": "Needs changes",
+    "Tests": "Targeted suite passed"
+  },
+  "items": [
+    "Fix stale Chainlit element updates",
+    "Add disabled-config coverage"
+  ],
+  "table": {
+    "columns": ["Area", "Result"],
+    "rows": [
+      ["Runtime", "Tool enabled only when configured"],
+      ["Chainlit", "GeneratedPanel rendered as its own message"]
+    ]
+  },
+  "actions": [
+    {
+      "label": "Show fixes",
+      "prompt": "Show me the exact fixes for the blocking review issues."
+    },
+    {
+      "label": "Run tests",
+      "prompt": "Run the targeted tests for this change."
+    }
+  ],
+  "id": "review-summary"
+}
+```
+
+After calling the tool, continue with the normal answer. The panel should complement the answer, not replace it.

--- a/skills/chainlit-generative-ui/SKILL.md
+++ b/skills/chainlit-generative-ui/SKILL.md
@@ -5,19 +5,22 @@ description: Use this skill in Chainlit when a response would benefit from a gen
 
 # chainlit-generative-ui
 
-Use Chainlit generative UI to make structured results easier to scan while keeping the normal text response.
+Use Chainlit generative UI as the active interaction layer for structured Chainlit turns while
+keeping the normal text response.
 
 Working rules:
 
 1. Call `render_chainlit_ui` only when that tool is available in the current tool list. If it is absent, answer normally in text.
-2. Use the UI for concise, user-facing structure: summaries, decision cards, status panels, short checklists, small tables, and follow-up actions.
-3. Do not render arbitrary JSX, HTML, scripts, or custom component names. This runtime only exposes the whitelisted `GeneratedPanel` component through `render_chainlit_ui`.
-4. Put only plain strings in `items`. Do not put objects with `label` and `prompt` there.
-5. Put prompt buttons in `actions`. Treat each button as a user-facing follow-up request with a clear label and prompt.
-6. For checklist-style panels with follow-up buttons, put the checklist labels in `items` and the clickable follow-ups in `actions`.
-7. Keep generated panels compact. Put detailed reasoning, long explanations, code, logs, and large datasets in the text response or files instead.
-8. Do not put secrets, hidden reasoning, system messages, or internal tool details in the panel.
-9. Reuse `id` only when updating the same panel. Use a stable, short id such as `deployment-summary` or `review-findings`.
+2. Default to rendering UI for concise, user-facing structure: summaries, decision cards, status panels, short checklists, small tables, and follow-up actions.
+3. Include `actions` when the user may want next steps. Prefer useful continuation buttons such as "Run tests", "Show diff", "Explain config", or "Create PR".
+4. Skip UI for simple one-sentence answers, conversational acknowledgements, and cases where a panel would duplicate the text without adding interaction.
+5. Do not render arbitrary JSX, HTML, scripts, or custom component names. This runtime only exposes the whitelisted `GeneratedPanel` component through `render_chainlit_ui`.
+6. Put only plain strings in `items`. Do not put objects with `label` and `prompt` there.
+7. Put prompt buttons in `actions`. Treat each button as a user-facing follow-up request with a clear label and prompt.
+8. For checklist-style panels with follow-up buttons, put the checklist labels in `items` and the clickable follow-ups in `actions`.
+9. Keep generated panels compact. Put detailed reasoning, long explanations, code, logs, and large datasets in the text response or files instead.
+10. Do not put secrets, hidden reasoning, system messages, or internal tool details in the panel.
+11. Reuse `id` only when updating the same panel. Use a stable, short id such as `deployment-summary` or `review-findings`.
 
 Supported `render_chainlit_ui` fields:
 

--- a/skills/chainlit-generative-ui/SKILL.md
+++ b/skills/chainlit-generative-ui/SKILL.md
@@ -18,9 +18,10 @@ Working rules:
 6. Put only plain strings in `items`. Do not put objects with `label` and `prompt` there.
 7. Put prompt buttons in `actions`. Treat each button as a user-facing follow-up request with a clear label and prompt.
 8. For checklist-style panels with follow-up buttons, put the checklist labels in `items` and the clickable follow-ups in `actions`.
-9. Keep generated panels compact. Put detailed reasoning, long explanations, code, logs, and large datasets in the text response or files instead.
-10. Do not put secrets, hidden reasoning, system messages, or internal tool details in the panel.
-11. Reuse `id` only when updating the same panel. Use a stable, short id such as `deployment-summary` or `review-findings`.
+9. Do not duplicate the same option in `items` and `actions`. If it is clickable, put it only in `actions`.
+10. Keep generated panels compact. Put detailed reasoning, long explanations, code, logs, and large datasets in the text response or files instead.
+11. Do not put secrets, hidden reasoning, system messages, or internal tool details in the panel.
+12. Reuse `id` only when updating the same panel. Use a stable, short id such as `deployment-summary` or `review-findings`.
 
 Supported `render_chainlit_ui` fields:
 

--- a/tests/test_agent_stream_events.py
+++ b/tests/test_agent_stream_events.py
@@ -489,6 +489,58 @@ def test_adapter_streams_summarization_status_events() -> None:
     ]
 
 
+def test_adapter_streams_langgraph_ui_message_events() -> None:
+    adapter = AgentStreamEventAdapter(prompt="hello")
+
+    events = adapter.events_from_raw_event(
+        _raw_event(
+            (
+                "custom",
+                {
+                    "type": "ui",
+                    "id": "panel-1",
+                    "name": "GeneratedPanel",
+                    "props": {
+                        "title": "Build result",
+                        "facts": {"Tests": "passing"},
+                    },
+                    "metadata": {"source": "main-agent"},
+                },
+            )
+        )
+    )
+
+    assert events == [
+        AgentStreamEvent(
+            kind="ui_message",
+            source="main-agent",
+            ui_id="panel-1",
+            ui_name="GeneratedPanel",
+            ui_props={
+                "title": "Build result",
+                "facts": {"Tests": "passing"},
+            },
+            ui_metadata={"source": "main-agent"},
+        )
+    ]
+
+
+def test_adapter_streams_langgraph_ui_remove_events() -> None:
+    adapter = AgentStreamEventAdapter(prompt="hello")
+
+    events = adapter.events_from_raw_event(
+        _raw_event(("custom", {"type": "remove-ui", "id": "panel-1"}))
+    )
+
+    assert events == [
+        AgentStreamEvent(
+            kind="ui_remove",
+            source="main-agent",
+            ui_id="panel-1",
+        )
+    ]
+
+
 def test_adapter_ignores_nested_chain_events() -> None:
     adapter = AgentStreamEventAdapter(prompt="hello")
 

--- a/tests/test_chainlit_bridge_streaming.py
+++ b/tests/test_chainlit_bridge_streaming.py
@@ -839,6 +839,59 @@ async def test_bridge_updates_existing_ui_element_by_id() -> None:
 
 
 @pytest.mark.anyio
+async def test_bridge_updates_shared_ui_element_registry_across_instances() -> None:
+    """Verify generated UI ids persist when bridge instances share a registry."""
+    generated_ui_elements: dict[str, _CustomElement] = {}
+    first_bridge = ChainlitEventBridge(
+        prompt="hello",
+        generated_ui_elements=generated_ui_elements,
+    )
+    second_bridge = ChainlitEventBridge(
+        prompt="next",
+        generated_ui_elements=generated_ui_elements,
+    )
+
+    await first_bridge.handle_event(
+        {
+            "event": "on_chain_stream",
+            "data": {
+                "chunk": (
+                    "custom",
+                    {
+                        "type": "ui",
+                        "id": "panel-1",
+                        "name": "GeneratedPanel",
+                        "props": {"title": "First"},
+                    },
+                ),
+            },
+        }
+    )
+    await second_bridge.handle_event(
+        {
+            "event": "on_chain_stream",
+            "data": {
+                "chunk": (
+                    "custom",
+                    {
+                        "type": "ui",
+                        "id": "panel-1",
+                        "name": "GeneratedPanel",
+                        "props": {"title": "Second"},
+                    },
+                ),
+            },
+        }
+    )
+
+    assert len(_CustomElement.instances) == 1
+    assert _CustomElement.instances[0].props == {"title": "Second"}
+    assert _CustomElement.instances[0].update_count == 1
+    assert len(_Message.instances) == 1
+    assert generated_ui_elements == {"panel-1": _CustomElement.instances[0]}
+
+
+@pytest.mark.anyio
 async def test_bridge_removes_existing_ui_element_by_id() -> None:
     """Verify remove-ui events remove the tracked custom element."""
     bridge = ChainlitEventBridge(prompt="hello")

--- a/tests/test_chainlit_bridge_streaming.py
+++ b/tests/test_chainlit_bridge_streaming.py
@@ -131,6 +131,7 @@ class _Message:
         """
         self.content = content
         self.author = author
+        self.elements = list(_kwargs.get("elements", []) or [])
         self.id = f"message-{len(self.instances) + 1}"
         self.tokens: list[str] = []
         self.actions: list[Any] = []
@@ -214,6 +215,29 @@ class _Step:
         self.update_count += 1
 
 
+class _CustomElement:
+    """Provide an internal helper for Chainlit custom elements."""
+
+    instances: list["_CustomElement"] = []
+
+    def __init__(self, name: str, props: dict[str, Any], display: str = "inline", **_kwargs: Any) -> None:
+        """Initialize the custom element test double."""
+        self.name = name
+        self.props = props
+        self.display = display
+        self.update_count = 0
+        self.remove_count = 0
+        self.instances.append(self)
+
+    async def update(self) -> None:
+        """Record update calls on the test double."""
+        self.update_count += 1
+
+    async def remove(self) -> None:
+        """Record remove calls on the test double."""
+        self.remove_count += 1
+
+
 class _ToolMessage:
     """Provide an internal helper for a completed tool message."""
 
@@ -255,10 +279,12 @@ def _patch_chainlit_tasks(monkeypatch) -> None:
     """
     _Message.instances.clear()
     _Step.instances.clear()
+    _CustomElement.instances.clear()
     monkeypatch.setattr(chainlit_bridge.cl, "TaskStatus", _TaskStatus)
     monkeypatch.setattr(chainlit_bridge.cl, "Task", _Task)
     monkeypatch.setattr(chainlit_bridge.cl, "Step", _Step)
     monkeypatch.setattr(chainlit_bridge.cl, "Message", _Message)
+    monkeypatch.setattr(chainlit_bridge.cl, "CustomElement", _CustomElement)
 
 
 @pytest.mark.anyio
@@ -734,3 +760,153 @@ async def test_chainlit_bridge_shows_summarization_status() -> None:
     assert step.output == "Conversation summarization triggered."
     assert step.send_count == 1
     assert step.update_count == 1
+
+
+@pytest.mark.anyio
+async def test_bridge_renders_whitelisted_ui_message_as_custom_element() -> None:
+    """Verify whitelisted LangGraph UI events render Chainlit custom elements."""
+    bridge = ChainlitEventBridge(prompt="hello")
+
+    await bridge.handle_event(
+        {
+            "event": "on_chain_stream",
+            "data": {
+                "chunk": (
+                    "custom",
+                    {
+                        "type": "ui",
+                        "id": "panel-1",
+                        "name": "GeneratedPanel",
+                        "props": {"title": "Build result"},
+                        "metadata": {"source": "main-agent"},
+                    },
+                ),
+            },
+        }
+    )
+
+    assert len(_CustomElement.instances) == 1
+    assert _CustomElement.instances[0].name == "GeneratedPanel"
+    assert _CustomElement.instances[0].props == {"title": "Build result"}
+    assert _CustomElement.instances[0].display == "inline"
+    assert len(_Message.instances) == 1
+    assert _Message.instances[0].elements == [_CustomElement.instances[0]]
+    assert _Message.instances[0].send_count == 1
+
+
+@pytest.mark.anyio
+async def test_bridge_updates_existing_ui_element_by_id() -> None:
+    """Verify repeat UI ids update the existing custom element props."""
+    bridge = ChainlitEventBridge(prompt="hello")
+
+    await bridge.handle_event(
+        {
+            "event": "on_chain_stream",
+            "data": {
+                "chunk": (
+                    "custom",
+                    {
+                        "type": "ui",
+                        "id": "panel-1",
+                        "name": "GeneratedPanel",
+                        "props": {"title": "First"},
+                    },
+                ),
+            },
+        }
+    )
+    await bridge.handle_event(
+        {
+            "event": "on_chain_stream",
+            "data": {
+                "chunk": (
+                    "custom",
+                    {
+                        "type": "ui",
+                        "id": "panel-1",
+                        "name": "GeneratedPanel",
+                        "props": {"title": "Updated"},
+                    },
+                ),
+            },
+        }
+    )
+
+    assert len(_CustomElement.instances) == 1
+    assert _CustomElement.instances[0].props == {"title": "Updated"}
+    assert _CustomElement.instances[0].update_count == 1
+    assert len(_Message.instances) == 1
+
+
+@pytest.mark.anyio
+async def test_bridge_removes_existing_ui_element_by_id() -> None:
+    """Verify remove-ui events remove the tracked custom element."""
+    bridge = ChainlitEventBridge(prompt="hello")
+
+    await bridge.handle_event(
+        {
+            "event": "on_chain_stream",
+            "data": {
+                "chunk": (
+                    "custom",
+                    {
+                        "type": "ui",
+                        "id": "panel-1",
+                        "name": "GeneratedPanel",
+                        "props": {"title": "First"},
+                    },
+                ),
+            },
+        }
+    )
+    await bridge.handle_event(
+        {
+            "event": "on_chain_stream",
+            "data": {"chunk": ("custom", {"type": "remove-ui", "id": "panel-1"})},
+        }
+    )
+
+    assert _CustomElement.instances[0].remove_count == 1
+
+
+@pytest.mark.anyio
+async def test_bridge_ignores_unknown_or_disabled_ui_components() -> None:
+    """Verify unregistered components and disabled generative UI do not render."""
+    bridge = ChainlitEventBridge(prompt="hello")
+    disabled_bridge = ChainlitEventBridge(prompt="hello", generative_ui_enabled=False)
+
+    await bridge.handle_event(
+        {
+            "event": "on_chain_stream",
+            "data": {
+                "chunk": (
+                    "custom",
+                    {
+                        "type": "ui",
+                        "id": "panel-1",
+                        "name": "UnknownPanel",
+                        "props": {"title": "First"},
+                    },
+                ),
+            },
+        }
+    )
+    await disabled_bridge.handle_event(
+        {
+            "event": "on_chain_stream",
+            "data": {
+                "chunk": (
+                    "custom",
+                    {
+                        "type": "ui",
+                        "id": "panel-2",
+                        "name": "GeneratedPanel",
+                        "props": {"title": "Second"},
+                    },
+                ),
+            },
+        }
+    )
+
+    assert _CustomElement.instances == []
+    assert _Message.instances == []

--- a/tests/test_deepagent_runtime_rag.py
+++ b/tests/test_deepagent_runtime_rag.py
@@ -4045,6 +4045,7 @@ def test_render_chainlit_ui_tool_pushes_generated_panel(monkeypatch) -> None:
             },
             "id": "panel-1",
             "metadata": {"source": "main-agent"},
+            "state_key": None,
         }
     ]
     assert result == {

--- a/tests/test_deepagent_runtime_rag.py
+++ b/tests/test_deepagent_runtime_rag.py
@@ -3956,6 +3956,15 @@ def test_get_agent_includes_render_chainlit_ui_tool_by_default(
     assert "render_chainlit_ui" in tool_names
 
 
+def test_system_prompt_directs_active_chainlit_ui_interaction() -> None:
+    """Verify the built-in prompt pushes active Chainlit generated UI use."""
+    prompt = deepagent_runtime.SYSTEM_PROMPT
+
+    assert "Actively use `render_chainlit_ui`" in prompt
+    assert "next-step action buttons" in prompt
+    assert "For simple one-sentence answers" in prompt
+
+
 def test_get_agent_omits_render_chainlit_ui_tool_when_disabled(
     tmp_path: Path,
     monkeypatch,

--- a/tests/test_deepagent_runtime_rag.py
+++ b/tests/test_deepagent_runtime_rag.py
@@ -4054,8 +4054,10 @@ def test_render_chainlit_ui_tool_pushes_generated_panel(monkeypatch) -> None:
     }
 
 
-def test_render_chainlit_ui_tool_normalizes_action_shaped_items(monkeypatch) -> None:
-    """Verify action-shaped list items render as text and prompt buttons."""
+def test_render_chainlit_ui_tool_promotes_action_items_without_duplicate_list(
+    monkeypatch,
+) -> None:
+    """Verify action-shaped items become buttons without duplicate list rows."""
     pushed: list[dict[str, Any]] = []
 
     def fake_push_ui_message(name: str, props: dict[str, Any], **kwargs: Any):
@@ -4071,6 +4073,12 @@ def test_render_chainlit_ui_tool_normalizes_action_shaped_items(monkeypatch) -> 
             "id": "mock-checklist-panel",
             "title": "Task Checklist",
             "summary": "Example of a short checklist panel.",
+            "actions": [
+                {
+                    "label": "Configure model provider",
+                    "prompt": "Show me how to change the model provider.",
+                },
+            ],
             "items": [
                 {
                     "label": "Configure model provider",
@@ -4084,10 +4092,7 @@ def test_render_chainlit_ui_tool_normalizes_action_shaped_items(monkeypatch) -> 
         }
     )
 
-    assert pushed[0]["props"]["items"] == [
-        "Configure model provider",
-        "Set up MCP servers",
-    ]
+    assert "items" not in pushed[0]["props"]
     assert pushed[0]["props"]["actions"] == [
         {
             "label": "Configure model provider",

--- a/tests/test_deepagent_runtime_rag.py
+++ b/tests/test_deepagent_runtime_rag.py
@@ -3931,6 +3931,166 @@ def test_get_agent_omits_rag_tool_when_service_is_missing(
     assert any(isinstance(item, ToolExecutionResilienceMiddleware) for item in middleware)
 
 
+def test_get_agent_includes_render_chainlit_ui_tool_by_default(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Verify the main agent receives the built-in Chainlit UI render tool."""
+    captured: dict[str, object] = {}
+
+    def fake_create_deep_agent(*, tools=None, **kwargs):
+        """Capture Deep Agent factory arguments for tests."""
+        captured["tools"] = tools or []
+        captured["kwargs"] = kwargs
+        return object()
+
+    monkeypatch.setattr(deepagent_runtime, "create_deep_agent", fake_create_deep_agent)
+
+    runtime = AgentRuntime(make_runtime_config(tmp_path))
+    runtime._store = InMemoryStore()
+    runtime._checkpointer = MemorySaver()
+
+    asyncio.run(runtime.get_agent("medium", thread_id="thread-1"))
+
+    tool_names = [tool.name for tool in captured["tools"]]
+    assert "render_chainlit_ui" in tool_names
+
+
+def test_get_agent_omits_render_chainlit_ui_tool_when_disabled(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Verify the render UI tool is omitted when generative UI is disabled."""
+    captured: dict[str, object] = {}
+
+    def fake_create_deep_agent(*, tools=None, **kwargs):
+        """Capture Deep Agent factory arguments for tests."""
+        captured["tools"] = tools or []
+        captured["kwargs"] = kwargs
+        return object()
+
+    monkeypatch.setattr(deepagent_runtime, "create_deep_agent", fake_create_deep_agent)
+
+    runtime = AgentRuntime(
+        make_runtime_config(
+            tmp_path,
+            extensions=ExtensionsConfig(
+                config_path=None,
+                chainlit_generative_ui_enabled=False,
+            ),
+        )
+    )
+    runtime._store = InMemoryStore()
+    runtime._checkpointer = MemorySaver()
+
+    asyncio.run(runtime.get_agent("medium", thread_id="thread-1"))
+
+    tool_names = [tool.name for tool in captured["tools"]]
+    assert "render_chainlit_ui" not in tool_names
+
+
+def test_render_chainlit_ui_tool_pushes_generated_panel(monkeypatch) -> None:
+    """Verify the render UI tool emits a LangGraph GeneratedPanel UI message."""
+    pushed: list[dict[str, Any]] = []
+
+    def fake_push_ui_message(name: str, props: dict[str, Any], **kwargs: Any):
+        """Capture UI messages without requiring a runnable context."""
+        pushed.append({"name": name, "props": props, **kwargs})
+        return {"type": "ui", "id": kwargs.get("id") or "panel-1", "name": name}
+
+    monkeypatch.setattr(deepagent_runtime, "push_ui_message", fake_push_ui_message)
+
+    tool = deepagent_runtime.create_render_chainlit_ui_tool()
+    result = tool.invoke(
+        {
+            "id": "panel-1",
+            "title": "Build result",
+            "summary": "All checks completed.",
+            "facts": {"Tests": "passing"},
+            "items": ["Config parsed", "Bridge rendered"],
+            "table": {
+                "columns": ["Check", "Status"],
+                "rows": [["pytest", "pass"]],
+            },
+            "actions": [
+                {"label": "Run full suite", "prompt": "Run the full test suite."}
+            ],
+        }
+    )
+
+    assert pushed == [
+        {
+            "name": "GeneratedPanel",
+            "props": {
+                "title": "Build result",
+                "summary": "All checks completed.",
+                "facts": {"Tests": "passing"},
+                "items": ["Config parsed", "Bridge rendered"],
+                "table": {
+                    "columns": ["Check", "Status"],
+                    "rows": [["pytest", "pass"]],
+                },
+                "actions": [
+                    {"label": "Run full suite", "prompt": "Run the full test suite."}
+                ],
+            },
+            "id": "panel-1",
+            "metadata": {"source": "main-agent"},
+        }
+    ]
+    assert result == {
+        "rendered": True,
+        "component": "GeneratedPanel",
+        "id": "panel-1",
+    }
+
+
+def test_render_chainlit_ui_tool_normalizes_action_shaped_items(monkeypatch) -> None:
+    """Verify action-shaped list items render as text and prompt buttons."""
+    pushed: list[dict[str, Any]] = []
+
+    def fake_push_ui_message(name: str, props: dict[str, Any], **kwargs: Any):
+        """Capture UI messages without requiring a runnable context."""
+        pushed.append({"name": name, "props": props, **kwargs})
+        return {"type": "ui", "id": kwargs.get("id") or "panel-1", "name": name}
+
+    monkeypatch.setattr(deepagent_runtime, "push_ui_message", fake_push_ui_message)
+
+    tool = deepagent_runtime.create_render_chainlit_ui_tool()
+    tool.invoke(
+        {
+            "id": "mock-checklist-panel",
+            "title": "Task Checklist",
+            "summary": "Example of a short checklist panel.",
+            "items": [
+                {
+                    "label": "Configure model provider",
+                    "prompt": "Show me how to change the model provider.",
+                },
+                {
+                    "label": "Set up MCP servers",
+                    "prompt": "List the configured MCP servers.",
+                },
+            ],
+        }
+    )
+
+    assert pushed[0]["props"]["items"] == [
+        "Configure model provider",
+        "Set up MCP servers",
+    ]
+    assert pushed[0]["props"]["actions"] == [
+        {
+            "label": "Configure model provider",
+            "prompt": "Show me how to change the model provider.",
+        },
+        {
+            "label": "Set up MCP servers",
+            "prompt": "List the configured MCP servers.",
+        },
+    ]
+
+
 def test_stateful_mcp_reuses_session_per_chainlit_session(
     tmp_path: Path,
     monkeypatch,
@@ -4199,6 +4359,27 @@ commands = [
     assert extensions.chainlit_tool_steps_enabled is False
     assert extensions.chainlit_startup_status_enabled is False
     assert extensions.chainlit_chronological_ui_enabled is False
+    assert extensions.chainlit_generative_ui_enabled is True
+
+
+def test_load_extensions_config_parses_chainlit_generative_ui_flag(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Verify that load extensions config parses generative UI toggle."""
+    config_path = tmp_path / "deepagent.toml"
+    config_path.write_text(
+        """
+[chainlit]
+generative_ui_enabled = false
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DEEPAGENT_CONFIG", str(config_path))
+
+    extensions = deepagent_runtime.load_extensions_config()
+
+    assert extensions.chainlit_generative_ui_enabled is False
 
 
 def test_load_extensions_config_parses_chainlit_starters(
@@ -4506,6 +4687,25 @@ chronological_ui_enabled = "sometimes"
     monkeypatch.setenv("DEEPAGENT_CONFIG", str(config_path))
 
     with pytest.raises(ValueError, match="chronological_ui_enabled"):
+        deepagent_runtime.load_extensions_config()
+
+
+def test_load_extensions_config_rejects_non_boolean_generative_ui_flag(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Verify that load extensions config rejects non boolean generative UI flag."""
+    config_path = tmp_path / "deepagent.toml"
+    config_path.write_text(
+        """
+[chainlit]
+generative_ui_enabled = "sometimes"
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DEEPAGENT_CONFIG", str(config_path))
+
+    with pytest.raises(ValueError, match="generative_ui_enabled"):
         deepagent_runtime.load_extensions_config()
 
 


### PR DESCRIPTION
## Summary
- Add a `generative_ui_enabled` Chainlit toggle to control generated panels
- Introduce a `render_chainlit_ui` tool that emits whitelisted `GeneratedPanel` UI messages
- Wire the Chainlit bridge to render, update, and remove generated custom elements
- Document the new config flag in `README.md` and `deepagent.toml.example`

## Testing
- Unit tests added for stream event parsing, bridge rendering/update/removal, config parsing, and tool behavior