### PR TITLE
Queue generated UI after the final response

### DIFF
--- a/chainagents/interfaces/chainlit/bridge.py
+++ b/chainagents/interfaces/chainlit/bridge.py
@@ -7,7 +7,7 @@ import ast
 import json
 import time
 import tomllib
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Any
 
@@ -1002,6 +1002,8 @@ class ChainlitEventBridge:
         self.generated_ui_elements = (
             generated_ui_elements if generated_ui_elements is not None else {}
         )
+        self.pending_generated_ui_events: dict[str, AgentStreamEvent] = {}
+        self.pending_generated_ui_order: list[str] = []
         self.generated_file_paths: list[str] = []
         self.collapse_scheduled_step_ids: set[str] = set()
         self.pending_collapse_tasks: set[asyncio.Task[Any]] = set()
@@ -1082,6 +1084,7 @@ class ChainlitEventBridge:
         """Finish the chainlit event bridge."""
         await self._close_all_open_steps()
         await self._send_final_response_message()
+        await self._flush_pending_generated_ui_messages()
         if self.run_task_list is not None:
             await self.run_task_list.finish()
 
@@ -1229,12 +1232,43 @@ class ChainlitEventBridge:
         await step.update()
 
     async def _render_ui_message(self, event: AgentStreamEvent) -> None:
-        """Render a whitelisted LangGraph UI event as a Chainlit CustomElement."""
+        """Queue a whitelisted LangGraph UI event for post-response rendering."""
         if not self.generative_ui_enabled:
             return
         if event.ui_name not in GENERATIVE_UI_COMPONENTS or not event.ui_id:
             return
 
+        self._queue_generated_ui_message(event)
+
+    def _queue_generated_ui_message(self, event: AgentStreamEvent) -> None:
+        """Store a generated UI event until the final response has been sent."""
+        existing_pending = self.pending_generated_ui_events.get(event.ui_id)
+        if existing_pending is not None:
+            if event.ui_metadata.get("merge") is True:
+                event = replace(
+                    event,
+                    ui_props={
+                        **existing_pending.ui_props,
+                        **event.ui_props,
+                    },
+                )
+            self.pending_generated_ui_events[event.ui_id] = event
+            return
+
+        self.pending_generated_ui_events[event.ui_id] = event
+        self.pending_generated_ui_order.append(event.ui_id)
+
+    async def _flush_pending_generated_ui_messages(self) -> None:
+        """Render queued generated UI messages after the final response."""
+        for ui_id in list(self.pending_generated_ui_order):
+            event = self.pending_generated_ui_events.pop(ui_id, None)
+            if event is None:
+                continue
+            await self._send_generated_ui_message(event)
+        self.pending_generated_ui_order.clear()
+
+    async def _send_generated_ui_message(self, event: AgentStreamEvent) -> None:
+        """Send or update one generated UI CustomElement."""
         existing_element = self.generated_ui_elements.get(event.ui_id)
         if existing_element is not None:
             if event.ui_metadata.get("merge") is True:
@@ -1259,6 +1293,9 @@ class ChainlitEventBridge:
         """Remove a tracked Chainlit CustomElement for a LangGraph remove-ui event."""
         if not self.generative_ui_enabled or not event.ui_id:
             return
+        self.pending_generated_ui_events.pop(event.ui_id, None)
+        if event.ui_id in self.pending_generated_ui_order:
+            self.pending_generated_ui_order.remove(event.ui_id)
         element = self.generated_ui_elements.pop(event.ui_id, None)
         if element is not None:
             await element.remove()

--- a/chainagents/runtime/core.py
+++ b/chainagents/runtime/core.py
@@ -129,7 +129,7 @@ Operating constraints:
 - When you finish, explain the result clearly and concisely.
 - For non-trivial, multi-step work, call `write_todos` early and keep it updated as you progress so the UI can reflect your current plan and progress.
 - If you expect to use multiple tools or perform more than two distinct steps, create a todo list before proceeding with the main work.
-- Actively use `render_chainlit_ui` in Chainlit for interactive or structured answers. When the tool is available, default to a compact GeneratedPanel for summaries, facts, checklists, comparisons, status updates, choices, and next-step action buttons. Still provide the normal text answer. For simple one-sentence answers or when the tool is absent, answer in text only.
+- Actively use `render_chainlit_ui` in Chainlit for interactive or structured answers. When the tool is available, default to a compact GeneratedPanel for summaries, facts, checklists, comparisons, status updates, choices, and next-step action buttons. Still provide the normal text answer. Do not describe generated panels as above or below the answer; use non-positional wording such as "the generated panel" or "the panel actions." For simple one-sentence answers or when the tool is absent, answer in text only.
 
 Availability questions:
 - When asked what skills are available, answer from the actually loaded Skills section in your system prompt, not from generic world knowledge or broad capabilities.

--- a/prompts/ui_promots.md
+++ b/prompts/ui_promots.md
@@ -12,6 +12,9 @@ Default behavior:
   comparisons, status updates, and mock UI requests.
 - Add action buttons whenever the user may reasonably want to continue with one of several next
   steps.
+- Do not describe generated panels as above or below the answer. Chainlit renders generated panels
+  after the text response, so use non-positional wording such as "the generated panel" or "the
+  panel actions" instead.
 - Skip UI for simple one-sentence answers, conversational acknowledgements, or when the
   `render_chainlit_ui` tool is absent.
 
@@ -85,4 +88,5 @@ Avoid:
 - Overusing panels for simple one-sentence answers.
 
 After rendering a panel, still answer in text. The text should state the main result and mention
-what the UI actions can help the user do next.
+what the UI actions can help the user do next without saying the panel is above or below the
+answer.

--- a/skills/chainlit-generative-ui/SKILL.md
+++ b/skills/chainlit-generative-ui/SKILL.md
@@ -15,13 +15,14 @@ Working rules:
 3. Include `actions` when the user may want next steps. Prefer useful continuation buttons such as "Run tests", "Show diff", "Explain config", or "Create PR".
 4. Skip UI for simple one-sentence answers, conversational acknowledgements, and cases where a panel would duplicate the text without adding interaction.
 5. Do not render arbitrary JSX, HTML, scripts, or custom component names. This runtime only exposes the whitelisted `GeneratedPanel` component through `render_chainlit_ui`.
-6. Put only plain strings in `items`. Do not put objects with `label` and `prompt` there.
-7. Put prompt buttons in `actions`. Treat each button as a user-facing follow-up request with a clear label and prompt.
-8. For checklist-style panels with follow-up buttons, put the checklist labels in `items` and the clickable follow-ups in `actions`.
-9. Do not duplicate the same option in `items` and `actions`. If it is clickable, put it only in `actions`.
-10. Keep generated panels compact. Put detailed reasoning, long explanations, code, logs, and large datasets in the text response or files instead.
-11. Do not put secrets, hidden reasoning, system messages, or internal tool details in the panel.
-12. Reuse `id` only when updating the same panel. Use a stable, short id such as `deployment-summary` or `review-findings`.
+6. Do not describe generated panels as above or below the answer. Chainlit renders them after the text response, so use non-positional wording such as "the generated panel" or "the panel actions."
+7. Put only plain strings in `items`. Do not put objects with `label` and `prompt` there.
+8. Put prompt buttons in `actions`. Treat each button as a user-facing follow-up request with a clear label and prompt.
+9. For checklist-style panels with follow-up buttons, put the checklist labels in `items` and the clickable follow-ups in `actions`.
+10. Do not duplicate the same option in `items` and `actions`. If it is clickable, put it only in `actions`.
+11. Keep generated panels compact. Put detailed reasoning, long explanations, code, logs, and large datasets in the text response or files instead.
+12. Do not put secrets, hidden reasoning, system messages, or internal tool details in the panel.
+13. Reuse `id` only when updating the same panel. Use a stable, short id such as `deployment-summary` or `review-findings`.
 
 Supported `render_chainlit_ui` fields:
 
@@ -68,4 +69,4 @@ Example tool call:
 }
 ```
 
-After calling the tool, continue with the normal answer. The panel should complement the answer, not replace it.
+After calling the tool, continue with the normal answer. The panel should complement the answer, not replace it. Refer to it without above/below placement language.

--- a/tests/test_chainlit_bridge_streaming.py
+++ b/tests/test_chainlit_bridge_streaming.py
@@ -785,6 +785,11 @@ async def test_bridge_renders_whitelisted_ui_message_as_custom_element() -> None
         }
     )
 
+    assert _CustomElement.instances == []
+    assert _Message.instances == []
+
+    await bridge.finish()
+
     assert len(_CustomElement.instances) == 1
     assert _CustomElement.instances[0].name == "GeneratedPanel"
     assert _CustomElement.instances[0].props == {"title": "Build result"}
@@ -792,6 +797,47 @@ async def test_bridge_renders_whitelisted_ui_message_as_custom_element() -> None
     assert len(_Message.instances) == 1
     assert _Message.instances[0].elements == [_CustomElement.instances[0]]
     assert _Message.instances[0].send_count == 1
+
+
+@pytest.mark.anyio
+async def test_bridge_sends_generated_ui_after_final_response(monkeypatch) -> None:
+    """Verify generated UI panels appear after the final answer message."""
+    bridge = ChainlitEventBridge(prompt="hello")
+    monkeypatch.setattr(
+        chainlit_bridge,
+        "attach_response_export_actions",
+        lambda *args, **kwargs: None,
+    )
+
+    await bridge._stream_response("Final answer")
+    await bridge.handle_event(
+        {
+            "event": "on_chain_stream",
+            "data": {
+                "chunk": (
+                    "custom",
+                    {
+                        "type": "ui",
+                        "id": "panel-1",
+                        "name": "GeneratedPanel",
+                        "props": {"title": "Build result"},
+                    },
+                ),
+            },
+        }
+    )
+
+    assert _Message.instances == []
+
+    await bridge.finish()
+
+    assert len(_Message.instances) == 2
+    assert _Message.instances[0].content == "Final answer"
+    assert _Message.instances[0].elements == []
+    assert _Message.instances[1].content == ""
+    assert _Message.instances[1].elements == [_CustomElement.instances[0]]
+    assert _Message.instances[0].send_count == 1
+    assert _Message.instances[1].send_count == 1
 
 
 @pytest.mark.anyio
@@ -832,9 +878,11 @@ async def test_bridge_updates_existing_ui_element_by_id() -> None:
         }
     )
 
+    await bridge.finish()
+
     assert len(_CustomElement.instances) == 1
     assert _CustomElement.instances[0].props == {"title": "Updated"}
-    assert _CustomElement.instances[0].update_count == 1
+    assert _CustomElement.instances[0].update_count == 0
     assert len(_Message.instances) == 1
 
 
@@ -867,6 +915,8 @@ async def test_bridge_updates_shared_ui_element_registry_across_instances() -> N
             },
         }
     )
+    await first_bridge.finish()
+
     await second_bridge.handle_event(
         {
             "event": "on_chain_stream",
@@ -883,6 +933,8 @@ async def test_bridge_updates_shared_ui_element_registry_across_instances() -> N
             },
         }
     )
+
+    await second_bridge.finish()
 
     assert len(_CustomElement.instances) == 1
     assert _CustomElement.instances[0].props == {"title": "Second"}
@@ -912,6 +964,8 @@ async def test_bridge_removes_existing_ui_element_by_id() -> None:
             },
         }
     )
+    await bridge.finish()
+
     await bridge.handle_event(
         {
             "event": "on_chain_stream",

--- a/tests/test_deepagent_runtime_rag.py
+++ b/tests/test_deepagent_runtime_rag.py
@@ -3963,6 +3963,7 @@ def test_system_prompt_directs_active_chainlit_ui_interaction() -> None:
     assert "Actively use `render_chainlit_ui`" in prompt
     assert "next-step action buttons" in prompt
     assert "For simple one-sentence answers" in prompt
+    assert "Do not describe generated panels as above or below the answer" in prompt
 
 
 def test_get_agent_omits_render_chainlit_ui_tool_when_disabled(


### PR DESCRIPTION
## Summary
- Queue whitelisted generated UI events until the final response is sent
- Flush queued generated UI messages during bridge shutdown
- Drop queued UI events when a remove-ui event arrives
- Update Chainlit UI guidance to avoid above/below placement wording
- Add tests for post-response rendering and updated UI ordering behavior

## Testing
- Updated unit tests for the Chainlit bridge streaming flow
- Updated runtime prompt coverage to assert the new UI wording